### PR TITLE
fix(codemode): render empty tools as () and accept zero args

### DIFF
--- a/packages/codemode/src/tool-runtime.ts
+++ b/packages/codemode/src/tool-runtime.ts
@@ -6,6 +6,7 @@ import {
   identifierSegment,
   inputProperties,
   inputTypeScript,
+  isEmptyInput,
   outputTypeScript,
 } from "./tool-schema.js"
 import { isNamespace, type Namespace } from "./namespace.js"
@@ -328,7 +329,9 @@ const flattenTools = <R>(
 const describeTool = <R>(visible: VisibleTool<R>): ToolDescription => ({
   path: visible.path,
   description: visible.tool.description,
-  signature: `${toolExpression(visible.path)}(input: ${inputTypeScript(visible.tool, true)}): Promise<${outputTypeScript(visible.tool, true)}>`,
+  signature: isEmptyInput(visible.tool)
+    ? `${toolExpression(visible.path)}(): Promise<${outputTypeScript(visible.tool, true)}>`
+    : `${toolExpression(visible.path)}(input: ${inputTypeScript(visible.tool, true)}): Promise<${outputTypeScript(visible.tool, true)}>`,
 })
 
 // Discovery bytes are durable instructions, so order only after canonical-path collisions settle.
@@ -522,10 +525,11 @@ export const make = <R>(
 
   const executeTool = (name: string, tool: Tool<R>, externalArgs: Array<unknown>) =>
     Effect.gen(function* () {
-      if (externalArgs.length !== 1)
-        throw new ToolRuntimeError("InvalidToolInput", `Tool '${name}' expects exactly one input object.`)
+      const normalized = externalArgs.length === 0 ? [{}] : externalArgs
+      if (normalized.length !== 1)
+        throw new ToolRuntimeError("InvalidToolInput", `Tool '${name}' expects at most one input object.`)
       const input = yield* Effect.try({
-        try: () => decodeToolInput(tool, externalArgs[0]),
+        try: () => decodeToolInput(tool, normalized[0]),
         catch: (cause) =>
           new ToolRuntimeError(
             "InvalidToolInput",

--- a/packages/codemode/src/tool-schema.ts
+++ b/packages/codemode/src/tool-schema.ts
@@ -261,6 +261,11 @@ export const inputProperties = <R>(tool: Tool<R>): Array<InputProperty> => {
 export const inputTypeScript = <R>(tool: Tool<R>, pretty = false): string =>
   isEffectSchema(tool.input) ? toTypeScript(tool.input, false, pretty) : jsonSchemaToTypeScript(tool.input, pretty)
 
+// Empty object schemas render as `{}` in compact form; anything with properties,
+// an index signature, or union members renders differently, so equality is a
+// conservative emptiness test for both Effect and JSON Schema inputs.
+export const isEmptyInput = <R>(tool: Tool<R>): boolean => inputTypeScript(tool) === "{}"
+
 export const outputTypeScript = <R>(tool: Tool<R>, pretty = false): string =>
   tool.output === undefined
     ? "void"

--- a/packages/codemode/test/tool-paths.test.ts
+++ b/packages/codemode/test/tool-paths.test.ts
@@ -29,7 +29,7 @@ describe("dotted tool names", () => {
     const catalog = runtime.catalog()
     expect(catalog).toHaveLength(1)
     expect(catalog[0]?.path).toBe("api.issues.list")
-    expect(catalog[0]?.signature).toStartWith("tools.api.issues.list(input:")
+    expect(catalog[0]?.signature).toStartWith("tools.api.issues.list(")
   })
 
   test("the advertised dotted path is executable", async () => {
@@ -138,9 +138,15 @@ describe("tool input diagnostics", () => {
   })
 
   test("a wrong argument count keeps the existing error without a stale-signature hint", async () => {
-    const diagnostic = await failure(runtime, `return await tools.notes.echo()`)
+    const diagnostic = await failure(runtime, `return await tools.notes.echo({}, {})`)
     expect(diagnostic.kind).toBe("InvalidToolInput")
     expect(diagnostic.suggestions).toBeUndefined()
+  })
+
+  test("an empty-input tool advertises () and runs with zero arguments", async () => {
+    const empty = CodeMode.make({ tools: { ping: echo("Ping", "pong") } })
+    expect(empty.catalog()[0]?.signature).toBe("tools.ping(): Promise<string>")
+    expect(await value(empty, `return await tools.ping()`)).toBe("pong")
   })
 })
 

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -113,7 +113,7 @@ const tools = Layer.mock(Tool.Service, {
             type: "tool",
             name: "captured.lookup",
             description: "Captured Code Mode catalog",
-            signature: "tools.captured.lookup(input: {}): Promise<string>",
+            signature: "tools.captured.lookup(): Promise<string>",
           },
         ],
       },
@@ -327,7 +327,7 @@ it.effect(
       )
       expect(instructionUpdates).toHaveLength(1)
       expect(instructionUpdates?.[0]).toContain("Changed context")
-      expect(instructionUpdates?.[0]).toContain("tools.captured.lookup(input: {}): Promise<string>")
+      expect(instructionUpdates?.[0]).toContain("tools.captured.lookup(): Promise<string>")
       expect(userTexts(requests[0])).toEqual(["Existing durable context", "Summarize privately"])
       expect(
         requests[0]?.messages.flatMap((message) =>


### PR DESCRIPTION
Parameterless tools (e.g. Cloudflare get_user) showed as (input: {}) and required an explicit empty object. Empty-input tools now advertise () and zero arguments defaults to {} behind the scenes, matching the native tool path. ({}) keeps working everywhere.