### PR TITLE
fix(opencode): support local Ollama reasoning

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -817,6 +817,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       max: { effort: "max" },
     }
   }
+  if (model.providerID === "ollama" && model.api.npm === "@ai-sdk/openai-compatible") {
+    // Local Ollama uses /v1/chat/completions, where native `think` is exposed as `reasoning_effort`.
+    return Object.fromEntries(["none", "high"].map((effort) => [effort, { reasoningEffort: effort }]))
+  }
   // Kimi's Anthropic-compatible transports implement adaptive thinking effort.
   if (isKimiFamily(model) && ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
     return Object.fromEntries(

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -369,7 +369,12 @@ const live: Layer.Layer<
 
             // Adapter seam: both runtimes expose the same LLMEvent stream. Native
             // already returns one; AI SDK streams are converted here.
-            const state = LLMAISDK.adapterState()
+            const state = LLMAISDK.adapterState({
+              parseReasoningTags:
+                input.model.providerID === "ollama" &&
+                input.model.api.npm === "@ai-sdk/openai-compatible" &&
+                input.model.capabilities.reasoning,
+            })
             return Stream.fromAsyncIterable(result.result.fullStream, (e) =>
               e instanceof Error ? e : new Error(String(e)),
             ).pipe(

--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -7,7 +7,7 @@ import { ProviderError } from "@/provider/error"
 type Result = Awaited<ReturnType<typeof streamText>>
 type AISDKEvent = Result["fullStream"] extends AsyncIterable<infer T> ? T : never
 
-export function adapterState() {
+export function adapterState(options: { parseReasoningTags?: boolean } = {}) {
   return {
     step: 0,
     text: 0,
@@ -16,6 +16,11 @@ export function adapterState() {
     currentReasoningID: undefined as string | undefined,
     toolNames: {} as Record<string, string>,
     copilotTotalNanoAiu: undefined as number | undefined,
+    parseReasoningTags: options.parseReasoningTags ?? false,
+    structuredReasoning: false,
+    tagBuffer: "",
+    tagReasoning: false,
+    tagMetadata: undefined as ProviderMetadata | undefined,
   }
 }
 
@@ -74,6 +79,79 @@ function currentReasoningID(state: ReturnType<typeof adapterState>, id: string |
   return state.currentReasoningID
 }
 
+// Some Ollama model templates expose reasoning as tagged text instead of the
+// OpenAI-compatible reasoning field. Buffer partial tags across stream chunks.
+function reasoningTags(
+  state: ReturnType<typeof adapterState>,
+  text: string,
+  metadata: ProviderMetadata | undefined,
+  end = false,
+) {
+  const events: LLMEvent[] = []
+  const write = (value: string) => {
+    if (!value) return
+    if (state.tagReasoning) {
+      const active = state.currentReasoningID
+      const id = currentReasoningID(state, undefined)
+      if (!active) {
+        events.push(LLMEvent.reasoningStart({ id, providerMetadata: state.tagMetadata ?? metadata }))
+        state.tagMetadata = undefined
+      }
+      events.push(LLMEvent.reasoningDelta({ id, text: value, providerMetadata: metadata }))
+      return
+    }
+    const active = state.currentTextID
+    const id = currentTextID(state, undefined)
+    if (!active) {
+      events.push(LLMEvent.textStart({ id, providerMetadata: state.tagMetadata ?? metadata }))
+      state.tagMetadata = undefined
+    }
+    events.push(LLMEvent.textDelta({ id, text: value, providerMetadata: metadata }))
+  }
+  const close = () => {
+    if (state.tagReasoning && state.currentReasoningID) {
+      events.push(LLMEvent.reasoningEnd({ id: state.currentReasoningID, providerMetadata: metadata }))
+      state.currentReasoningID = undefined
+      return
+    }
+    if (!state.tagReasoning && state.currentTextID) {
+      events.push(LLMEvent.textEnd({ id: state.currentTextID, providerMetadata: metadata }))
+      state.currentTextID = undefined
+    }
+  }
+
+  let content = state.tagBuffer + text
+  state.tagBuffer = ""
+  while (content) {
+    const tag = state.tagReasoning ? "</think>" : "<think>"
+    const index = content.indexOf(tag)
+    if (index !== -1) {
+      write(content.slice(0, index))
+      close()
+      state.tagReasoning = !state.tagReasoning
+      content = content.slice(index + tag.length)
+      continue
+    }
+
+    const pending = end
+      ? 0
+      : (Array.from(
+          { length: Math.min(tag.length - 1, content.length) },
+          (_, index) => Math.min(tag.length - 1, content.length) - index,
+        ).find((length) => tag.startsWith(content.slice(-length))) ?? 0)
+    write(content.slice(0, content.length - pending))
+    state.tagBuffer = content.slice(content.length - pending)
+    content = ""
+  }
+
+  if (end) {
+    close()
+    state.tagReasoning = false
+    state.tagMetadata = undefined
+  }
+  return events
+}
+
 export function toLLMEvents(
   state: ReturnType<typeof adapterState>,
   event: AISDKEvent,
@@ -114,6 +192,7 @@ export function toLLMEvents(
     case "finish":
       return Effect.sync(() => {
         const events = [
+          ...(state.parseReasoningTags && !state.structuredReasoning ? reasoningTags(state, "", undefined, true) : []),
           LLMEvent.finish({
             reason: finishReason(event.finishReason),
             usage: usage(event.totalUsage),
@@ -122,11 +201,16 @@ export function toLLMEvents(
         ]
         // Reset so the adapter can be reused for a follow-up stream without leaking
         // counters or block IDs. adapterState() is the single source of truth for shape.
-        Object.assign(state, adapterState())
+        Object.assign(state, adapterState({ parseReasoningTags: state.parseReasoningTags }))
         return events
       })
 
     case "text-start":
+      if (state.parseReasoningTags && !state.structuredReasoning)
+        return Effect.sync(() => {
+          state.tagMetadata = providerMetadata(event.providerMetadata)
+          return []
+        })
       return Effect.sync(() => {
         state.currentTextID = currentTextID(state, event.id)
         return [
@@ -138,6 +222,8 @@ export function toLLMEvents(
       })
 
     case "text-delta":
+      if (state.parseReasoningTags && !state.structuredReasoning)
+        return Effect.sync(() => reasoningTags(state, event.text, providerMetadata(event.providerMetadata)))
       return Effect.succeed([
         LLMEvent.textDelta({
           id: currentTextID(state, event.id),
@@ -147,6 +233,8 @@ export function toLLMEvents(
       ])
 
     case "text-end":
+      if (state.parseReasoningTags && !state.structuredReasoning)
+        return Effect.sync(() => reasoningTags(state, "", providerMetadata(event.providerMetadata), true))
       return Effect.sync(() => {
         const id = currentTextID(state, event.id)
         state.currentTextID = undefined
@@ -160,6 +248,7 @@ export function toLLMEvents(
 
     case "reasoning-start":
       return Effect.sync(() => {
+        state.structuredReasoning = true
         state.currentReasoningID = currentReasoningID(state, event.id)
         return [
           LLMEvent.reasoningStart({

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4231,6 +4231,27 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
+  test("ollama exposes reasoning toggles for openai-compatible models", () => {
+    const model = createMockModel({
+      id: "ollama/qwen3.8:27b",
+      providerID: "ollama",
+      api: {
+        id: "qwen3.8:27b",
+        url: "http://localhost:11434/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const variants = ProviderTransform.variants(model)
+    expect(variants).toEqual({
+      none: { reasoningEffort: "none" },
+      high: { reasoningEffort: "high" },
+    })
+    if (!variants.high) throw new Error("missing high variant")
+    expect(ProviderTransform.providerOptions(model, variants.high)).toEqual({
+      ollama: { reasoningEffort: "high" },
+    })
+  })
+
   test("minimax returns empty object", () => {
     const model = createMockModel({
       id: "minimax/minimax-model",

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -185,6 +185,31 @@ describe("session.llm.ai-sdk adapter", () => {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- tests defensive adapter branches outside AI SDK's current typed surface
   const uncheckedAdapterEvent = (input: unknown) => input as AISDKAdapterEvent
 
+  test("parses Ollama reasoning tags split across stream chunks", async () => {
+    const state = LLMAISDK.adapterState({ parseReasoningTags: true })
+    const events = await Effect.runPromise(
+      Effect.forEach(
+        [
+          { type: "text-start", id: "text-1" },
+          { type: "text-delta", id: "text-1", text: "<thi" },
+          { type: "text-delta", id: "text-1", text: "nk>plan</thi" },
+          { type: "text-delta", id: "text-1", text: "nk>answer" },
+          { type: "text-end", id: "text-1" },
+        ].map(uncheckedAdapterEvent),
+        (event) => LLMAISDK.toLLMEvents(state, event),
+      ).pipe(Effect.map((items) => items.flat())),
+    )
+
+    expect(events).toMatchObject([
+      { type: "reasoning-start", id: "reasoning-0" },
+      { type: "reasoning-delta", id: "reasoning-0", text: "plan" },
+      { type: "reasoning-end", id: "reasoning-0" },
+      { type: "text-start", id: "text-0" },
+      { type: "text-delta", id: "text-0", text: "answer" },
+      { type: "text-end", id: "text-0" },
+    ])
+  })
+
   test("maps AI SDK stream chunks without losing session-visible fields", async () => {
     const metadata = { openai: { itemID: "item-1" } }
     const events = await adapt([

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1708,8 +1708,9 @@ Ollama can automatically configure itself for OpenCode. See the [Ollama integrat
         "baseURL": "http://localhost:11434/v1"
       },
       "models": {
-        "llama2": {
-          "name": "Llama 2"
+        "qwen3.5": {
+          "name": "Qwen 3.5",
+          "reasoning": true
         }
       }
     }
@@ -1719,11 +1720,12 @@ Ollama can automatically configure itself for OpenCode. See the [Ollama integrat
 
 In this example:
 
-- `ollama` is the custom provider ID. This can be any string you want.
+- `ollama` is the custom provider ID. Keep this ID to use the built-in Ollama reasoning variants.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.
 - `models` is a map of model IDs to their configurations. The model name will be displayed in the model selection list.
+- Set `reasoning` to `true` for thinking models. Use `ctrl+t` to switch between the `none` and `high` reasoning variants; `/thinking` only changes whether reasoning blocks are displayed.
 
 :::tip
 If tool calls aren't working, try increasing `num_ctx` in Ollama. Start around 16k - 32k.


### PR DESCRIPTION
### Issue for this PR

  Closes #47359

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [x] Documentation

  ### What does this PR do?

  Ollama thinking models using the OpenAI-compatible
  endpoint could not select a reasoning effort, and
  tagged reasoning could appear as raw `<think>` text.

  This adds `none` and `high` reasoning variants,
  converts streamed `<think>` blocks into standard
  reasoning events, and documents using `Ctrl+T` to
  select reasoning effort. `/thinking` remains a
  display toggle.

  ### How did you verify your code works?

  From `packages/opencode`:

  - `bun test` — 3574 passed, 22 skipped, 1 todo, 0
  failed
  - `bun typecheck`
  - added tests for Ollama reasoning option mapping
  and `<think>` tags split across stream chunks

  To reproduce, configure an Ollama thinking model
  with `"reasoning": true`, select `high` with
  `Ctrl+T`, and confirm that reasoning appears without
  raw `<think>` tags.

  ### Screenshots / recordings

  Not applicable; this does not change the UI.

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR
