### PR TITLE
fix(provider): map LongCat binary thinking variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1758,7 +1758,10 @@ function reasoningToggle(model: Provider.Model): NonNullable<Provider.Model["var
       none: { enableThinking: false },
       high: { enableThinking: true },
     }
-  if (model.api.npm === "@ai-sdk/cohere")
+  if (
+    model.api.npm === "@ai-sdk/cohere" ||
+    (model.providerID === "longcat" && model.api.npm === "@ai-sdk/openai-compatible")
+  )
     return {
       none: { thinking: { type: "disabled" } },
       high: { thinking: { type: "enabled" } },

--- a/packages/opencode/test/provider/longcat.test.ts
+++ b/packages/opencode/test/provider/longcat.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import type { ModelsDev } from "@opencode-ai/core/models-dev"
+import { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
+
+const catalog: ModelsDev.Provider = {
+  id: "longcat",
+  name: "LongCat",
+  env: ["LONGCAT_API_KEY"],
+  npm: "@ai-sdk/openai-compatible",
+  api: "https://api.longcat.chat/openai",
+  models: {
+    "LongCat-2.0": {
+      id: "LongCat-2.0",
+      name: "LongCat-2.0",
+      family: "longcat",
+      release_date: "2026-06-30",
+      attachment: false,
+      reasoning: true,
+      temperature: true,
+      tool_call: true,
+      reasoning_options: [{ type: "toggle" }],
+      interleaved: { field: "reasoning_content" },
+      limit: { context: 1_000_000, output: 131_072 },
+      modalities: { input: ["text"], output: ["text"] },
+    },
+  },
+}
+
+test.each([
+  ["none", "disabled"],
+  ["high", "enabled"],
+] as const)("LongCat catalog variant %s sends thinking.type=%s", async (variant, type) => {
+  const model = Provider.fromModelsDevProvider(catalog).models["LongCat-2.0"]
+  const requests: { url: string; body: Record<string, unknown> }[] = []
+  const sdk = createOpenAICompatible({
+    name: model.providerID,
+    baseURL: model.api.url,
+    apiKey: "test-key",
+    fetch: Object.assign(
+      async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const request = new Request(input, init)
+        requests.push({ url: request.url, body: await request.json() })
+        return Response.json({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          created: 0,
+          model: model.api.id,
+          choices: [{ index: 0, message: { role: "assistant", content: "Hello" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })
+      },
+      { preconnect: () => undefined },
+    ),
+  })
+
+  await sdk.chatModel(model.api.id).doGenerate({
+    prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+    providerOptions: ProviderTransform.providerOptions(model, model.variants?.[variant] ?? {}),
+  })
+
+  expect(requests).toHaveLength(1)
+  expect(requests[0].url).toBe("https://api.longcat.chat/openai/chat/completions")
+  expect(requests[0].body.thinking).toEqual({ type })
+  expect(requests[0].body).not.toHaveProperty("reasoning_effort")
+  expect(Object.keys(model.variants ?? {})).toEqual(["none", "high"])
+})
+
+test.each([
+  { id: "other", npm: "@ai-sdk/openai-compatible" },
+  { id: "longcat", npm: "@ai-sdk/openai" },
+])("LongCat thinking controls do not affect $id with $npm", ({ id, npm }) => {
+  const model = Provider.fromModelsDevProvider({ ...catalog, id, npm }).models["LongCat-2.0"]
+
+  expect(model.variants?.high).toHaveProperty("reasoningEffort", "high")
+  expect(model.variants?.high).not.toHaveProperty("thinking")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #47871.

### Type of change

- [x] Bug fix

### What does this PR do?

Map the direct LongCat provider's catalog-declared reasoning toggle to `none/high` using `thinking.type: disabled/enabled`. It currently falls through to OpenAI effort variants, which omit LongCat's toggle. Restrict the mapping to `longcat` with `@ai-sdk/openai-compatible`.

### How did you verify your code works?

From `packages/opencode`, `bun test test/provider/provider.test.ts test/provider/transform.test.ts test/provider/longcat.test.ts` passed 667 tests. The four new tests exercise catalog normalization through actual SDK request serialization; the two toggle cases fail before the fix, and two negative cases protect other providers/SDKs. Prettier and whitespace checks passed.

Four live API checks on 2026-09-08 also passed through catalog normalization, ProviderTransform and the AI SDK (HTTP 200): thinking off/on, streamed tool calls, and continuation preserving real reasoning/tool-result history. The existing `/openai/chat/completions` endpoint worked without changes.

`bun typecheck` reports an existing `src/bus/global.ts:14` TS2416 error. Pristine HEAD produces byte-identical output. Tested on macOS with Bun 1.3.14.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] Tested locally
- [x] No unrelated changes

AI assistance: Codex helped implement, review, and test this change.
