### PR TITLE
fix(cli): preserve remote launch directories

### DIFF
--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -16,7 +16,7 @@ export default Runtime.handler(Commands, (input) =>
   Effect.gen(function* () {
     const requestedDirectory = Option.getOrUndefined(input.directory)
     const requestedServer = Option.getOrUndefined(input.server)
-    if (requestedDirectory !== undefined) process.chdir(requestedDirectory)
+    if (requestedServer === undefined && requestedDirectory !== undefined) process.chdir(requestedDirectory)
     const preflight = UpdatePreflight.make()
     yield* Effect.addFinalizer(() => Effect.promise(() => preflight.close()))
     const serviceStarts = yield* Queue.unbounded<{
@@ -78,6 +78,7 @@ export default Runtime.handler(Commands, (input) =>
         prompt: Option.getOrUndefined(input.prompt),
         auto: input.auto || input.yolo || input.dangerouslySkipPermissions,
       },
+      directory: requestedServer === undefined ? undefined : requestedDirectory,
       config: {
         path: config.path,
         get: () => runPromise(config.get()),

--- a/packages/cli/test/default-directory.test.ts
+++ b/packages/cli/test/default-directory.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { OPENCODE_VERSION } from "../src/version"
+import { ServiceConfig } from "../src/services/service-config"
+import { isolatedEnv } from "./fixture/environment"
+import { tmpdir } from "./fixture/tmpdir"
+
+test.each([false, true])(
+  "remote directory does not require a local path (server first: %s)",
+  async (first) => {
+    await using root = await tmpdir()
+    const directory = path.join(root.path, "remote only", "project")
+    expect(await fs.stat(directory).catch(() => undefined)).toBeUndefined()
+    const result = await launch({ root: root.path, directory, remote: true, first })
+    expect(result.directory, result.stderr).toBe(directory)
+    expect(result.stderr).not.toContain("ENOENT")
+  },
+  15_000,
+)
+
+test("remote relative directory is passed to the server unchanged", async () => {
+  await using root = await tmpdir()
+  const result = await launch({ root: root.path, directory: "remote-only/project", remote: true })
+  expect(result.directory, result.stderr).toBe("remote-only/project")
+}, 15_000)
+
+test("local relative directory still changes the launch directory", async () => {
+  await using root = await tmpdir()
+  await fs.mkdir(path.join(root.path, "project"))
+  const result = await launch({ root: root.path, directory: "project" })
+  expect(result.directory).toBe(await fs.realpath(path.join(root.path, "project")))
+}, 15_000)
+
+test("omitting the directory preserves the launch directory", async () => {
+  await using root = await tmpdir()
+  const result = await launch({ root: root.path, remote: true })
+  expect(result.directory).toBe(await fs.realpath(root.path))
+  expect(result.calls).toContain("/api/location")
+}, 15_000)
+
+test("a missing local directory still fails before connecting", async () => {
+  await using root = await tmpdir()
+  const result = await launch({ root: root.path, directory: "missing-project" })
+  expect(result.directory).toBeUndefined()
+  expect(result.stderr).toContain("ENOENT")
+}, 15_000)
+
+test("an explicit remote directory error does not fall back to a different project", async () => {
+  await using root = await tmpdir()
+  const result = await launch({ root: root.path, directory: "/remote/project", remote: true })
+  expect(result.calls).toContain("/api/fs/list")
+  expect(result.calls).not.toContain("/api/location")
+}, 15_000)
+
+async function launch(input: { root: string; directory?: string; remote?: boolean; first?: boolean }) {
+  const requested = Promise.withResolvers<string | null>()
+  const calls: string[] = []
+  await using server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url)
+      calls.push(url.pathname)
+      if (url.pathname === "/api/health")
+        return Response.json({ healthy: true, version: OPENCODE_VERSION, pid: process.pid })
+      if (url.pathname === "/api/fs/list") requested.resolve(url.searchParams.get("location[directory]"))
+      // Stop at the real location request, before starting an interactive renderer.
+      return new Response("Fixture stops before rendering", { status: 500 })
+    },
+  })
+  const registration = path.join(input.root, "state", "opencode", ServiceConfig.filename())
+  await fs.mkdir(path.dirname(registration), { recursive: true })
+  await Bun.write(
+    registration,
+    JSON.stringify({
+      id: "directory-test",
+      version: OPENCODE_VERSION,
+      url: server.url.toString(),
+      pid: process.pid,
+    }),
+  )
+  const directory = input.directory === undefined ? [] : [input.directory]
+  const remote = input.remote ? ["--server", server.url.toString()] : []
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      "run",
+      "--conditions=browser",
+      "--preload",
+      Bun.resolveSync("@opentui/solid/preload", import.meta.dir),
+      path.resolve(import.meta.dir, "../src/index.ts"),
+      "--print-logs",
+      ...(input.first ? [...remote, ...directory] : [...directory, ...remote]),
+    ],
+    {
+      cwd: input.root,
+      env: isolatedEnv(input.root, {
+        OPENCODE_DISABLE_AUTOUPDATE: "true",
+        OPENCODE_PASSWORD: undefined,
+        OPENCODE_SERVER_PASSWORD: undefined,
+        OTEL_EXPORTER_OTLP_ENDPOINT: undefined,
+      }),
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "pipe",
+      timeout: 10_000,
+    },
+  )
+  const stderr = new Response(child.stderr).text()
+  try {
+    const result = {
+      directory: await Promise.race([requested.promise, child.exited.then(() => undefined)]),
+      stderr: await stderr,
+      calls,
+    }
+    await child.exited
+    expect(child.signalCode, result.stderr).toBeNull()
+    return result
+  } finally {
+    child.kill()
+    await child.exited
+  }
+}

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -186,6 +186,7 @@ export type TuiInput = {
     }
   }
   args: Args
