### PR TITLE
fix(opencode): move daily date out of the cached system prompt

### DIFF
--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { Effect } from "effect"
+import { DateTime, Effect } from "effect"
 import { Agent } from "@/agent/agent"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { InstanceState } from "@/effect/instance-state"
@@ -12,6 +12,14 @@ import PROMPT_PLAN from "./prompt/plan.txt"
 import BUILD_SWITCH from "./prompt/build-switch.txt"
 import PLAN_MODE from "./prompt/plan-mode.txt"
 
+const DATE_REGEX = /^<system-reminder>Today's date is (\d{4}-\d{2}-\d{2})<\/system-reminder>$/
+
+function localDateISO(date: Date) {
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${date.getFullYear()}-${month}-${day}`
+}
+
 export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   messages: SessionV1.WithParts[]
   agent: Agent.Info
@@ -22,6 +30,27 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const sessions = yield* Session.Service
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
+
+  const today = localDateISO(yield* DateTime.nowAsDate)
+  const hasDate = (part: SessionV1.Part): part is SessionV1.TextPart =>
+    part.type === "text" && !part.ignored && Boolean(part.synthetic) && DATE_REGEX.test(part.text)
+  // TODO: remove this injection once the V2 System Context date ships.
+  const lastDate = input.messages
+    .findLast((msg) => msg.parts.some(hasDate))
+    ?.parts.findLast(hasDate)
+    ?.text.match(DATE_REGEX)?.[1]
+
+  if (lastDate !== today) {
+    const datePart = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: userMessage.info.id,
+      sessionID: userMessage.info.sessionID,
+      type: "text",
+      text: `<system-reminder>Today's date is ${today}</system-reminder>`,
+      synthetic: true,
+    })
+    userMessage.parts.push(datePart)
+  }
 
   if (!flags.experimentalPlanMode) {
     if (input.agent.name === "plan") {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -78,7 +78,6 @@ const layer = Layer.effect(
             `  Workspace root folder: ${ctx.worktree}`,
             `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
-            `  Today's date: ${new Date().toDateString()}`,
             `</env>`,
           ].join("\n"),
           references.length === 0

--- a/packages/opencode/test/session/reminders-date.test.ts
+++ b/packages/opencode/test/session/reminders-date.test.ts
@@ -1,0 +1,235 @@
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import type { Agent } from "../../src/agent/agent"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { SessionReminders } from "@/session/reminders"
+import { Session } from "@/session/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const root = LayerNode.group([
+  Session.node,
+  Database.node,
+  EventV2Bridge.node,
+  SessionProjector.node,
+  FSUtil.node,
+  CrossSpawnSpawner.node,
+  RuntimeFlags.node,
+])
+const env = LayerNode.compile(root, [[RuntimeFlags.node, RuntimeFlags.layer({})]] as const)
+
+const it = testEffect(env)
+
+const ref = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+const DATE_SHAPE = /^<system-reminder>Today's date is (\d{4}-\d{2}-\d{2})<\/system-reminder>$/
+
+function todayISO() {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, "0")
+  const day = String(now.getDate()).padStart(2, "0")
+  return `${now.getFullYear()}-${month}-${day}`
+}
+
+function agent(): Agent.Info {
+  return {
+    name: "build",
+    mode: "primary",
+    options: {},
+    permission: [{ permission: "*", pattern: "*", action: "allow" }],
+  }
+}
+
+const matchDatePart = (part: SessionV1.Part): part is SessionV1.TextPart =>
+  part.type === "text" && !part.ignored && Boolean(part.synthetic) && DATE_SHAPE.test(part.text)
+
+const dateParts = (msg: SessionV1.WithParts) => msg.parts.filter(matchDatePart)
+
+const storedDateParts = (messageID: MessageID) =>
+  Effect.map(MessageV2.parts(messageID), (parts) => parts.filter(matchDatePart))
+
+const seedUser = Effect.fn("test.seedUser")(function* (sessionID: SessionID, text: string) {
+  const session = yield* Session.Service
+  const msg = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  const part = yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID,
+    type: "text",
+    text,
+  })
+  return { info: msg, parts: [part] } satisfies SessionV1.WithParts
+})
+
+const seedAssistant = Effect.fn("test.seedAssistant")(function* (input: {
+  sessionID: SessionID
+  parentID: MessageID
+}) {
+  const session = yield* Session.Service
+  const msg: SessionV1.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    sessionID: input.sessionID,
+    mode: "build",
+    agent: "build",
+    parentID: input.parentID,
+    path: { cwd: "/test", root: "/test" },
+    cost: 0,
+    tokens: {
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+    finish: "end_turn",
+  }
+  yield* session.updateMessage(msg)
+  return { info: msg, parts: [] } satisfies SessionV1.WithParts
+})
+
+const seedSyntheticPart = Effect.fn("test.seedSyntheticPart")(function* (input: {
+  msg: SessionV1.WithParts
+  text: string
+  ignored?: boolean
+}) {
+  const session = yield* Session.Service
+  const part = yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: input.msg.info.id,
+    sessionID: input.msg.info.sessionID,
+    type: "text",
+    text: input.text,
+    synthetic: true,
+    ...(input.ignored === undefined ? {} : { ignored: input.ignored }),
+  })
+  input.msg.parts.push(part)
+  return part
+})
+
+it.live("injects today's date part exactly once per day", () =>
+  provideTmpdirInstance(() =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const chat = yield* session.create({})
+      const user = yield* seedUser(chat.id, "hello")
+      const expected = `<system-reminder>Today's date is ${todayISO()}</system-reminder>`
+
+      const result = yield* SessionReminders.apply({ messages: [user], agent: agent(), session: chat })
+
+      const lastUser = result.findLast((msg) => msg.info.role === "user")
+      expect(lastUser).toBeDefined()
+      if (!lastUser) return
+      const injected = dateParts(lastUser)
+      expect(injected).toHaveLength(1)
+      expect(injected[0].text).toBe(expected)
+      expect(injected[0].messageID).toBe(lastUser.info.id)
+
+      const stored = yield* storedDateParts(lastUser.info.id)
+      expect(stored.map((part) => part.text)).toEqual([expected])
+
+      const persistedBefore = yield* MessageV2.parts(lastUser.info.id)
+      yield* SessionReminders.apply({ messages: result, agent: agent(), session: chat })
+      expect(dateParts(lastUser)).toHaveLength(1)
+      const persistedAfter = yield* MessageV2.parts(lastUser.info.id)
+      expect(persistedAfter).toHaveLength(persistedBefore.length)
+    }),
+  ),
+)
+
+it.live("injects a fresh date part on the last user message when only a stale date exists", () =>
+  provideTmpdirInstance(() =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const chat = yield* session.create({})
+      const first = yield* seedUser(chat.id, "yesterday's question")
+      yield* seedSyntheticPart({ msg: first, text: "<system-reminder>Today's date is 2020-01-01</system-reminder>" })
+      const reply = yield* seedAssistant({ sessionID: chat.id, parentID: first.info.id })
+      const second = yield* seedUser(chat.id, "today's question")
+
+      const result = yield* SessionReminders.apply({
+        messages: [first, reply, second],
+        agent: agent(),
+        session: chat,
+      })
+      const expected = `<system-reminder>Today's date is ${todayISO()}</system-reminder>`
+
+      expect(dateParts(result[0]).map((part) => part.text)).toEqual([
+        "<system-reminder>Today's date is 2020-01-01</system-reminder>",
+      ])
+
+      const lastUser = result.findLast((msg) => msg.info.role === "user")
+      expect(lastUser?.info.id).toBe(second.info.id)
+      expect(dateParts(lastUser!).map((part) => part.text)).toEqual([expected])
+
+      const stored = yield* storedDateParts(second.info.id)
+      expect(stored.map((part) => part.text)).toEqual([expected])
+    }),
+  ),
+)
+
+it.live("only a visible well-formed synthetic date part suppresses injection", () =>
+  provideTmpdirInstance(() =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const chat = yield* session.create({})
+      const today = todayISO()
+      const reminder = `<system-reminder>Today's date is ${today}</system-reminder>`
+
+      const user = yield* seedUser(chat.id, reminder)
+      yield* seedSyntheticPart({ msg: user, text: reminder, ignored: true })
+      yield* seedSyntheticPart({ msg: user, text: "<system-reminder>Today's date is 2026-9-7</system-reminder>" })
+      yield* seedSyntheticPart({ msg: user, text: "<system-reminder>Today's date is not-a-date</system-reminder>" })
+      yield* seedSyntheticPart({ msg: user, text: `${reminder} trailing text` })
+
+      yield* SessionReminders.apply({ messages: [user], agent: agent(), session: chat })
+
+      const injected = dateParts(user)
+      expect(injected).toHaveLength(1)
+      expect(injected[0].text).toBe(reminder)
+      expect(Boolean(injected[0].ignored)).toBe(false)
+    }),
+  ),
+)
+
+it.live("no user message is a no-op", () =>
+  provideTmpdirInstance(() =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const chat = yield* session.create({})
+      const user = yield* seedUser(chat.id, "hello")
+      const reply = yield* seedAssistant({ sessionID: chat.id, parentID: user.info.id })
+      const messages = [reply]
+
+      const result = yield* SessionReminders.apply({ messages, agent: agent(), session: chat })
+
+      expect(result).toBe(messages)
+      const stored = yield* MessageV2.parts(reply.info.id)
+      expect(stored).toHaveLength(0)
+    }),
+  ),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #29672

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Remove the date in the initial system prompt. Replace it with injecting a synthetic part on the current last user message, only when no visible synthetic date part with today's date exists.

Why the change is needed, is already documented in the related issue.

Before: The date is in the system prompt

```
<env>
  Working directory: /repo
  Workspace root folder: /repo
  Is directory a git repo: yes
  Platform: linux
  Today's date: Mon Sep 07 2026
</env>
```

After: The date line is removed, replaced with a system reminder attached to the current last user message

```
user: fix the bug
<system-reminder>Today's date is 2026-09-07</system-reminder>
```

Behaviour:

- Injected only when no visible, well-formed synthetic date part with today's date exists.
- Day change mid-session: new reminder appended to the current last user message.
- Resume after N days: system prefix cache-hits if exists, fresh reminder appended at the tail.
- Non-synthetic, ignored, or malformed date-like parts never suppress injection.
- Compaction drops the old reminder, next turn re-injects.
- No user message in the projection: no-op.

Note: V2 system context already have this intention, remove when V2 ships its own mechanism.

### How did you verify your code works?

`packages/opencode/test/session/reminders-date.test.ts` covers the above. 

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR