### PR TITLE
docs(ecosystem): add Heym

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Heym](https://github.com/heymrun/heym)                                                | Visual AI workflow platform you can self host, with OpenCode coding agents and Go usage tracking |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #37656

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [Heym](https://github.com/heymrun/heym) to the Projects table. Heym is a source available AI workflow platform you can self host. Its OpenCode Go node runs the OpenCode CLI against GitHub repositories and can return patches or open pull requests. It also provides Go subscription usage tracking.

We use Heym to develop Heym itself, with [more than 50 pull requests merged from its coding agents](https://github.com/heymrun/heym/pulls?q=is%3Apr+is%3Amerged+author%3Aheym-coder), including OpenCode. [OpenCode examples](https://github.com/heymrun/heym/pulls?q=sort%3Aupdated-desc+is%3Apr+opencode) include [workflow execution history](https://github.com/heymrun/heym/pull/498) and [folder icon selection](https://github.com/heymrun/heym/pull/472).

OpenCode support directed us to this page to submit a community listing for review.

[Integration docs](https://github.com/heymrun/heym/blob/main/frontend/src/docs/content/nodes/opencode-go-node.md) | [Website](https://heym.run/)

### How did you verify your code works?

Checked the repository and documentation links, verified the Markdown table structure, and confirmed the diff adds only the Heym row under Projects.

### Screenshots / recordings

OpenCode Go credentials in Heym.

![OpenCode Go credentials in Heym](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/heym-ecosystem-opencode-credentials-2026-09-07.png)

AI Defaults with model selection and OpenCode Go usage across the 5-hour, weekly, and monthly windows.

![AI Defaults and OpenCode Go subscription usage](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/heym-ecosystem-opencode-go-usage-2026-09-07.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
