### PR TITLE
fix(session): clear time.archived so archived sessions can be restored

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -70,7 +70,8 @@ function sessionRow(info: SessionV1.SessionInfo): typeof SessionTable.$inferInse
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,
-    time_archived: info.time.archived,
+    // null, not undefined: Drizzle omits undefined keys from .set(), leaving a stale value.
+    time_archived: info.time.archived ?? null,
   }
 }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -197,7 +197,8 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
           permission: Permission.merge(current.permission ?? [], ctx.payload.permission),
         })
       }
-      if (ctx.payload.time?.archived !== undefined) {
+      // An absent `archived` inside `time` is the clear signal; body arrives as {"time":{}}.
+      if (ctx.payload.time !== undefined) {
         yield* session.setArchived({ sessionID: ctx.params.sessionID, time: ctx.payload.time.archived })
       }
       return yield* requireSession(ctx.params.sessionID)

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -154,7 +154,8 @@ export function toRow(info: Info) {
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,
-    time_archived: info.time.archived,
+    // null, not undefined — same .set() hazard as the projector's sessionRow.
+    time_archived: info.time.archived ?? null,
   }
 }
 

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -845,6 +845,64 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "clears the archived timestamp when time is sent without it",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory, "content-type": "application/json" }
+        const session = yield* createSession({ title: "unarchive" })
+        const path = pathFor(SessionPaths.update, { sessionID: session.id })
+
+        const archived = yield* requestJson<Session.Info>(path, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ time: { archived: 1 } }),
+        })
+        expect(archived.time.archived).toBe(1)
+
+        const cleared = yield* requestJson<Session.Info>(path, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ time: {} }),
+        })
+        expect(cleared.time.archived).toBeUndefined()
+
+        // Re-read so a stale value written to the row would surface here.
+        const reread = yield* requestJson<Session.Info>(pathFor(SessionPaths.get, { sessionID: session.id }), {
+          headers,
+        })
+        expect(reread.time.archived).toBeUndefined()
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "leaves the archived timestamp untouched when time is absent",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory, "content-type": "application/json" }
+        const session = yield* createSession({ title: "archived" })
+        const path = pathFor(SessionPaths.update, { sessionID: session.id })
+
+        yield* requestJson<Session.Info>(path, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ time: { archived: 1 } }),
+        })
+
+        const renamed = yield* requestJson<Session.Info>(path, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ title: "renamed" }),
+        })
+        expect(renamed.title).toBe("renamed")
+        expect(renamed.time.archived).toBe(1)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "uses project-scoped path and directory precedence",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #47849

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clearing `time.archived` returned HTTP 200 and did nothing, so a session could be archived but never restored. Two independent defects sit on that path, and either one alone is enough to make it unreachable — which is why adding an "Unarchive" button doesn't fix it.

**1. `packages/core/src/session/projector.ts`** passed `info.time.archived` straight through, so clearing sent `undefined`. Drizzle omits undefined keys from `.set()`, which means "leave this column alone", not "set NULL" — the row kept its previous value. Coalescing to `null` emits an explicit SQL NULL.

**2. The session update handler** guarded on `ctx.payload.time?.archived !== undefined`. A client clearing the field sends `{"time":{}}`, because `JSON.stringify` drops undefined-valued properties, so the guard short-circuited and `setArchived` was never called. Gating on `time !== undefined` treats presence of the object as the intent signal and an absent `archived` as the clear.

`toRow` in `session.ts` carried the same shape. Not a live bug — it only reaches `.values()` on the import path, where an insert applies the column default — but it sits beside an `onConflictDoUpdate` that reuses the row, so it is coalesced for consistency.

Note `ArchivedTimestamp` is `Schema.Finite` and accepts `0` and negative values for legacy compatibility, so presence must be tested rather than truthiness.

Scope is backend only. TUI archive/unarchive follows in a separate PR so this one carries no UX decision, and the web UI is #43919.

### How did you verify your code works?

Two integration tests in `httpapi-session.test.ts`: archive, clear via `{"time":{}}`, then **re-read** to prove the cleared value persisted rather than being masked by the response object; and a title-only PATCH leaving an existing archived timestamp alone.

Manually against a local `opencode serve`:

```bash
curl -X PATCH localhost:4096/session/$SID -H 'content-type: application/json' \
  -H "x-opencode-directory: $PWD" -d '{"time":{"archived":1700000000000}}'   # archived

curl -X PATCH localhost:4096/session/$SID -H 'content-type: application/json' \
  -H "x-opencode-directory: $PWD" -d '{"time":{}}'                          # cleared

curl localhost:4096/session/$SID -H "x-opencode-directory: $PWD"            # still cleared
```

Also confirmed a session stored with `archived: 0` reads back as archived rather than active.

Fork PRs can't run the gated jobs without maintainer approval, so I ran their commands locally:

- `bun turbo typecheck --force` — 30/30, 0 cached
- `packages/opencode` `bun run test:httpapi` — 208 pass
- `httpapi-session.test.ts` — 23 pass
- `packages/core` — 1097 pass
- `test/cli/import.test.ts` — 6 pass

### Screenshots / recordings

Not a UI change — this PR is backend only.

<img width="242*3" height="450" alt="pr47848-session-unarchive-fix" src="https://github.com/user-attachments/assets/86c22b9a-5d7e-4f9e-a9b4-d403f0cc109d" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
