### PR TITLE
fix(provider): patch empty Gemini replay messages for Vertex AI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1059,6 +1059,7 @@
     "tree-sitter-bash",
   ],
   "patchedDependencies": {
+    "@ai-sdk/google@3.0.108": "patches/@ai-sdk%2Fgoogle@3.0.108.patch",
     "@pierre/trees@1.0.0-beta.4": "patches/@pierre%2Ftrees@1.0.0-beta.4.patch",
     "@tanstack/virtual-core@3.17.3": "patches/@tanstack%2Fvirtual-core@3.17.3.patch",
     "@ai-sdk/xai@3.0.102": "patches/@ai-sdk%2Fxai@3.0.102.patch",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "@ai-sdk/groq@3.0.31": "patches/@ai-sdk%2Fgroq@3.0.31.patch",
     "@ai-sdk/anthropic@3.0.111": "patches/@ai-sdk%2Fanthropic@3.0.111.patch",
     "@ai-sdk/amazon-bedrock@4.0.166": "patches/@ai-sdk%2Famazon-bedrock@4.0.166.patch",
-    "@ai-sdk/openai@3.0.88": "patches/@ai-sdk%2Fopenai@3.0.88.patch"
+    "@ai-sdk/openai@3.0.88": "patches/@ai-sdk%2Fopenai@3.0.88.patch",
+    "@ai-sdk/google@3.0.108": "patches/@ai-sdk%2Fgoogle@3.0.108.patch"
   }
 }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -368,6 +368,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               })
             continue
           }
+          if (part.text.length === 0) continue
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -2246,4 +2246,84 @@ describe("session.llm.stream", () => {
       }),
     },
   )
+
+  const geminiVertexFixture = { providerID: "google-vertex", modelID: "gemini-2.5-flash" }
+  it.instance(
+    "sends Google Vertex API payload for Gemini models omitting empty reasoning parts",
+    () =>
+      Effect.gen(function* () {
+        const model = loadFixture(geminiVertexFixture.providerID, geminiVertexFixture.modelID).model
+        const pathSuffix = `/v1beta1/projects/test-project/locations/us-central1/publishers/google/models/${model.id}:streamGenerateContent`
+
+        const chunks = [
+          {
+            candidates: [{ content: { parts: [{ text: "Hello" }] }, finishReason: "STOP" }],
+            usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+          },
+        ]
+        const request = waitRequest(pathSuffix, createEventResponse(chunks))
+
+        const resolved = yield* Provider.use.getModel(
+          ProviderV2.ID.make(geminiVertexFixture.providerID),
+          ModelV2.ID.make(model.id),
+        )
+        const sessionID = SessionID.make("session-test-vertex-1")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.3,
+          topP: 0.8,
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-vertex-1"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderV2.ID.make(geminiVertexFixture.providerID), modelID: resolved.id },
+        } satisfies SessionV1.User
+
+        yield* drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: [{ type: "reasoning", text: "" }] },
+          ],
+          tools: {},
+        })
+
+        const capture = yield* Effect.promise(() => request)
+        const body = capture.body
+        const config = body.generationConfig as
+          | { temperature?: number; topP?: number; maxOutputTokens?: number }
+          | undefined
+
+        expect(capture.url.pathname).toBe(pathSuffix)
+        expect(body.contents).toEqual([{ role: "user", parts: [{ text: "Hello" }] }])
+        expect(config?.temperature).toBe(0.3)
+        expect(config?.topP).toBe(0.8)
+        expect(config?.maxOutputTokens).toBe(ProviderTransform.maxOutputTokens(resolved))
+      }),
+    {
+      config: () => ({
+        enabled_providers: [geminiVertexFixture.providerID],
+        provider: {
+          [geminiVertexFixture.providerID]: {
+            options: {
+              project: "test-project",
+              location: "us-central1",
+              baseURL: `${state.server!.url.origin}/v1beta1/projects/test-project/locations/us-central1/publishers/google`,
+            },
+          },
+        },
+      }),
+    },
+  )
 })

--- a/patches/@ai-sdk%2Fgoogle@3.0.108.patch
+++ b/patches/@ai-sdk%2Fgoogle@3.0.108.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/index.js b/dist/index.js
+index 42600e796d652c7875d7641b0c1fd204ba74699b..b4ab296fde1ef969fad9b8ae0ab0023eda84dfe9 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -685,6 +685,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 583d152b57bee68a7301247223227db5a2f79ba8..5f9d1229800867de16eebc2c6930b527116d504c 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -691,6 +691,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/dist/internal/index.js b/dist/internal/index.js
+index 88511c9da09d42a35ba59616ef763b1cc73bd5c0..11dedb04bc6b3885b7b90494e956e0f05bdedf1f 100644
+--- a/dist/internal/index.js
++++ b/dist/internal/index.js
+@@ -468,6 +468,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
+index 0d2953ff873b4de75f8ef0c95e024edbe3e1516a..9208705ffb9bb897461168954a5afb07fab3214a 100644
+--- a/dist/internal/index.mjs
++++ b/dist/internal/index.mjs
+@@ -450,6 +450,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/src/convert-to-google-generative-ai-messages.ts b/src/convert-to-google-generative-ai-messages.ts
+index 50fc3ee09cc5e6ccd2cd2a72e5d22f398409f579..1d23d82991029baa85fb04e37ce1662a08ab7c0c 100644
+--- a/src/convert-to-google-generative-ai-messages.ts
++++ b/src/convert-to-google-generative-ai-messages.ts
+@@ -459,6 +459,11 @@ export function convertToGoogleGenerativeAIMessages(
+             })
+             .filter(part => part !== undefined),
+         });
++        // Empty text and reasoning parts, including signature-bearing ones, are
++        // filtered above. Do not emit a model entry that Gemini rejects.
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+ 
+         break;
+       }


### PR DESCRIPTION
### Issue for this PR

Closes #47863

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #30463 patched `@ai-sdk/google@3.0.73` to pop empty model turns (`if (contents[contents.length - 1].parts.length === 0) contents.pop()`). However, `@ai-sdk/google-vertex` depends on `@ai-sdk/google@3.0.108` in `bun.lock`, which was not covered by the 3.0.73 patch rule. As a result, Gemini on Vertex AI (`google-vertex`) still emitted `{ role: "model", parts: [] }` when an assistant turn contained only empty reasoning parts (`text: ""`), resulting in HTTP 400 (`Unable to submit request because it must include at least one parts field`).

This PR:
1. Adds `patches/@ai-sdk%2Fgoogle@3.0.108.patch` to apply the same `contents.pop()` guard to `@ai-sdk/google@3.0.108` used by `@ai-sdk/google-vertex`.
2. Adds a guard in `MessageV2.toModelMessagesEffect` (`packages/opencode/src/session/message-v2.ts`) to skip zero-length reasoning parts when replaying history.
3. Adds a unit test in `packages/opencode/test/session/llm.test.ts` covering `google-vertex` payload construction with empty reasoning parts.

### How did you verify your code works?

- Ran `bun test test/session/llm.test.ts -t "sends Google"`: both `google` and `google-vertex` tests pass.
- Verified typecheck with `bun turbo typecheck` (all 30 package tasks passed).

### Screenshots / recordings

_N/A (backend/protocol fix)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR