### PR TITLE
fix(session): overflow trigger ignores cache reads; replay re-injects overflow payloads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -243,7 +243,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -267,7 +267,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -381,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "drizzle-orm": "catalog:",
@@ -435,7 +435,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -449,7 +449,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -461,7 +461,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -493,7 +493,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -509,7 +509,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -540,7 +540,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -559,7 +559,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -690,7 +690,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -766,7 +766,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -781,7 +781,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -796,7 +796,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -836,7 +836,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -849,7 +849,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -883,7 +883,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -902,7 +902,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -944,7 +944,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -971,7 +971,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1022,7 +1022,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -51,6 +51,23 @@ type CompletedCompaction = {
 const truncate = (value: string) =>
   value.length <= TOOL_OUTPUT_MAX_CHARS ? value : `${value.slice(0, TOOL_OUTPUT_MAX_CHARS)}\n[truncated]`
 
+// Replay must never re-inject the payload that caused the overflow. User
+// document attachments are stored as `file`/`text` parts and are truncated
+// nowhere else in the pipeline (the 2k cap above covers tool outputs only),
+// so replaying them verbatim re-creates the overflow on the very next call
+// and wedges the session permanently.
+export const REPLAY_PART_MAX_CHARS = TOOL_OUTPUT_MAX_CHARS
+
+export function replayPartFor(part: SessionV1.Part): SessionV1.Part | { type: "text"; text: string } {
+  if (part.type === "file") {
+    return { type: "text", text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
+  }
+  if (part.type === "text" && part.text.length > REPLAY_PART_MAX_CHARS) {
+    return { type: "text", text: `[Document omitted: ${part.text.length} characters]` }
+  }
+  return part
+}
+
 const serialize = (message: SessionV1.WithParts) => {
   if (message.info.role === "user") {
     const text = message.parts
@@ -481,10 +498,7 @@ const layer = Layer.effect(
           })
           for (const part of replay.parts) {
             if (part.type === "compaction") continue
-            const replayPart =
-              part.type === "file" && MessageV2.isMedia(part.mime)
-                ? { type: "text" as const, text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
-                : part
+            const replayPart = replayPartFor(part)
             yield* session.updatePart({
               ...replayPart,
               id: PartID.ascending(),

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -28,7 +28,15 @@ export function isOverflow(input: {
   if (input.cfg.compaction?.auto === false) return false
   if (input.model.limit.context === 0) return false
 
-  const count =
-    input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
+  // `total_tokens` semantics are provider-dependent: OpenAI-style providers
+  // include cached tokens in the total, while Anthropic-style providers report
+  // cached tokens separately (excluding cache reads). A session with a
+  // near-100% prompt-cache hit ratio can therefore report a tiny `total`
+  // forever, blinding the trigger while the real context grows unbounded.
+  // Always compare the full context size (input + cache) against the window.
+  const count = Math.max(
+    input.tokens.total ?? 0,
+    input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write,
+  )
   return count >= usable(input)
 }

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -8,7 +8,7 @@ import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { Config } from "@/config/config"
 import { LLM } from "../../src/session/llm"
-import { SessionCompaction } from "../../src/session/compaction"
+import { SessionCompaction, replayPartFor } from "../../src/session/compaction"
 import { Token } from "@/util/token"
 import { Plugin } from "../../src/plugin"
 import { provideTmpdirInstance, TestInstance } from "../fixture/fixture"
@@ -423,6 +423,21 @@ describe("session.compaction.isOverflow", () => {
         const compact = yield* SessionCompaction.Service
         const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
         const tokens = { input: 271_000, output: 1_000, reasoning: 0, cache: { read: 2_000, write: 0 } }
+        expect(yield* compact.isOverflow({ tokens, model })).toBe(true)
+      }),
+    ),
+  )
+
+  it.live(
+    "counts cache reads when total_tokens excludes cached tokens (Anthropic-style providers)",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const model = createModel({ context: 300_000, output: 131_072 })
+        // Anthropic-style usage: prompt_tokens excludes cache reads, so the
+        // reported total stays tiny while the real context (cache reads)
+        // grows unbounded. The trigger must count cache reads.
+        const tokens = { input: 15, output: 100, reasoning: 0, cache: { read: 2_900_000, write: 0 }, total: 115 }
         expect(yield* compact.isOverflow({ tokens, model })).toBe(true)
       }),
     ),
@@ -1955,5 +1970,31 @@ describe("SessionNs.getUsage", () => {
     expect(result.tokens.input).toBe(500)
     expect(result.tokens.cache.read).toBe(200)
     expect(result.tokens.cache.write).toBe(300)
+  })
+})
+
+describe("session.compaction.replayPartFor", () => {
+  test("replaces file attachments with reference placeholders regardless of mime", () => {
+    const part = { type: "file", mime: "application/json", filename: "flow.json" } as any
+    const out = replayPartFor(part as any)
+    expect(out.type).toBe("text")
+    expect((out as any).text).toBe("[Attached application/json: flow.json]")
+  })
+
+  test("replaces media file attachments with reference placeholders", () => {
+    const part = { type: "file", mime: "image/png", filename: "shot.png" } as any
+    const out = replayPartFor(part as any)
+    expect((out as any).text).toBe("[Attached image/png: shot.png]")
+  })
+
+  test("omits oversized text parts instead of re-injecting them", () => {
+    const part = { type: "text", text: "x".repeat(5_000) } as any
+    const out = replayPartFor(part as any)
+    expect((out as any).text).toBe("[Document omitted: 5000 characters]")
+  })
+
+  test("keeps small text parts verbatim", () => {
+    const part = { type: "text", text: "hello" } as any
+    expect(replayPartFor(part as any)).toBe(part)
   })
 })

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem — two production wedge mechanisms (12+ sessions, Aug–Sep)

### 1. Proactive compaction trigger is blind on Anthropic-style usage

`isOverflow` trusted the provider-reported `total_tokens`:

```ts
const count = input.tokens.total || input + output + cache.read + cache.write
```

`total_tokens` semantics are provider-dependent. OpenAI-style providers include cached tokens; Anthropic-style paths report them separately (**excluding** cache reads). A session with a near-100% prompt-cache hit ratio therefore reports `total_tokens` in the single digits forever while its real context grows unbounded — the trigger never fires. Confirmed in production: a session grew to **3.17M true tokens** (cache reads) across hundreds of turns while the reported non-cached input stayed at 3–15 tokens; it wedged for 7+ days. Live-confirmed on opus as a latent hazard: `input=1` token/turn with 68k–80k riding on cache reads.

### 2. Overflow-replay re-injects the payload that caused the overflow

After an overflow-triggered compaction, the replay path copies the overflowed user turn's parts **verbatim** into a new user message. Its only substitution covers media-file parts — so multi-MB user document attachments (JSON files stored as `file`/`text` parts, truncated nowhere else in the pipeline) get re-injected exactly as-is. Production forensics: byte-identical 4.52MB attachment sets in two user messages 34 seconds apart; every retry cycle re-injected them (+1.19M tokens per cycle) until the session passed every model's context window and compaction itself could no longer run (`ContextOverflowError: Conversation history too large to compact`). User document text is untruncatable by design (the 2k cap covers tool outputs only), so the wedge is permanent.

## Fix

1. **`overflow.ts`** — compare the full context size against the usable window: `count = Math.max(total ?? 0, input + output + cache.read + cache.write)`. Cache-inclusive providers are unaffected (max picks the larger, identical value); cache-excluding providers now fire correctly.
2. **`compaction.ts`** — new `replayPartFor()` used by the replay loop: all `file` attachments become `[Attached <mime>: <filename>]` reference placeholders (previously only media), and `text` parts over `REPLAY_PART_MAX_CHARS` become `[Document omitted: N characters]`. Small typed text (the actual replayed prompt) passes through untouched.

## Tests

- `isOverflow` regression: `{ input: 15, cache.read: 2_900_000, total: 115 }` against a 300k-context model → `true` (was `false` on v1.18.18 — this is the production wedge signature).
- `replayPartFor`: json/image file parts → placeholders; 5,000-char text part → omitted; small text → verbatim.
- `bun test test/session/compaction.test.ts`: 59 pass / 0 fail; `tsgo --noEmit` clean. (`revert-compact`/`prompt` suites have 14 pre-existing failures on the clean v1.18.18 tag — unchanged by this PR.)
