### PR TITLE
fix(opencode): keep Windows PATH casing in TUI worker env

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -207,11 +207,17 @@ export const TuiThreadCommand = cmd({
       }
       const cwd = Filesystem.resolve(process.cwd())
 
-      const worker = new Worker(file, {
-        env: Object.fromEntries(
-          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-        ),
-      })
+      const env = Object.fromEntries(
+        Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+      )
+      if (process.platform === "win32") {
+        const value = env.PATH ?? env.Path
+        if (value) {
+          env.PATH = value
+          env.Path = value
+        }
+      }
+      const worker = new Worker(file, { env })
       const client = Rpc.client<typeof rpc>(worker)
       const reload = () => {
         client.call("reload", undefined).catch(() => {})


### PR DESCRIPTION
### Issue for this PR

Closes #37125

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, `process.env` is case-insensitive. Copying it with `Object.fromEntries` makes a plain object that usually only has `Path`. Bun workers don't treat that as case-insensitive, so `PATH` is missing and the TUI shell ends up with a broken path (often just `C:\Windows\System32`).

This writes the same value to both `PATH` and `Path` on the worker env. Same idea as the helper from #23310, which got dropped when the copy was inlined.

### How did you verify your code works?

On Windows, `Object.keys` after `Object.fromEntries(process.env)` has `Path` and no `PATH`. After mirroring both, they exist with the same value.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
