### PR TITLE
feat(core): expose session rename tool

### DIFF
--- a/packages/core/src/tool/plugin/opencode.ts
+++ b/packages/core/src/tool/plugin/opencode.ts
@@ -6,6 +6,13 @@ import { AbsolutePath } from "@opencode-ai/schema/schema"
 import { Session } from "@opencode-ai/schema/session"
 import { Effect, Schema } from "effect"
 
+export const RenameInput = Schema.Struct({
+  sessionID: Schema.optionalKey(Session.ID).annotate({ description: "Omit to rename the current session." }),
+  title: Schema.String.check(Schema.isMinLength(1)).annotate({ description: "New session title." }),
+})
+
+const RenameOutput = Schema.Struct({ sessionID: Session.ID, title: Schema.String })
+
 export const MoveInput = Schema.Struct({
   sessionID: Schema.optionalKey(Session.ID).annotate({ description: "Omit to move the current session." }),
   directory: AbsolutePath.check(Schema.isMinLength(1)).annotate({
@@ -30,6 +37,26 @@ export const Plugin = {
     yield* ctx.tool
       .transform((draft) => {
         draft.namespace({ name: "opencode", description: "OpenCode session and runtime tools." })
+        draft.add({
+          name: "session_rename",
+          description:
+            "Rename a session, or omit sessionID to rename the current session. Use a short, specific title that summarizes the work being done.",
+          input: RenameInput,
+          output: RenameOutput,
+          options: { namespace: "opencode", codemode: true },
+          execute: (input, context) => {
+            const sessionID = input.sessionID ?? context.sessionID
+            const title = input.title.trim()
+            if (!title) return Effect.fail(new ToolFailure({ message: "Session title must not be empty" }))
+            return ctx.session.rename({ sessionID, title }).pipe(
+              Effect.as({
+                output: { sessionID, title },
+                content: `Renamed session ${sessionID} to ${title}.`,
+              }),
+              Effect.mapError((error) => new ToolFailure({ message: `Unable to rename session ${sessionID}`, error })),
+            )
+          },
+        })
         draft.add({
           name: "session_move",
           description:


### PR DESCRIPTION
### Issue for this PR

N/A — internal task.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `tools.opencode.session_rename({ title, sessionID? })` to the curated OpenCode Code Mode namespace. It defaults to the calling session, accepts an explicit session ID, trims surrounding title whitespace, and returns the renamed session ID and title.

### How did you verify your code works?

- 63 relevant existing Core tests pass
- `bun typecheck` passes in `packages/core`
- The pre-push workspace typecheck passes
- Oxlint, Effect pattern scans, Prettier, and `git diff --check` pass

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