+  directory?: string
   config: Config.Interface
   updater?: UpdateSource
   packages: PackageSource
@@ -209,9 +210,13 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
   })
   const options = { baseUrl: input.server.endpoint.url, headers: Service.headers(input.server.endpoint) }
   const api = OpenCode.make(options)
-  const location = yield* Effect.tryPromise(() => api.file.list({ location: { directory: process.cwd() } })).pipe(
+  const location = yield* Effect.tryPromise(() =>
+    api.file.list({ location: { directory: input.directory ?? process.cwd() } }),
+  ).pipe(
     Effect.map((response) => response.location),
-    Effect.catch(() => Effect.tryPromise(() => api.location.get())),
+    Effect.catch((error) =>
+      input.directory === undefined ? Effect.tryPromise(() => api.location.get()) : Effect.fail(error),
+    ),
   )
   const directory = location.directory
   const pluginDirectories = yield* Effect.promise(() => localPluginDirectories(process.cwd(), global.config))


### PR DESCRIPTION
### Issue for this PR

Closes #47665

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode2 /remote/project --server <url>` tries to enter `/remote/project` on the client, so a directory that only exists on the server fails with `ENOENT` before connecting.

Skip the local `chdir` when `--server` is set and pass the directory through to the TUI's initial location request. Skipping `chdir` alone wasn't enough: that request still used the client's cwd.

If the server rejects an explicit directory, return the error instead of silently opening its default project. Local launches and remote launches without a directory keep their existing behavior.

### How did you verify your code works?

Added seven tests that launch the real CLI against a local HTTP fixture. They cover both argument orders, remote absolute/relative paths, local directory handling, and the error fallback. The remote path cases failed before the fix; all seven now pass. The fixture stops before the interactive renderer, so this isn't a Mac-to-Linux end-to-end run.

With Bun 1.4.2 on macOS:

- CLI: directory, server-connection, import-export, env, session-target, and standalone tests — 22 passed.
- TUI: new-session-location and app-lifecycle tests — 35 passed. The lifecycle suite emitted resize-listener warnings but no failures.
- `bun typecheck` passed in both packages.

### Screenshots / recordings

Not applicable; no visual changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
