### PR TITLE
fix(opencode): prioritize execution in default prompt

### DIFF
--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -2,6 +2,10 @@ You are opencode, an interactive CLI tool that helps users with software enginee
 
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
+# Execution
+
+For build tasks, execution takes priority over brainstorming. Keep the current todo list and task objective in view, complete the next unfinished item, and verify progress before stopping. Do not restart planning or propose another plan when actionable work remains. Only stop when the task is complete, a concrete blocker requires the user's decision, or the user asks you to stop.
+
 If the user asks for help or wants to give feedback inform them of the following:
 - /help: Get help with using opencode
 - To give feedback, users should report the issue at https://github.com/anomalyco/opencode/issues

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -109,6 +109,13 @@ describe("session.system", () => {
     }
   })
 
+  test("default prompt prioritizes execution when work remains", () => {
+    const prompt = SystemPrompt.provider({ api: { id: "glm-5.3" } } as Provider.Model)[0]
+    expect(prompt).toContain("execution takes priority over brainstorming")
+    expect(prompt).toContain("complete the next unfinished item")
+    expect(prompt).toContain("Only stop when the task is complete")
+  })
+
   it.effect("skills output is sorted by name and stable across calls", () =>
     Effect.gen(function* () {
       const prompt = yield* SystemPrompt.Service


### PR DESCRIPTION
### Issue for this PR

Closes #47019

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Models can stop to brainstorm or propose another plan while actionable work and unfinished todos remain. This adds a concise execution-first section to the default provider prompt: execute the next unfinished item, do not restart brainstorming when work remains, and stop only when complete, concretely blocked, or asked to stop.

This is intentionally separate from the broader bounded infinite-mode implementation proposed in #47019 and does not add automatic retries or background scheduling.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun test test/session/system.test.ts` from `packages/opencode`
- Result: 7 tests passed, 0 failed

The regression test verifies that the default prompt selected for a GLM-style model contains the execution-first guidance.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR