### PR TITLE
feat(core): switch connected accounts when the active one is rate limited

### DIFF
--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -59,7 +59,9 @@ export const isContextOverflowFailure = (failure: unknown) =>
     : Schema.is(ProviderErrorEvent)(failure) && failure.classification === "context-overflow"
 
 const decodeJson = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))
-const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "billing_error"])
+// `usage_limit_reached` is the ChatGPT subscription quota (5-hour or weekly
+// window) reported by the Codex backend; it resets in hours, not seconds.
+const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "usage_limit_reached", "billing_error"])
 const AUTH_CODES = new Set(["authentication_error", "permission_error"])
 const SERVER_CODES = new Set([
   "api_error",

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -160,6 +160,10 @@ describe("provider error rawBody classification", () => {
       ['{"type":"error","error":{"type":"overloaded_error","message":"Try again"}}', "ProviderInternal"],
       ['{"error":{"code":"insufficient_quota","message":"Request failed"}}', "QuotaExceeded"],
       [
+        '{"error":{"type":"usage_limit_reached","message":"You have hit your usage limit.","resets_in_seconds":3600}}',
+        "QuotaExceeded",
+      ],
+      [
         '{"type":"response.failed","response":{"error":{"code":"authentication_error","message":"Denied"}}}',
         "Authentication",
       ],

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -1239,6 +1239,16 @@ export type IntegrationWellknownAddOperation<E = never> = (
   input: IntegrationWellknownAddInput,
 ) => Effect.Effect<IntegrationWellknownAddOutput, E>
 
+export type IntegrationSettingsUpdateInput = {
+  readonly integrationID: Integration.ID
+  readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  readonly autoSwitch?: boolean | undefined
+}
+export type IntegrationSettingsUpdateOutput = void
+export type IntegrationSettingsUpdateOperation<E = never> = (
+  input: IntegrationSettingsUpdateInput,
+) => Effect.Effect<IntegrationSettingsUpdateOutput, E>
+
 export type IntegrationConnectKeyInput = {
   readonly integrationID: Integration.ID
   readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
@@ -1338,6 +1348,7 @@ export interface IntegrationApi<E = never> {
   readonly list: IntegrationListOperation<E>
   readonly get: IntegrationGetOperation<E>
   readonly wellknown: { readonly add: IntegrationWellknownAddOperation<E> }
+  readonly settings: { readonly update: IntegrationSettingsUpdateOperation<E> }
   readonly connect: { readonly key: IntegrationConnectKeyOperation<E> }
   readonly oauth: {
     readonly connect: IntegrationOauthConnectOperation<E>

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -116,6 +116,8 @@ import type {
   IntegrationGetOutput,
   IntegrationWellknownAddInput,
   IntegrationWellknownAddOutput,
+  IntegrationSettingsUpdateInput,
+  IntegrationSettingsUpdateOutput,
   IntegrationConnectKeyInput,
   IntegrationConnectKeyOutput,
   IntegrationOauthConnectInput,
@@ -840,6 +842,16 @@ const EndpointIntegrationWellknownAdd =
       ),
     )
 
+const EndpointIntegrationSettingsUpdate =
+  (raw: RawClient["server.integration"]) => (input: IntegrationSettingsUpdateInput) =>
+    preserveEffect<IntegrationSettingsUpdateOutput>()(
+      raw["integration.settings.update"]({
+        params: { integrationID: input["integrationID"] },
+        query: { location: input["location"] },
+        payload: { autoSwitch: input["autoSwitch"] },
+      }).pipe(Effect.mapError(mapClientError)),
+    )
+
 const EndpointIntegrationConnectKey = (raw: RawClient["server.integration"]) => (input: IntegrationConnectKeyInput) =>
   preserveEffect<IntegrationConnectKeyOutput>()(
     raw["integration.connect.key"]({
@@ -917,6 +929,7 @@ const adaptGroupIntegration = (raw: RawClient["server.integration"]) => ({
   list: EndpointIntegrationList(raw),
   get: EndpointIntegrationGet(raw),
   wellknown: { add: EndpointIntegrationWellknownAdd(raw) },
+  settings: { update: EndpointIntegrationSettingsUpdate(raw) },
   connect: { key: EndpointIntegrationConnectKey(raw) },
   oauth: {
     connect: EndpointIntegrationOauthConnect(raw),

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -110,6 +110,8 @@ import type {
   IntegrationGetOutput,
   IntegrationWellknownAddInput,
   IntegrationWellknownAddOutput,
+  IntegrationSettingsUpdateInput,
+  IntegrationSettingsUpdateOutput,
   IntegrationConnectKeyInput,
   IntegrationConnectKeyOutput,
   IntegrationOauthConnectInput,
@@ -1136,6 +1138,21 @@ export function make(options: ClientOptions) {
               path: `/api/experimental/integration/wellknown`,
               query: { location: input["location"] },
               body: { url: input["url"] },
+              successStatus: 204,
+              declaredStatuses: [400, 401],
+              empty: true,
+            },
+            requestOptions,
+          ),
+      },
+      settings: {
+        update: (input: IntegrationSettingsUpdateInput, requestOptions?: RequestOptions) =>
+          request<IntegrationSettingsUpdateOutput>(
+            {
+              method: "PATCH",
+              path: `/api/integration/${encodeURIComponent(input.integrationID)}/settings`,
+              query: { location: input["location"] },
+              body: { autoSwitch: input["autoSwitch"] },
               successStatus: 204,
               declaredStatuses: [400, 401],
               empty: true,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -230,6 +230,8 @@ export type ConnectionCredentialInfo = { type: "credential"; id: string; label: 
 
 export type ConnectionEnvInfo = { type: "env"; name: string }
 
+export type IntegrationSettings = { autoSwitch: boolean }
+
 export type IntegrationAttemptStatus =
   | {
       status: "pending"
@@ -2261,6 +2263,7 @@ export type IntegrationInfo = {
   metadata?: { [x: string]: any }
   methods: Array<IntegrationMethod>
   connections: Array<ConnectionInfo>
+  settings: IntegrationSettings
 }
 
 export type V2Event =
@@ -4479,6 +4482,16 @@ export type IntegrationWellknownAddInput = {
 }
 
 export type IntegrationWellknownAddOutput = void
+
+export type IntegrationSettingsUpdateInput = {
+  readonly integrationID: { readonly integrationID: string }["integrationID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly autoSwitch?: { readonly autoSwitch?: boolean | undefined }["autoSwitch"]
+}
+
+export type IntegrationSettingsUpdateOutput = void
 
 export type IntegrationConnectKeyInput = {
   readonly integrationID: { readonly integrationID: string }["integrationID"]

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -41,8 +41,17 @@ test("exposes every standard HTTP API group", () => {
   expect(Object.keys(client.debug)).toEqual(["location"])
   expect(Object.keys(client.debug.location)).toEqual(["list", "evict"])
   expect(Object.keys(client.message)).toEqual(["list"])
-  expect(Object.keys(client.integration)).toEqual(["list", "get", "wellknown", "connect", "oauth", "command"])
+  expect(Object.keys(client.integration)).toEqual([
+    "list",
+    "get",
+    "wellknown",
+    "settings",
+    "connect",
+    "oauth",
+    "command",
+  ])
   expect(Object.keys(client.integration.wellknown)).toEqual(["add"])
+  expect(Object.keys(client.integration.settings)).toEqual(["update"])
   expect(Object.keys(client.integration.connect)).toEqual(["key"])
   expect(Object.keys(client.integration.oauth)).toEqual(["connect", "status", "complete", "cancel"])
   expect(Object.keys(client.integration.command)).toEqual(["connect", "status", "cancel"])
@@ -247,6 +256,29 @@ test("credential.activate uses the public HTTP contract", async () => {
   expect(request?.url).toBe(
     "http://localhost:3000/api/credential/cred_work/activate?location%5Bdirectory%5D=%2Ftmp%2Fproject",
   )
+})
+
+test("integration.settings.update uses the public HTTP contract", async () => {
+  let request: Request | undefined
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async (input, init) => {
+      request = input instanceof Request ? input : new Request(input, init)
+      return new Response(null, { status: 204 })
+    },
+  })
+
+  await client.integration.settings.update({
+    integrationID: "openai",
+    location: { directory: "/tmp/project" },
+    autoSwitch: true,
+  })
+
+  expect(request?.method).toBe("PATCH")
+  expect(request?.url).toBe(
+    "http://localhost:3000/api/integration/openai/settings?location%5Bdirectory%5D=%2Ftmp%2Fproject",
+  )
+  expect(await request?.json()).toEqual({ autoSwitch: true })
 })
 
 test("integration connections optionally submit a form answer", async () => {

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -19,6 +19,7 @@ import {
 } from "effect"
 import { Integration } from "@opencode-ai/schema/integration"
 import { Credential } from "./credential.js"
+import { KV } from "./kv.js"
 import { State } from "./state.js"
 import { Bus } from "./bus.js"
 import { IntegrationConnection } from "./integration/connection.js"
@@ -52,6 +53,9 @@ export type Method = Integration.Method
 
 export const Info = Integration.Info
 export type Info = Integration.Info
+
+export const Settings = Integration.Settings
+export type Settings = Integration.Settings
 
 export type OAuthAuthorization = {
   readonly url: string
@@ -176,6 +180,10 @@ export interface Interface extends State.Transformable<Editor> {
     /** Removes a stored credential connection. */
     readonly remove: (credentialID: Credential.ID) => Effect.Effect<void>
   }
+  readonly settings: {
+    /** Updates the stored settings of one integration. */
+    readonly update: (id: ID, updates: Partial<Settings>) => Effect.Effect<void>
+  }
   readonly oauth: {
     /** Starts a stateful OAuth attempt. */
     readonly connect: (input: {
@@ -217,6 +225,9 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/In
 const attemptLifetime = Duration.toMillis(Duration.minutes(10))
 const terminalRetention = Duration.toMillis(Duration.minutes(1))
 const scrubInterval = Duration.seconds(30)
+// Automatic account switching is opt-in so a rate limit never silently moves
+// traffic to another account the user did not intend to spend.
+const DEFAULT_SETTINGS: Settings = { autoSwitch: false }
 
 type AttemptTime = { created: number; expires: number }
 type PendingAttempt = {
@@ -261,6 +272,7 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const credentials = yield* Credential.Service
+    const kv = yield* KV.Service
     const bus = yield* Bus.Service
     const processes = yield* AppProcess.Service
     const scope = yield* Scope.Scope
@@ -357,13 +369,21 @@ const layer = Layer.effect(
       return [...credentials, ...env]
     }
 
-    const project = (entry: Entry, connections: IntegrationConnection.Info[]): Info =>
+    const settingsKey = (id: ID) => `integration:settings:${id}`
+
+    const loadSettings = Effect.fn("Integration.loadSettings")(function* (id: ID) {
+      const value = yield* kv.get(settingsKey(id))
+      return Schema.is(Settings)(value) ? value : DEFAULT_SETTINGS
+    })
+
+    const project = (entry: Entry, connections: IntegrationConnection.Info[], settings: Settings): Info =>
       Info.make({
         id: entry.ref.id,
         name: entry.ref.name,
         ...(entry.ref.metadata === undefined ? {} : { metadata: entry.ref.metadata }),
         methods: entry.methods,
         connections,
+        settings,
       })
 
     const authorize = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
@@ -651,13 +671,15 @@ const layer = Layer.effect(
       get: Effect.fn("Integration.get")(function* (id) {
         const entry = state.get().integrations.get(id)
         if (!entry) return undefined
-        return project(entry, resolveConnections(entry, yield* credentials.list(id)))
+        return project(entry, resolveConnections(entry, yield* credentials.list(id)), yield* loadSettings(id))
       }),
       list: Effect.fn("Integration.list")(function* () {
         const saved = Map.groupBy(yield* credentials.all(), (credential) => credential.integrationID)
-        return Array.from(state.get().integrations.values(), (entry) =>
-          project(entry, resolveConnections(entry, saved.get(entry.ref.id) ?? [])),
-        ).toSorted((a, b) => a.name.localeCompare(b.name))
+        return (yield* Effect.forEach(state.get().integrations.values(), (entry) =>
+          Effect.map(loadSettings(entry.ref.id), (settings) =>
+            project(entry, resolveConnections(entry, saved.get(entry.ref.id) ?? []), settings),
+          ),
+        )).toSorted((a, b) => a.name.localeCompare(b.name))
       }),
       connection: {
         active: Effect.fn("Integration.connection.active")(function* (id) {
@@ -712,6 +734,15 @@ const layer = Layer.effect(
           credentials.update(credentialID, updates),
         ),
         remove: Effect.fn("Integration.connection.remove")((credentialID) => credentials.remove(credentialID)),
+      },
+      settings: {
+        update: Effect.fn("Integration.settings.update")(function* (id, updates) {
+          const current = yield* loadSettings(id)
+          const next = { autoSwitch: updates.autoSwitch ?? current.autoSwitch }
+          if (next.autoSwitch === current.autoSwitch) return
+          yield* kv.set(settingsKey(id), next)
+          yield* bus.publish(Integration.Event.Updated, {})
+        }),
       },
       oauth: {
         connect: connectOAuth,
@@ -796,5 +827,5 @@ const layer = Layer.effect(
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Credential.node, Bus.node, AppProcess.node],
+  deps: [Credential.node, KV.node, Bus.node, AppProcess.node],
 })

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -267,6 +267,10 @@ export const make = Effect.fn("PluginHost.make")(function* (
     integration: {
       list: () => response(integration.list()),
       get: (input) => response(integration.get(Integration.ID.make(input.integrationID))),
+      settings: {
+        update: (input) =>
+          integration.settings.update(Integration.ID.make(input.integrationID), { autoSwitch: input.autoSwitch }),
+      },
       connect: {
         key: (input) =>
           integration.connection.key({

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -233,16 +233,19 @@ export const OpenAIPlugin = define({
     const loading = Semaphore.makeUnsafe(1)
     let chatgpt: Credential.OAuth | undefined
 
-    const load = Effect.fn("OpenAIPlugin.load")(function* () {
+    const active = Effect.fn("OpenAIPlugin.active")(function* () {
       const connection = yield* ctx.integration.connection.active("openai")
       const credential = connection
         ? yield* ctx.integration.connection.resolve(connection).pipe(Effect.orElseSucceed(() => undefined))
         : undefined
-      chatgpt =
-        credential?.type === "oauth" &&
+      return credential?.type === "oauth" &&
         (credential.methodID === browserMethodID || credential.methodID === headlessMethodID)
-          ? credential
-          : undefined
+        ? credential
+        : undefined
+    })
+
+    const load = Effect.fn("OpenAIPlugin.load")(function* () {
+      chatgpt = yield* active()
     })
 
     yield* ctx.integration.transform((editor) => {
@@ -294,12 +297,17 @@ export const OpenAIPlugin = define({
     yield* ctx.session.hook(
       "model.request",
       (evt) =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
           if (!chatgpt) return
           if (evt.baseURL && URL.canParse(evt.baseURL) && new URL(evt.baseURL).origin === "https://api.openai.com")
             evt.baseURL = codexBaseURL
           evt.headers.originator = "opencode"
           evt.headers["session-id"] = evt.sessionID
+          // The catalog header is rebuilt asynchronously after an account
+          // switch. Read the account from the credential this request
+          // authenticates with so the header never lags behind the token.
+          const account = (yield* active())?.metadata?.accountID
+          if (typeof account === "string") evt.headers["chatgpt-account-id"] = account
         }),
       { providerID: Provider.ID.openai },
     )

--- a/packages/core/src/session/runner/failover.ts
+++ b/packages/core/src/session/runner/failover.ts
@@ -1,0 +1,35 @@
+export * as SessionRunnerFailover from "./failover.js"
+
+import { Model } from "@opencode-ai/schema/model"
+import { Effect } from "effect"
+import { Catalog } from "../../catalog.js"
+import { Credential } from "../../credential.js"
+import { Integration } from "../../integration.js"
+
+export interface Interface {
+  /** Activates the next connected account for the model's integration.
+   *  Returns the credential that was active (now exhausted), or undefined when
+   *  auto-switch is off, the active connection is not a credential, or no
+   *  un-exhausted candidate remains. */
+  readonly next: (model: Model.Ref, exhausted: ReadonlySet<Credential.ID>) => Effect.Effect<Credential.ID | undefined>
+}
+
+export const make = (integrations: Integration.Interface, catalog: Catalog.Interface): Interface => ({
+  next: Effect.fn("SessionRunnerFailover.next")(function* (model, exhausted) {
+    const provider = yield* catalog.provider.get(model.providerID)
+    const integrationID = provider?.integrationID ?? Integration.ID.make(model.providerID)
+    const info = yield* integrations.get(integrationID)
+    if (!info?.settings.autoSwitch) return undefined
+    const active = yield* integrations.connection.active(integrationID)
+    if (active?.type !== "credential") return undefined
+    // Connections list the active account first, so the first remaining
+    // candidate is the next account the user would have picked manually.
+    const candidate = info.connections
+      .filter((connection) => connection.type === "credential")
+      .find((connection) => connection.id !== active.id && !exhausted.has(connection.id))
+    if (!candidate) return undefined
+    yield* integrations.connection.activate(candidate.id)
+    yield* Effect.logInfo("account switched", { integrationID, from: active.id, to: candidate.id })
+    return active.id
+  }),
+})

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -5,6 +5,8 @@ import { and, desc, eq, sql } from "drizzle-orm"
 import { Cause, Effect, Exit, FiberMap, Layer } from "effect"
 import { Database } from "../../database/database.js"
 import { Bus } from "../../bus.js"
+import { Catalog } from "../../catalog.js"
+import { Integration } from "../../integration.js"
 import { InstructionState } from "../instruction-state.js"
 import { SessionCompaction } from "../compaction.js"
 import { SessionContext } from "../context.js"
@@ -24,6 +26,7 @@ import { Snapshot } from "../../snapshot.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { llmClient } from "../../effect/app-node-platform.js"
 import { StepFailedError } from "../error.js"
+import { SessionRunnerFailover } from "./failover.js"
 import { SessionRunnerRetry } from "./retry.js"
 import { SessionStep } from "./step.js"
 import { ToolOutput } from "../../tool-output.js"
@@ -44,6 +47,9 @@ const layer = Layer.effect(
     const compaction = yield* SessionCompaction.Service
     const plugins = yield* Plugin.Service
     const title = yield* SessionTitle.Service
+    const integrations = yield* Integration.Service
+    const catalog = yield* Catalog.Service
+    const failover = SessionRunnerFailover.make(integrations, catalog)
     const steps = yield* SessionStep.make
     // Title generation starts once input is visible and must not delay model execution.
     const titles = yield* FiberMap.make<SessionSchema.ID, void, never>()
@@ -199,7 +205,7 @@ const layer = Layer.effect(
     const runStep = Effect.fn("SessionRunner.runStep")(function* (first: SessionContext.Loaded, step: number) {
       const sessionID = first.session.id
       let assistantMessageID = SessionMessage.ID.create()
-      const retry = yield* SessionRunnerRetry.make(bus, sessionID)
+      const retry = yield* SessionRunnerRetry.make(bus, sessionID, failover)
       let initial: SessionContext.Loaded | undefined = first
       let recoverOverflow = true
       let recoverContinuation = true
@@ -363,5 +369,7 @@ export const node = makeLocationNode({
     Snapshot.node,
     ToolOutput.node,
     Database.node,
+    Integration.node,
+    Catalog.node,
   ],
 })

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -6,10 +6,12 @@ import { Model } from "@opencode-ai/schema/model"
 import { SessionError } from "@opencode-ai/schema/session-error"
 import { Clock, Duration, Effect, Pull, Schedule } from "effect"
 import { Bus } from "../../bus.js"
+import type { Credential } from "../../credential.js"
 import type { PluginHooks } from "../../plugin/hooks.js"
 import { SessionEvent } from "../event.js"
 import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
+import type { SessionRunnerFailover } from "./failover.js"
 
 interface Input {
   readonly cause: AIError
@@ -78,37 +80,67 @@ const schedule = Schedule.max([Schedule.exponential("2 seconds"), Schedule.recur
   }),
 )
 
-export const policy = (sessionID: SessionSchema.ID) =>
+/** Retries on the current account before treating it as exhausted. */
+const ACCOUNT_ATTEMPTS = 2
+
+/** A provider asking for a longer wait than this exhausts the account instead. */
+const ACCOUNT_RETRY_AFTER_MAX = Duration.toMillis("30 seconds")
+
+/** The next account starts immediately; the pause only covers credential propagation. */
+const SWITCH_DELAY = 1_000
+
+export const policy = (sessionID: SessionSchema.ID, failover?: SessionRunnerFailover.Interface) =>
   Effect.gen(function* () {
-    const step = yield* Schedule.toStep(schedule)
+    let step = yield* Schedule.toStep(schedule)
     let attempt = 1
+    let accountAttempts = 0
+    const exhausted = new Set<Credential.ID>()
+    const propose = Effect.fnUntraced(function* (input: Input, retry: boolean, delay: number) {
+      attempt++
+      const event: PluginHooks.Domains["session"]["retry"] = {
+        sessionID,
+        agent: input.agent,
+        model: input.model,
+        error: input.error,
+        attempt,
+        decision: retry ? { retry: true, delay } : { retry: false },
+      }
+      yield* input.hook(event)
+      if (!event.decision.retry) return event.decision
+      const normalized =
+        Number.isFinite(event.decision.delay) && event.decision.delay >= 0 ? Math.ceil(event.decision.delay) : delay
+      return { retry: true as const, attempt, delay: normalized }
+    })
     return (input: Input) =>
       Effect.gen(function* () {
+        const reason = input.cause.reason._tag
+        if (failover && (reason === "RateLimit" || reason === "QuotaExceeded")) {
+          const requested = retryAfter(input)
+          const spent =
+            reason === "QuotaExceeded" ||
+            accountAttempts >= ACCOUNT_ATTEMPTS ||
+            (requested !== undefined && requested > ACCOUNT_RETRY_AFTER_MAX)
+          const previous = spent ? yield* failover.next(input.model, exhausted) : undefined
+          if (previous) {
+            exhausted.add(previous)
+            accountAttempts = 0
+            // The account that just took over owns a full retry budget.
+            step = yield* Schedule.toStep(schedule)
+            return yield* propose(input, true, SWITCH_DELAY)
+          }
+          accountAttempts++
+        }
         const now = yield* Clock.currentTimeMillis
         const next = yield* step(now, input).pipe(Pull.catchDone(() => Effect.succeed(undefined)))
         if (!next) return { retry: false as const }
         const [, duration] = next
-        attempt++
-        const delay = Math.ceil(Duration.toMillis(duration))
-        const event: PluginHooks.Domains["session"]["retry"] = {
-          sessionID,
-          agent: input.agent,
-          model: input.model,
-          error: input.error,
-          attempt,
-          decision: input.retry ? { retry: true, delay } : { retry: false },
-        }
-        yield* input.hook(event)
-        if (!event.decision.retry) return event.decision
-        const normalized =
-          Number.isFinite(event.decision.delay) && event.decision.delay >= 0 ? Math.ceil(event.decision.delay) : delay
-        return { retry: true as const, attempt, delay: normalized }
+        return yield* propose(input, input.retry, Math.ceil(Duration.toMillis(duration)))
       })
   })
 
-export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
+export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID, failover: SessionRunnerFailover.Interface) =>
   Effect.gen(function* () {
-    const decide = yield* policy(sessionID)
+    const decide = yield* policy(sessionID, failover)
     const wait = (input: {
       readonly decision: Decision
       readonly assistantMessageID: SessionMessage.ID

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -42,6 +42,9 @@ const integrations = Layer.mock(Integration.Service, {
     update: () => Effect.die("unused"),
     remove: () => Effect.die("unused"),
   },
+  settings: {
+    update: () => Effect.die("unused"),
+  },
   oauth: {
     connect: () => Effect.die("unused"),
     status: () => Effect.die("unused"),

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -67,6 +67,7 @@ describe("Integration", () => {
           metadata: { source: "plugin", featured: true },
           methods: [],
           connections: [],
+          settings: { autoSwitch: false },
         }),
       )
 
@@ -673,4 +674,39 @@ describe("Integration", () => {
         }),
     )
   })
+
+  it.effect("stores per-integration settings and notifies clients", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const bus = yield* Bus.Service
+      const integrationID = Integration.ID.make("openai")
+      yield* integrations.transform((editor) => editor.method.update({ integrationID, method: { type: "key" } }))
+      expect((yield* integrations.get(integrationID))?.settings).toEqual({ autoSwitch: false })
+
+      const events: string[] = []
+      yield* bus.subscribe(Integration.Event.Updated).pipe(
+        Stream.runForEach((event) => Effect.sync(() => void events.push(event.type))),
+        Effect.forkScoped,
+      )
+      yield* Effect.yieldNow
+
+      yield* integrations.settings.update(integrationID, { autoSwitch: true })
+      expect((yield* integrations.get(integrationID))?.settings).toEqual({ autoSwitch: true })
+      expect((yield* integrations.list()).find((item) => item.id === integrationID)?.settings).toEqual({
+        autoSwitch: true,
+      })
+      yield* eventually(
+        Effect.sync(() => events.length),
+        (length) => length === 1,
+      )
+
+      // Writing the same value again is a no-op so clients are not asked to refetch.
+      yield* integrations.settings.update(integrationID, { autoSwitch: true })
+      yield* Effect.promise(() => Bun.sleep(5))
+      expect(events).toEqual([Integration.Event.Updated.type])
+
+      yield* integrations.settings.update(integrationID, { autoSwitch: false })
+      expect((yield* integrations.get(integrationID))?.settings).toEqual({ autoSwitch: false })
+    }),
+  )
 })

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -282,6 +282,9 @@ function resourceMcpLayer(
             update: unusedIntegration,
             remove: unusedIntegration,
           },
+          settings: {
+            update: unusedIntegration,
+          },
           oauth: {
             connect: unusedIntegration,
             status: unusedIntegration,

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -361,6 +361,9 @@ describe("ModelResolver", () => {
         update: () => Effect.die("unused"),
         remove: () => Effect.die("unused"),
       },
+      settings: {
+        update: () => Effect.die("unused"),
+      },
       oauth: {
         connect: () => Effect.die("unused"),
         status: () => Effect.die("unused"),

--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -77,6 +77,9 @@ export function host(overrides: Overrides = {}): Plugin.Context {
     integration: overrides.integration ?? {
       list: () => Effect.die("unused integration.list"),
       get: () => Effect.die("unused integration.get"),
+      settings: {
+        update: () => Effect.die("unused integration.settings.update"),
+      },
       connect: {
         key: () => Effect.die("unused integration.connect.key"),
       },
@@ -309,6 +312,9 @@ export function integrationHost(integration: Integration.Interface): Plugin.Cont
   return {
     list: () => Effect.die("unused integration.list"),
     get: () => Effect.die("unused integration.get"),
+    settings: {
+      update: () => Effect.die("unused integration.settings.update"),
+    },
     connect: {
       key: () => Effect.die("unused integration.connect.key"),
     },

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -649,6 +649,7 @@ describe("ModelsDevPlugin", () => {
             },
           ],
           connections: [],
+          settings: { autoSwitch: false },
         }),
       ])
     }).pipe(Effect.provide(models(path.join(import.meta.dir, "fixtures", "models-dev.json")))),

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -177,8 +177,49 @@ describe("OpenAIPlugin", () => {
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-6-astra"))).enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.10"))).enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5"))).enabled).toBe(false)
-      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.04-astra"))).enabled).toBe(false)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.04-astra"))).enabled).toBe(
+        false,
+      )
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.99"))).enabled).toBe(false)
+    }),
+  )
+
+  it.effect("sends the account header of the credential active at request time", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const credentials = yield* Credential.Service
+      yield* catalog.transform((catalog) => {
+        catalog.provider.update(Provider.ID.openai, (draft) => {
+          draft.package = Provider.aisdk("@ai-sdk/openai")
+        })
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-5.5"), () => {})
+      })
+      const chatgpt = (accountID: string) =>
+        Credential.OAuth.make({
+          type: "oauth",
+          methodID: Integration.MethodID.make("chatgpt-browser"),
+          access: `${accountID}-token`,
+          refresh: "refresh",
+          expires: Date.now() + 60_000,
+          metadata: { accountID },
+        })
+      const first = yield* credentials.create({
+        integrationID: Integration.ID.make("openai"),
+        value: chatgpt("acct_1"),
+      })
+      yield* credentials.create({ integrationID: Integration.ID.make("openai"), value: chatgpt("acct_2") })
+      yield* addPlugin()
+
+      expect((yield* request(Provider.ID.openai, "https://api.openai.com/v1")).headers).toMatchObject({
+        "chatgpt-account-id": "acct_2",
+      })
+
+      // Switching accounts must be visible to the very next request, before the
+      // asynchronous catalog refresh has run.
+      yield* credentials.activate(first.id)
+      expect((yield* request(Provider.ID.openai, "https://api.openai.com/v1")).headers).toMatchObject({
+        "chatgpt-account-id": "acct_1",
+      })
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -12,6 +12,7 @@ import {
   TransportError,
   InvalidProviderOutputError,
   InvalidRequestError,
+  QuotaExceededError,
   RateLimitError,
   UnknownProviderError,
 } from "@opencode-ai/ai"
@@ -20,6 +21,8 @@ import { AnthropicMessages, OpenAIResponses } from "@opencode-ai/ai/protocols"
 import { compileRequest } from "@opencode-ai/ai/route/client"
 import { TestLLM } from "@opencode-ai/ai/testing"
 import { Catalog } from "@opencode-ai/core/catalog"
+import { Credential } from "@opencode-ai/core/credential"
+import { Integration } from "@opencode-ai/core/integration"
 import { Database } from "@opencode-ai/core/database/database"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -81,7 +84,7 @@ import { Location } from "@opencode-ai/core/location"
 import { Provider } from "@opencode-ai/core/provider"
 import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Queue, Schema, Scope, Stream } from "effect"
 import { TestClock } from "effect/testing"
-import { asc, desc, eq, sql } from "drizzle-orm"
+import { and, asc, desc, eq, sql } from "drizzle-orm"
 import { testEffect } from "./lib/effect"
 import { promptLocationNode } from "./fixture/prompt-location"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
@@ -461,6 +464,8 @@ const layer = Layer.unwrap(
         SessionInbox.node,
         Agent.node,
         Catalog.node,
+        Credential.node,
+        Integration.node,
         Tool.node,
         PluginHooks.node,
         echoNode,
@@ -642,6 +647,70 @@ const invalidRequest = () =>
 const rateLimited = (retryAfterMs?: number) =>
   new AIError({
     reason: new RateLimitError({ message: "Rate limited", retryAfterMs }),
+  })
+
+const quotaExceeded = () =>
+  new AIError({
+    reason: new QuotaExceededError({ message: "Usage limit reached" }),
+  })
+
+// The test model's provider has no catalog entry, so its integration is the provider id.
+const fakeIntegrationID = Integration.ID.make("fake")
+
+/** Connects `count` accounts; the last one created is the active connection. */
+const connectAccounts = Effect.fnUntraced(function* (count: number, autoSwitch: boolean) {
+  const integrations = yield* Integration.Service
+  const credentials = yield* Credential.Service
+  yield* integrations.transform((editor) =>
+    editor.update(fakeIntegrationID, (integration) => (integration.name = "Fake")),
+  )
+  const accounts = yield* Effect.forEach(
+    Array.from({ length: count }, (_, index) => index + 1),
+    (index) =>
+      credentials.create({
+        integrationID: fakeIntegrationID,
+        label: `Account ${index}`,
+        value: Credential.Key.make({ type: "key", key: `key-${index}` }),
+      }),
+  )
+  if (autoSwitch) yield* integrations.settings.update(fakeIntegrationID, { autoSwitch: true })
+  return accounts
+})
+
+const activeAccount = Effect.gen(function* () {
+  const integrations = yield* Integration.Service
+  const active = yield* integrations.connection.active(fakeIntegrationID)
+  return active?.type === "credential" ? active.id : undefined
+})
+
+const isSwitch = Schema.is(Credential.Event.Switched.data)
+
+/** Collects the account each `credential.switched` activates. Listeners run inside publish, so they never lag. */
+const recordSwitches = (s: Scenario) =>
+  Effect.gen(function* () {
+    const switches = new Array<Credential.ID>()
+    yield* s.bus.listen((event) =>
+      Effect.sync(() => {
+        if (event.type !== Credential.Event.Switched.type || !isSwitch(event.data)) return
+        if (event.data.credentialID) switches.push(event.data.credentialID)
+      }),
+    )
+    return switches
+  })
+
+const recordedRetries = (id: Session.ID) =>
+  Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    return yield* db
+      .select({ data: EventTable.data })
+      .from(EventTable)
+      .where(and(eq(EventTable.aggregate_id, id), eq(EventTable.type, "session.retry.scheduled.1")))
+      .orderBy(asc(EventTable.seq))
+      .all()
+      .pipe(
+        Effect.orDie,
+        Effect.map((rows) => rows.map((row) => row.data)),
+      )
   })
 
 const setupOverflowRecovery = Effect.fnUntraced(function* (s: Scenario) {
@@ -4979,6 +5048,111 @@ describe("SessionRunnerLLM", () => {
     yield* TestClock.adjust("1 millis")
     yield* Fiber.join(run)
     expect(s.requests).toHaveLength(2)
+  })
+
+  scenario("switches to the next connected account when the active one is out of quota", function* (s) {
+    const accounts = yield* connectAccounts(2, true)
+    const switches = yield* recordSwitches(s)
+    yield* s.admit("Switch on quota")
+    yield* s.llm.push(Stream.fail(quotaExceeded()))
+    yield* s.llm.push(TestLLM.text("Recovered", "quota-switch-success"))
+
+    const scheduled = yield* subscribeRetries(s)
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    yield* Queue.take(scheduled)
+    yield* TestClock.adjust("1000 millis")
+    yield* Fiber.join(run)
+
+    expect(s.requests).toHaveLength(2)
+    expect(yield* activeAccount).toBe(accounts[0].id)
+    expect(switches).toEqual([accounts[0].id])
+    const retries = yield* recordedRetries(sessionID)
+    expect(retries).toHaveLength(1)
+    expect(retries[0]?.attempt).toBeGreaterThanOrEqual(1)
+    expect(retries[0]?.at).toBe(1_000)
+    expect(yield* s.context).toMatchObject([
+      { type: "user" },
+      Expected.assistant({ finish: "stop" }, [Expected.text("Recovered")]),
+    ])
+  })
+
+  scenario("switches accounts instead of waiting out a long provider retry-after", function* (s) {
+    const accounts = yield* connectAccounts(2, true)
+    const switches = yield* recordSwitches(s)
+    yield* s.admit("Switch on long rate limit")
+    yield* s.llm.push(Stream.fail(rateLimited(3_600_000)))
+    yield* s.llm.push(TestLLM.text("Recovered", "long-rate-limit-success"))
+
+    const scheduled = yield* subscribeRetries(s)
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    yield* Queue.take(scheduled)
+    yield* TestClock.adjust("1000 millis")
+    yield* Fiber.join(run)
+
+    expect(s.requests).toHaveLength(2)
+    expect(yield* activeAccount).toBe(accounts[0].id)
+    expect(switches).toEqual([accounts[0].id])
+  })
+
+  scenario("retries the active account twice before switching on a plain rate limit", function* (s) {
+    const accounts = yield* connectAccounts(2, true)
+    const switches = yield* recordSwitches(s)
+    yield* s.admit("Retry then switch")
+    yield* s.llm.push(Stream.fail(rateLimited()), Stream.fail(rateLimited()), Stream.fail(rateLimited()))
+    yield* s.llm.push(TestLLM.text("Recovered", "rate-limit-switch-success"))
+
+    const scheduled = yield* subscribeRetries(s)
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    // Each scheduled retry observes the decision that produced it, before its backoff runs.
+    for (const delay of [2_400, 4_800]) {
+      yield* Queue.take(scheduled)
+      expect(switches).toEqual([])
+      expect(yield* activeAccount).toBe(accounts[1].id)
+      yield* TestClock.adjust(delay)
+    }
+    yield* Queue.take(scheduled)
+    expect(switches).toEqual([accounts[0].id])
+    yield* TestClock.adjust("1000 millis")
+    yield* Fiber.join(run)
+
+    expect(s.requests).toHaveLength(4)
+    expect(switches).toEqual([accounts[0].id])
+    expect(yield* activeAccount).toBe(accounts[0].id)
+  })
+
+  scenario("fails with the provider error once every connected account is exhausted", function* (s) {
+    const accounts = yield* connectAccounts(3, true)
+    const switches = yield* recordSwitches(s)
+    const failure = quotaExceeded()
+    yield* s.admit("Exhaust every account")
+    yield* s.llm.always(Stream.fail(failure))
+
+    const scheduled = yield* subscribeRetries(s)
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    // Every account but the last one gives up its turn through one switch retry.
+    for (const _ of accounts.slice(1)) {
+      yield* Queue.take(scheduled)
+      yield* TestClock.adjust("1000 millis")
+    }
+    expect(yield* Fiber.join(run).pipe(Effect.flip)).toBe(failure)
+
+    expect(s.requests).toHaveLength(accounts.length)
+    expect(switches).toEqual([accounts[1].id, accounts[0].id])
+    expect(yield* activeAccount).toBe(accounts[0].id)
+  })
+
+  scenario("keeps quota failures terminal while auto-switch is off", function* (s) {
+    const accounts = yield* connectAccounts(2, false)
+    const switches = yield* recordSwitches(s)
+    const failure = quotaExceeded()
+    yield* s.llm.push(Stream.fail(failure), TestLLM.text("Must not run", "unused-switch"))
+
+    expect(yield* s.runPrompt("Do not switch accounts").pipe(Effect.flip)).toBe(failure)
+
+    expect(s.requests).toHaveLength(1)
+    expect(switches).toEqual([])
+    expect(yield* activeAccount).toBe(accounts[1].id)
+    expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
   })
 
   scenario("continues an incomplete stream after observable text", function* (s) {

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -347,6 +347,12 @@ export function fromPromise(plugin: Plugin) {
           integration: {
             list: adaptApiMethod(IntegrationEndpoints["integration.list"], host.integration.list),
             get: adaptApiMethod(IntegrationEndpoints["integration.get"], host.integration.get),
+            settings: {
+              update: adaptApiMethod(
+                IntegrationEndpoints["integration.settings.update"],
+                host.integration.settings.update,
+              ),
+            },
             connect: {
               key: adaptApiMethod(IntegrationEndpoints["integration.connect.key"], host.integration.connect.key),
             },

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -1621,14 +1621,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
-                    },
-                    {
-                      "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
                 }
               }
             }
@@ -5525,6 +5518,113 @@
                   }
                 },
                 "required": ["url"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/integration/{integrationID}/settings": {
+      "patch": {
+        "tags": ["integration"],
+        "operationId": "v2.integration.settings.update",
+        "parameters": [
+          {
+            "name": "integrationID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": false,
+            "style": "deepObject",
+            "explode": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Change stored settings for one integration, such as automatic account switching.",
+        "summary": "Update integration settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "autoSwitch": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
                 "additionalProperties": false
               }
             }
@@ -15857,9 +15957,12 @@
             "items": {
               "$ref": "#/components/schemas/Connection.Info"
             }
+          },
+          "settings": {
+            "$ref": "#/components/schemas/Integration.Settings"
           }
         },
-        "required": ["id", "name", "methods", "connections"],
+        "required": ["id", "name", "methods", "connections", "settings"],
         "additionalProperties": false
       },
       "Integration.KeyMethod": {
@@ -15913,6 +16016,16 @@
           }
         },
         "required": ["id", "type", "label"],
+        "additionalProperties": false
+      },
+      "Integration.Settings": {
+        "type": "object",
+        "properties": {
+          "autoSwitch": {
+            "type": "boolean"
+          }
+        },
+        "required": ["autoSwitch"],
         "additionalProperties": false
       },
       "InvalidCursorErrorEncoded": {

--- a/packages/protocol/src/groups/integration.ts
+++ b/packages/protocol/src/groups/integration.ts
@@ -53,6 +53,24 @@ export const IntegrationGroup = HttpApiGroup.make("server.integration")
       ),
   )
   .add(
+    HttpApiEndpoint.patch("integration.settings.update", "/api/integration/:integrationID/settings", {
+      params: { integrationID: Integration.ID },
+      query: LocationQuery,
+      payload: Schema.Struct({
+        autoSwitch: Schema.optional(Schema.Boolean),
+      }),
+      success: HttpApiSchema.NoContent,
+    })
+      .annotateMerge(locationQueryOpenApi)
+      .annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.integration.settings.update",
+          summary: "Update integration settings",
+          description: "Change stored settings for one integration, such as automatic account switching.",
+        }),
+      ),
+  )
+  .add(
     HttpApiEndpoint.post("integration.connect.key", "/api/integration/:integrationID/connect/key", {
       params: { integrationID: Integration.ID },
       query: LocationQuery,

--- a/packages/schema/src/integration.ts
+++ b/packages/schema/src/integration.ts
@@ -62,12 +62,19 @@ export const Ref = Schema.Struct({
   metadata: optional(Schema.Record(Schema.String, Schema.Any)),
 }).annotate({ identifier: "Integration.Ref" })
 
+export interface Settings extends Schema.Schema.Type<typeof Settings> {}
+export const Settings = Schema.Struct({
+  /** Switch to another connected account when the active one is rate limited or out of quota. */
+  autoSwitch: Schema.Boolean,
+}).annotate({ identifier: "Integration.Settings" })
+
 export const Info = Schema.Struct({
   id: ID,
   name: Schema.String,
   metadata: optional(Schema.Record(Schema.String, Schema.Any)),
   methods: Schema.Array(Method),
   connections: Schema.Array(Connection.Info),
+  settings: Settings,
 }).annotate({ identifier: "Integration.Info" })
 export interface Info extends Schema.Schema.Type<typeof Info> {}
 

--- a/packages/server/src/handlers/integration.ts
+++ b/packages/server/src/handlers/integration.ts
@@ -52,6 +52,14 @@ export const IntegrationHandler = HttpApiBuilder.group(Api, "server.integration"
         }),
       )
       .handle(
+        "integration.settings.update",
+        Effect.fn(function* (ctx) {
+          const service = yield* Integration.Service
+          yield* service.settings.update(ctx.params.integrationID, ctx.payload)
+          return HttpApiSchema.NoContent.make()
+        }),
+      )
+      .handle(
         "integration.connect.key",
         Effect.fn(function* (ctx) {
           const service = yield* Integration.Service

--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -164,6 +164,9 @@ function manageConnections(
     const current = createMemo(() =>
       data.location.integration.list(location)?.find((item) => item.id === integration.id),
     )
+    const autoSwitch = createMemo(() => (current() ?? integration).settings.autoSwitch)
+    // The add and settings rows are not accounts, so the account actions never apply to them.
+    const isAccount = (value?: string) => value !== undefined && value !== "add" && value !== "auto-switch"
 
     return (
       <DialogSelect
@@ -185,6 +188,23 @@ function manageConnections(
                 },
               ]
             : []),
+          {
+            title: "Switch accounts when rate limited",
+            // The row title fills the fixed dialog width, so the explanation stays searchable instead of clipped.
+            searchText: "Use the next connected account when the active one is rate limited or out of quota",
+            footer: autoSwitch() ? "on" : "off",
+            value: "auto-switch",
+            category: "Settings",
+            onSelect: () => {
+              void client.api.integration.settings
+                .update({
+                  integrationID: integration.id,
+                  location: locationQuery(location),
+                  autoSwitch: !autoSwitch(),
+                })
+                .catch(toast.error)
+            },
+          },
           ...credentialConnections(current() ?? integration)
             .toSorted((a, b) => a.label.localeCompare(b.label) || a.id.localeCompare(b.id))
             .map((connection) => {
@@ -210,8 +230,8 @@ function manageConnections(
           {
             command: "dialog.integration.rename",
             title: "rename",
-            hidden: selected() === "add",
-            disabled: (option) => !option || option.value === "add",
+            hidden: !isAccount(selected()),
+            disabled: (option) => !isAccount(option?.value),
             onTrigger: (option) => {
               dialog.replace(() => (
                 <DialogPrompt
@@ -235,8 +255,8 @@ function manageConnections(
           {
             command: "dialog.integration.delete",
             title: "delete",
-            hidden: selected() === "add",
-            disabled: (option) => !option || option.value === "add",
+            hidden: !isAccount(selected()),
+            disabled: (option) => !isAccount(option?.value),
             onTrigger: (option) => {
               if (deleting() !== option.value) return setDeleting(option.value)
               const final = credentialConnections(current() ?? integration).length === 1
@@ -312,7 +332,13 @@ async function beginKey(
     : undefined
   if (answer === null) return
   dialog.replace(() => (
-    <KeyMethod integration={integration} method={method} location={location} answer={answer} onConnected={onConnected} />
+    <KeyMethod
+      integration={integration}
+      method={method}
+      location={location}
+      answer={answer}
+      onConnected={onConnected}
+    />
   ))
 }
 

--- a/packages/tui/test/cli/cmd/tui/integration-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/integration-options.test.ts
@@ -10,6 +10,7 @@ import {
 const integration = (value: Partial<IntegrationInfo> & Pick<IntegrationInfo, "id" | "name">): IntegrationInfo => ({
   methods: [],
   connections: [],
+  settings: { autoSwitch: false },
   ...value,
 })
 

--- a/packages/tui/test/cli/tui/dialog-integration.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-integration.test.tsx
@@ -36,6 +36,49 @@ test("renders account management with an uncategorized add row and marks the act
   }
 })
 
+test("toggles the account switching setting between the add row and the connected accounts", async () => {
+  const fixture = await renderIntegration()
+
+  try {
+    const frame = fixture.app.captureCharFrame()
+    const row = (source: string) =>
+      source.split("\n").find((line) => line.includes("Switch accounts when rate limited"))
+
+    expect(frame.indexOf("Add account")).toBeLessThan(frame.indexOf("Settings"))
+    expect(frame.indexOf("Settings")).toBeLessThan(frame.indexOf("Switch accounts when rate limited"))
+    expect(frame.indexOf("Switch accounts when rate limited")).toBeLessThan(frame.indexOf("Connected accounts"))
+    expect(row(frame)?.trimEnd().endsWith("off")).toBe(true)
+    expect(row(frame)).not.toContain("\u25cf")
+
+    fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitForFrame((current) => row(current)?.trimEnd().endsWith("on") === true)
+
+    expect(fixture.requests).toEqual([
+      { method: "PATCH", path: "/api/integration/openai/settings", body: { autoSwitch: true } },
+    ])
+    expect(fixture.settings).toEqual({ autoSwitch: true })
+    const updated = fixture.app.captureCharFrame()
+    expect(row(updated)).not.toContain("\u25cf")
+    expect(updated.split("\n").find((line) => line.includes("Personal"))).toContain("\u25cf")
+
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitForFrame((current) => row(current)?.trimEnd().endsWith("off") === true)
+
+    expect(fixture.requests.at(-1)).toEqual({
+      method: "PATCH",
+      path: "/api/integration/openai/settings",
+      body: { autoSwitch: false },
+    })
+    expect(fixture.settings).toEqual({ autoSwitch: false })
+
+    await fixture.app.mockInput.typeText("out of quota")
+    await fixture.app.waitForFrame((current) => row(current) !== undefined && !current.includes("Personal"))
+  } finally {
+    fixture.app.renderer.destroy()
+  }
+})
+
 test("opens the key connection prompt from the initially focused add account row", async () => {
   const fixture = await renderIntegration()
 
@@ -53,6 +96,7 @@ test("switches the selected account with enter and keeps the reactive account ma
   const fixture = await renderIntegration()
 
   try {
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressEnter()
@@ -79,6 +123,7 @@ test("does not refetch when selecting the already-active account", async () => {
 
   try {
     fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressEnter()
 
     expect(fixture.requests).toEqual([])
@@ -93,6 +138,7 @@ test("renames the selected account through a prefilled prompt and reopens the ac
   const fixture = await renderIntegration()
 
   try {
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressKey("r", { ctrl: true })
@@ -121,6 +167,7 @@ test("requires delete confirmation and preserves the account manager when anothe
   try {
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressKey("d", { ctrl: true })
 
     expect(fixture.requests).toEqual([])
@@ -145,6 +192,7 @@ test("renames the account label rather than its delete-confirmation message", as
   try {
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressKey("d", { ctrl: true })
     await fixture.app.waitForFrame((frame) => frame.includes("again to confirm"))
 
@@ -164,6 +212,7 @@ test("marks the remaining account active after deleting the active credential", 
 
   try {
     fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressKey("d", { ctrl: true })
     fixture.app.mockInput.pressKey("d", { ctrl: true })
 
@@ -179,7 +228,7 @@ test("marks the remaining account active after deleting the active credential", 
   }
 })
 
-test("hides account rename and delete actions while the add account row is selected", async () => {
+test("hides account rename and delete actions while a non-account row is selected", async () => {
   const fixture = await renderIntegration()
 
   try {
@@ -193,6 +242,10 @@ test("hides account rename and delete actions while the add account row is selec
     expect(fixture.requests).toEqual([])
     expect(fixture.app.renderer.currentFocusedEditor).toBeInstanceOf(InputRenderable)
     expect(fixture.app.captureCharFrame()).toContain("Connected accounts")
+
+    fixture.app.mockInput.pressArrow("down")
+    expect(fixture.app.captureCharFrame()).not.toContain("rename")
+    expect(fixture.app.captureCharFrame()).not.toContain("delete")
 
     fixture.app.mockInput.pressArrow("down")
     await fixture.app.waitForFrame((frame) => frame.includes("rename") && frame.includes("delete"))
@@ -211,6 +264,7 @@ test("uses the active location for integration data and credential requests", as
   try {
     fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressEnter()
 
     await fixture.app.waitFor(() => fixture.requests.length === 1)
@@ -223,13 +277,14 @@ test("uses the active location for integration data and credential requests", as
 
 async function renderIntegration(activeLocation?: LocationRef) {
   const events = createEventStream()
-  const requests: Array<{ method: string; path: string; body?: { label: string } }> = []
+  const requests: Array<{ method: string; path: string; body?: { label: string } | { autoSwitch?: boolean } }> = []
   const locations: LocationRef[] = []
   const reads = { integration: 0, model: 0, provider: 0 }
   let accounts = [
     { type: "credential" as const, id: "cred_personal", label: "Personal" },
     { type: "credential" as const, id: "cred_work", label: "Work" },
   ]
+  let settings = { autoSwitch: false }
 
   const calls = createFetch(async (url, request) => {
     const directory =
@@ -254,6 +309,7 @@ async function renderIntegration(activeLocation?: LocationRef) {
             name: "OpenAI",
             methods: [{ type: "key", label: "API key" }],
             connections: [...accounts, { type: "env", name: "OPENAI_API_KEY" }],
+            settings,
           },
         ],
       })
@@ -267,6 +323,21 @@ async function renderIntegration(activeLocation?: LocationRef) {
     if (url.pathname === "/api/provider") {
       reads.provider++
       return json({ location, data: [] })
+    }
+
+    if (request.method === "PATCH" && /^\/api\/integration\/[^/]+\/settings$/.test(url.pathname)) {
+      locations.push(requestedLocation)
+      const body = (await request.json()) as { autoSwitch?: boolean }
+      settings = { autoSwitch: body.autoSwitch ?? settings.autoSwitch }
+      requests.push({ method: request.method, path: url.pathname, body })
+      events.emit({
+        id: `evt_settings_${requests.length}`,
+        created: Date.now(),
+        type: "integration.updated",
+        data: {},
+        location: requestedLocation,
+      })
+      return new Response(null, { status: 204 })
     }
 
     if (request.method === "POST" && /^\/api\/credential\/[^/]+\/activate$/.test(url.pathname)) {
@@ -364,6 +435,9 @@ async function renderIntegration(activeLocation?: LocationRef) {
     locations,
     get accounts() {
       return accounts
+    },
+    get settings() {
+      return settings
     },
   }
 }

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -1621,14 +1621,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
-                    },
-                    {
-                      "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
                 }
               }
             }
@@ -5525,6 +5518,113 @@
                   }
                 },
                 "required": ["url"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/integration/{integrationID}/settings": {
+      "patch": {
+        "tags": ["integration"],
+        "operationId": "v2.integration.settings.update",
+        "parameters": [
+          {
+            "name": "integrationID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": false,
+            "style": "deepObject",
+            "explode": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Change stored settings for one integration, such as automatic account switching.",
+        "summary": "Update integration settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "autoSwitch": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
                 "additionalProperties": false
               }
             }
@@ -15857,9 +15957,12 @@
             "items": {
               "$ref": "#/components/schemas/Connection.Info"
             }
+          },
+          "settings": {
+            "$ref": "#/components/schemas/Integration.Settings"
           }
         },
-        "required": ["id", "name", "methods", "connections"],
+        "required": ["id", "name", "methods", "connections", "settings"],
         "additionalProperties": false
       },
       "Integration.KeyMethod": {
@@ -15913,6 +16016,16 @@
           }
         },
         "required": ["id", "type", "label"],
+        "additionalProperties": false
+      },
+      "Integration.Settings": {
+        "type": "object",
+        "properties": {
+          "autoSwitch": {
+            "type": "boolean"
+          }
+        },
+        "required": ["autoSwitch"],
         "additionalProperties": false
       },
       "InvalidCursorErrorEncoded": {

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -1621,14 +1621,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
-                    },
-                    {
-                      "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/SessionNotFoundErrorEncoded"
                 }
               }
             }
@@ -5525,6 +5518,113 @@
                   }
                 },
                 "required": ["url"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/integration/{integrationID}/settings": {
+      "patch": {
+        "tags": ["integration"],
+        "operationId": "v2.integration.settings.update",
+        "parameters": [
+          {
+            "name": "integrationID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": false,
+            "style": "deepObject",
+            "explode": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Change stored settings for one integration, such as automatic account switching.",
+        "summary": "Update integration settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "autoSwitch": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
                 "additionalProperties": false
               }
             }
@@ -15857,9 +15957,12 @@
             "items": {
               "$ref": "#/components/schemas/Connection.Info"
             }
+          },
+          "settings": {
+            "$ref": "#/components/schemas/Integration.Settings"
           }
         },
-        "required": ["id", "name", "methods", "connections"],
+        "required": ["id", "name", "methods", "connections", "settings"],
         "additionalProperties": false
       },
       "Integration.KeyMethod": {
@@ -15913,6 +16016,16 @@
           }
         },
         "required": ["id", "type", "label"],
+        "additionalProperties": false
+      },
+      "Integration.Settings": {
+        "type": "object",
+        "properties": {
+          "autoSwitch": {
+            "type": "boolean"
+          }
+        },
+        "required": ["autoSwitch"],
         "additionalProperties": false
       },
       "InvalidCursorErrorEncoded": {

--- a/packages/www/src/docs/content/providers.mdx
+++ b/packages/www/src/docs/content/providers.mdx
@@ -108,6 +108,19 @@ Your identity needs the **Cognitive Services OpenAI User** role for Azure OpenAI
 role for other Foundry models. If a request fails because the token belongs to another tenant, sign in again with
 `az login --tenant TENANT_ID`.
 
+## Multiple accounts
+
+A provider can hold several stored accounts, for example two ChatGPT subscriptions connected through the OpenAI
+provider. Run `/connect`, select the provider, and choose **Add account** to connect another one. The account manager
+lists every stored account under **Connected accounts**; select one to make it active for the whole server, or use the
+rename and delete actions on it.
+
+Under **Settings**, turn on **Switch accounts when rate limited** to move to the next connected account automatically.
+When the active account is rate limited, OpenCode retries it a couple of times first, unless the provider reports that
+its usage quota is exhausted or asks for a long wait. It then activates the next account and continues the same step.
+Once every connected account is exhausted the request fails with the provider's rate limit error. The setting is off by
+default and is stored per provider.
+
 ## Endpoint
 
 Override `settings.baseURL` to send an existing provider through a proxy or compatible endpoint. Its existing package,


### PR DESCRIPTION
### Issue for this PR

Related to #5391 (multiple auth profiles per provider — the failover part of that request). Also touches on #45484 indirectly: the setting is server-side, so any client that later gets an account switcher can expose it.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 already lets you connect several accounts to one provider (e.g. two ChatGPT subscriptions on OpenAI) and pick the active one in `/connect`. When that account hits its limit you currently have to notice and switch by hand. This adds an opt-in, per-provider **Switch accounts when rate limited** setting under a new `Settings` category in the account manager.

When it is on and the active account fails with a rate limit:

- the runner retries that account twice as it does today, unless the provider reports the quota is exhausted (`QuotaExceeded`) or asks for a wait longer than 30 s — in those cases retrying the same account is pointless, so it switches straight away;
- it then activates the next connected account through the normal `Integration.connection.activate` (so every client sees the switch via `credential.switched`) and retries the same logical step after 1 s with a fresh retry budget. This works because `runStep` already re-loads the context after `Outcome.Retry`, and `ModelResolver` resolves the active credential on every resolve;
- accounts it has already switched away from during that step are remembered, so once every one is exhausted it falls back to the existing policy and fails with the provider's error. The total is bounded by `accounts × (2 + existing schedule)`.

Setting is off by default, stored in the KV table under `integration:settings:<id>`, exposed as `Integration.Info.settings.autoSwitch`, and changed through `PATCH /api/integration/:id/settings` (also in the plugin API as `ctx.integration.settings.update`).

Two supporting fixes that the feature needs, split into their own commits:

- `usage_limit_reached` (the Codex response when a ChatGPT plan's 5-hour/weekly window is used up) is classified as `QuotaExceeded` instead of `RateLimit`. It resets in hours, so backing off for a few seconds was never useful.
- The OpenAI plugin now sets `chatgpt-account-id` in the `model.request` hook from the credential that is active at request time. Previously it came from a catalog header rebuilt asynchronously on `credential.switched`, so the first request after a switch could carry the new token with the old account id. Request headers override provider headers on both the HTTP and WebSocket transport, and there is a test that switches and checks the very next request.

Compaction keeps the old retry policy on purpose: it retries an already-prepared request, so switching there would not change the auth the request was built with.

`chore: generate` also folds in one small pre-existing drift in `openapi.json` (a duplicated `anyOf` entry) — `bun run check:generated` was already failing on `v2` before this branch.

### How did you verify your code works?

- New core tests in `session-runner.test.ts` (TestClock, no real waits): switch on quota, switch on a 1 h retry-after, retry twice then switch on a plain 429, fail once every account is exhausted, and unchanged behaviour with the setting off.
- `integration.test.ts`: settings persistence/default/no-op, `integration.updated` emitted once.
- `provider-openai.test.ts`: account header follows the active credential on the next request after `activate`.
- `provider-error.test.ts`: `usage_limit_reached` → `QuotaExceeded`.
- TUI `dialog-integration.test.tsx`: row order, `off` → Enter → PATCH `{autoSwitch:true}` → `on`, rename/delete stay hidden on the settings row; `client/test/promise.test.ts` covers the wire shape.
- `bun typecheck` clean in every package that has the script; `bun test` in `core`, `tui`, `client`, `server`, `protocol`, `plugin`, `schema`, `ai` — the only failures are the same ones already failing on `v2` (`preload`, `npm-config`, `dialog-shell-output` timing, `contract hygiene`, `Host.resolve`).
- Prettier and `oxlint` show nothing new on touched files; `check:generated` passes in `protocol` and `www`.

### Screenshots / recordings

Account manager captured from the TUI test harness (100×30):

```
                        OpenAI                                           esc

                        Search

                        Add account

                        Settings
                        Switch accounts when rate limited                off

                        Connected accounts
                      ● Personal
                        Work
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
