### PR TITLE
fix(cli): install only opencode for stable AUR releases

### DIFF
--- a/packages/cli/script/publish-aur.ts
+++ b/packages/cli/script/publish-aur.ts
@@ -10,6 +10,7 @@ if (Script.channel !== "beta" && Script.channel !== "latest") {
 }
 const beta = Script.channel === "beta"
 const name = beta ? "opencode-beta" : "opencode-bin"
+const command = beta ? "opencode2" : "opencode"
 if (!(beta ? /^\d+\.\d+\.\d+-beta[.-]\d+(?:\.\d+)?$/ : /^\d+\.\d+\.\d+$/).test(Script.version)) {
   throw new Error(`Expected a ${Script.channel} release version`)
 }
@@ -65,8 +66,8 @@ await Bun.write(
     "arch=('x86_64' 'aarch64')",
     "license=('MIT')",
     "depends=('glibc' 'gcc-libs' 'ripgrep')",
-    beta ? "provides=('opencode2')" : "provides=('opencode' 'opencode2')",
-    beta ? "conflicts=('opencode2')" : "conflicts=('opencode' 'opencode2')",
+    `provides=('${command}')`,
+    `conflicts=('${command}')`,
     // Stripping a compiled Bun executable can damage its embedded application.
     "options=('!strip' '!debug')",
     "source=('LICENSE')",
@@ -74,8 +75,7 @@ await Bun.write(
     ...sources,
     "",
     "package() {",
-    '  install -Dm755 "$srcdir/package/bin/opencode2" "$pkgdir/usr/bin/opencode2"',
-    ...(beta ? [] : ['  ln -s opencode2 "$pkgdir/usr/bin/opencode"']),
+    `  install -Dm755 "$srcdir/package/bin/opencode2" "$pkgdir/usr/bin/${command}"`,
     '  install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"',
     "}",
     "",


### PR DESCRIPTION
### Issue for this PR

Maintainer request to drop the opencode2 command from stable AUR packages.

### Type of change

- [x] Bug fix

### What does this PR do?

Install and provide only `opencode` for latest-channel `opencode-bin`. Beta continues to install and provide `opencode2`.

### How did you verify your code works?

Generated and built a stable package using temporary release fixtures. Verified `/usr/bin` contains only `opencode` and `.SRCINFO` does not provide `opencode2`. All 34 pre-push typechecks passed.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR