### PR TITLE
fix(opencode): detect periodic doom-loop cycles

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -27,6 +27,7 @@ import { Database } from "@opencode-ai/core/database/database"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
 
 const DOOM_LOOP_THRESHOLD = 3
+const DOOM_LOOP_MAX_BLOCK = 4
 export type Result = "compact" | "stop" | "continue"
 
 export interface Handle {
@@ -254,6 +255,36 @@ const layer = Layer.effect(
 
       const isFilePart = (value: unknown): value is SessionV1.FilePart => Schema.is(SessionV1.FilePart)(value)
 
+      // Doom-loop detection covers periodic cycles, not just consecutive identical
+      // calls: a model repeating the block [lookup, search] three times never
+      // satisfies a last-three-parts comparison. Check whether the trailing run
+      // of settled tool calls ends with DOOM_LOOP_THRESHOLD repetitions of any
+      // block of length 1..DOOM_LOOP_MAX_BLOCK.
+      const isDoomLoop = Effect.fn("SessionProcessor.isDoomLoop")(function* (
+        messageID: SessionV1.Assistant["id"],
+      ) {
+        const parts = yield* MessageV2.parts(messageID).pipe(Effect.provideService(Database.Service, database))
+        const keys = parts.map((part) =>
+          part.type === "tool" && part.state.status !== "pending"
+            ? `${part.tool}:${JSON.stringify(part.state.input)}`
+            : undefined,
+        )
+        for (let block = 1; block <= DOOM_LOOP_MAX_BLOCK; block++) {
+          const window = keys.slice(-(block * DOOM_LOOP_THRESHOLD))
+          if (window.length !== block * DOOM_LOOP_THRESHOLD) continue
+          if (window.some((key) => key === undefined)) continue
+          let repeats = true
+          for (let i = block; i < window.length; i++) {
+            if (window[i] !== window[i - block]) {
+              repeats = false
+              break
+            }
+          }
+          if (repeats) return true
+        }
+        return false
+      })
+
       const toolResultOutput = (
         value: Extract<StreamEvent, { type: "tool-result" }>,
       ): { title: string; metadata: Record<string, any>; output: string; attachments?: SessionV1.FilePart[] } => {
@@ -350,23 +381,7 @@ const layer = Layer.effect(
                 : value.providerMetadata,
             }))
 
-            const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
-              Effect.provideService(Database.Service, database),
-            )
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
-
-            if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
-              !recentParts.every(
-                (part) =>
-                  part.type === "tool" &&
-                  part.tool === value.name &&
-                  part.state.status !== "pending" &&
-                  JSON.stringify(part.state.input) === JSON.stringify(input),
-              )
-            ) {
-              return
-            }
+            if (!(yield* isDoomLoop(ctx.assistantMessage.id))) return
 
             const agent = yield* agents.get(ctx.assistantMessage.agent)
             yield* permission.ask({

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -4,7 +4,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { expect } from "bun:test"
 import { tool } from "ai"
-import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Stream } from "effect"
 import path from "path"
 import z from "zod"
 import type { Agent } from "../../src/agent/agent"
@@ -22,7 +22,9 @@ import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { raw, reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Permission } from "@/permission"
 import { ProviderV2 } from "@opencode-ai/core/provider"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { LLMEvent } from "@opencode-ai/llm"
@@ -170,6 +172,7 @@ const root = LayerNode.group([
   Session.node,
   SessionProjector.node,
   Provider.node,
+  Permission.node,
   Database.node,
   EventV2Bridge.node,
   SessionStatus.node,
@@ -209,6 +212,40 @@ const providerErrorLLM = Layer.succeed(
 const providerErrorEnv = LayerNode.compile(root, [...replacements, [LLM.node, providerErrorLLM]])
 const itProviderError = testEffect(providerErrorEnv)
 
+function providerToolCall(id: string, name: string, input: Record<string, unknown>): LLMEvent[] {
+  return [
+    LLMEvent.toolInputStart({ id, name }),
+    LLMEvent.toolInputEnd({ id, name }),
+    LLMEvent.toolCall({ id, name, input, providerExecuted: true }),
+    LLMEvent.toolResult({
+      id,
+      name,
+      result: { type: "json", value: { output: "ok" } },
+      providerExecuted: true,
+    }),
+  ]
+}
+
+const periodicDoomLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.fromIterable([
+        LLMEvent.stepStart({ index: 0 }),
+        ...providerToolCall("call-a1", "lookup", { query: "a" }),
+        ...providerToolCall("call-b1", "search", { query: "b" }),
+        ...providerToolCall("call-a2", "lookup", { query: "a" }),
+        ...providerToolCall("call-b2", "search", { query: "b" }),
+        ...providerToolCall("call-a3", "lookup", { query: "a" }),
+        ...providerToolCall("call-b3", "search", { query: "b" }),
+        LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+        LLMEvent.finish({ reason: "tool-calls" }),
+      ]),
+  }),
+)
+const periodicDoomEnv = LayerNode.compile(root, [...replacements, [LLM.node, periodicDoomLLM]])
+const itPeriodicDoom = testEffect(periodicDoomEnv)
+
 const fragmentFailureLLM = Layer.succeed(
   LLM.Service,
   LLM.Service.of({
@@ -236,6 +273,61 @@ const boot = Effect.fn("test.boot")(function* () {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+itPeriodicDoom.live("session.processor effect tests detect periodic doom loops", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const events = yield* EventV2Bridge.Service
+        const permission = yield* Permission.Service
+        const asked = yield* Deferred.make<PermissionV1.Request>()
+        const off = yield* events.listen((event) => {
+          if (event.type === Permission.Event.Asked.type) {
+            Deferred.doneUnsafe(asked, Effect.succeed(event.data as PermissionV1.Request))
+          }
+          return Effect.void
+        })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "periodic doom loop")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies SessionV1.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "periodic doom loop" }],
+            tools: {},
+          })
+          .pipe(Effect.forkChild)
+
+        const request = yield* Deferred.await(asked).pipe(Effect.timeout("1 second"))
+        expect(request.permission).toBe("doom_loop")
+        expect(request.patterns).toEqual(["search"])
+        yield* permission.reply({ requestID: request.id, reply: "once" })
+        expect(yield* Fiber.join(run)).toBe("continue")
+        yield* off
+
+        const parts = yield* MessageV2.parts(msg.id)
+        const tools = parts.filter((part): part is SessionV1.ToolPart => part.type === "tool")
+        expect(tools).toHaveLength(6)
+        expect(tools.every((part) => part.state.status === "completed")).toBe(true)
+      }),
+    { config: cfg },
+  ),
+)
 
 it.live("session.processor effect tests capture llm input cleanly", () =>
   provideTmpdirServer(


### PR DESCRIPTION
### Issue for this PR

Closes #47759

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The doom-loop guard detected three identical trailing tool calls, but missed periodic cycles such as `lookup, search, lookup, search, lookup, search`.

This change detects three repetitions of trailing tool-call blocks up to four calls long and keeps using the existing `doom_loop` permission flow.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun test test/session/processor-effect.test.ts` from `packages/opencode`
- Result: 18 tests passed, 0 failed

The test suite includes a regression test for the six-call period-2 cycle and verifies that the permission request is emitted.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR