### PR TITLE
fix(core): clarify shell background parameter guidance

### DIFF
--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -54,7 +54,7 @@ export const Input = Schema.Struct({
   }),
   background: Schema.optionalKey(Schema.Boolean).annotate({
     description:
-      "Run the command in the background and return immediately. You will be notified when it completes. DO NOT poll its progress.",
+      "Run the command in the background and return immediately (useful for dev servers and long-running builds). You do not need to use '&' at the end of the command when using this parameter. You will be notified when it completes. DO NOT poll for completion.",
   }),
 })
 


### PR DESCRIPTION
## Summary
- Give dev servers and long-running builds as examples for background execution.
- Clarify that a trailing `&` is unnecessary.
- Target completion polling rather than all progress inspection.

## Testing
- Not run; tool-description-only change.