### PR TITLE
feat(core): add Poe browser OAuth

### DIFF
--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -25,6 +25,7 @@ import { OpenAICompatiblePlugin } from "./provider/openai-compatible.js"
 import { OpencodePlugin } from "./provider/opencode.js"
 import { OpenRouterPlugin } from "./provider/openrouter.js"
 import { PerplexityPlugin } from "./provider/perplexity.js"
+import { PoePlugin } from "./provider/poe.js"
 import { SapAICorePlugin } from "./provider/sap-ai-core.js"
 import { VercelPlugin } from "./provider/vercel.js"
 import { VenicePlugin } from "./provider/venice.js"
@@ -60,6 +61,7 @@ export const ProviderPlugins: PluginInternal.InternalPlugin[] = [
   OpenAIPlugin,
   OpenRouterPlugin,
   PerplexityPlugin,
+  PoePlugin,
   SapAICorePlugin,
   VercelPlugin,
   VenicePlugin,

--- a/packages/core/src/plugin/provider/poe.ts
+++ b/packages/core/src/plugin/provider/poe.ts
@@ -1,6 +1,7 @@
 import { define } from "@opencode/plugin/effect/plugin"
-import { Clock, Deferred, Effect, Schema } from "effect"
+import { Clock, Deferred, Effect, Option, Schema } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import type { ServerResponse } from "node:http"
 import { Credential } from "../../credential.js"
 import { Integration } from "../../integration.js"
 import { OauthCallbackPage } from "../../oauth/page.js"
@@ -8,15 +9,22 @@ import { OauthCallbackPage } from "../../oauth/page.js"
 const integrationID = Integration.ID.make("poe")
 const methodID = Integration.MethodID.make("browser")
 const clientID = "client_728290227fc048cc9262091a1ea197ea"
+const issuer = "https://poe.com"
+const maxExpiry = 8_640_000_000_000_000
 const Token = Schema.Struct({
-  api_key: Schema.NonEmptyString,
-  api_key_expires_in: Schema.optional(Schema.NullOr(Schema.Number)),
+  api_key: Schema.Trim.check(Schema.isNonEmpty(), Schema.isPattern(/^\S+$/)),
+  api_key_expires_in: Schema.optional(Schema.NullOr(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)))),
 })
+const decodeError = Schema.decodeUnknownOption(
+  Schema.fromJsonString(
+    Schema.Struct({ error: Schema.optional(Schema.String), error_description: Schema.optional(Schema.String) }),
+  ),
+)
 
 export const PoePlugin = define({
   id: "opencode.provider.poe",
   effect: Effect.fn(function* (ctx) {
-    const http = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
+    const http = yield* HttpClient.HttpClient
     yield* ctx.integration.transform((editor) => {
       editor.method.update({
         integrationID,
@@ -37,7 +45,7 @@ export const PoePlugin = define({
               yield* Effect.promise(() => crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier))),
             ).toString("base64url")
             const state = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64url")
-            const code = yield* Deferred.make<string, Error>()
+            const callback = yield* Deferred.make<{ code: string; response: ServerResponse }, Error>()
             const { createServer } = yield* Effect.promise(() => import("node:http"))
             const { EventEmitter } = yield* Effect.promise(() => import("node:events"))
             const server = createServer((request, response) => {
@@ -46,23 +54,23 @@ export const PoePlugin = define({
                 response.writeHead(404).end()
                 return
               }
-              const value = url.searchParams.get("code")
-              const error =
-                url.searchParams.get("state") !== state
-                  ? "Invalid OAuth state"
-                  : url.searchParams.get("error_description") ||
-                    url.searchParams.get("error") ||
-                    (!value ? "Missing authorization code" : undefined)
-              Effect.runFork(error ? Deferred.fail(code, new Error(error)) : Deferred.succeed(code, value ?? ""))
-              response
-                .writeHead(error ? 400 : 200, { "Content-Type": "text/html" })
-                .end(
-                  error
-                    ? OauthCallbackPage.error(error, { provider: "Poe" })
-                    : OauthCallbackPage.success({ provider: "Poe" }),
-                )
+              const error = callbackError(url.searchParams, state)
+              if (error) {
+                response
+                  .writeHead(400, { "Content-Type": "text/html" })
+                  .end(OauthCallbackPage.error(error, { provider: "Poe" }))
+                Effect.runSync(Deferred.fail(callback, new Error(error)))
+                return
+              }
+              if (!Effect.runSync(Deferred.succeed(callback, { code: url.searchParams.get("code") ?? "", response })))
+                response.writeHead(409).end("OAuth callback already received")
             })
-            yield* Effect.addFinalizer(() => Effect.sync(() => server.close()))
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => {
+                server.close()
+                server.closeAllConnections()
+              }),
+            )
             yield* Effect.tryPromise(() => EventEmitter.once(server.listen(0, "127.0.0.1"), "listening"))
             const address = server.address()
             if (!address || typeof address === "string")
@@ -70,7 +78,7 @@ export const PoePlugin = define({
             const redirect = `http://127.0.0.1:${address.port}/callback`
             return {
               mode: "auto" as const,
-              url: `https://poe.com/oauth/authorize?${new URLSearchParams({
+              url: `${issuer}/oauth/authorize?${new URLSearchParams({
                 response_type: "code",
                 client_id: clientID,
                 redirect_uri: redirect,
@@ -81,30 +89,23 @@ export const PoePlugin = define({
               }).toString()}`,
               instructions: "Complete authorization in your browser. This window will close automatically.",
               callback: Effect.gen(function* () {
-                const value = yield* Deferred.await(code)
-                const token = yield* http
-                  .execute(
-                    HttpClientRequest.post("https://api.poe.com/token").pipe(
-                      HttpClientRequest.bodyUrlParams({
-                        grant_type: "authorization_code",
-                        client_id: clientID,
-                        code: value,
-                        redirect_uri: redirect,
-                        code_verifier: verifier,
-                      }),
-                    ),
+                const request = yield* Deferred.await(callback)
+                const respond = (error?: string) =>
+                  Effect.sync(() =>
+                    request.response
+                      .writeHead(error ? 400 : 200, { "Content-Type": "text/html" })
+                      .end(
+                        error
+                          ? OauthCallbackPage.error(error, { provider: "Poe" })
+                          : OauthCallbackPage.success({ provider: "Poe" }),
+                      ),
                   )
-                  .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(Token)))
-                return Credential.OAuth.make({
-                  type: "oauth",
-                  methodID,
-                  access: token.api_key,
-                  refresh: "",
-                  expires:
-                    token.api_key_expires_in == null
-                      ? Number.MAX_SAFE_INTEGER
-                      : (yield* Clock.currentTimeMillis) + token.api_key_expires_in * 1000,
-                })
+                return yield* exchangeCode(http, { code: request.code, redirect, verifier }).pipe(
+                  Effect.tap(() => respond()),
+                  Effect.tapError((error) => respond(error.message)),
+                  // Bun's server.closeAllConnections() leaves an unanswered callback response pending.
+                  Effect.onInterrupt(() => Effect.sync(() => request.response.destroy())),
+                )
               }),
             }
           }),
@@ -112,3 +113,51 @@ export const PoePlugin = define({
     })
   }),
 })
+
+function callbackError(params: URLSearchParams, state: string) {
+  if (params.get("state") !== state) return "Invalid OAuth state"
+  // Poe's client pins this issuer but does not require iss; its documented callbacks may omit it.
+  if (params.has("iss") && params.get("iss") !== issuer) return "Invalid OAuth issuer"
+  if (params.has("error")) {
+    const detail = params.get("error_description") || params.get("error") || "Authorization denied"
+    return detail.includes(state) ? "Poe authorization failed" : detail
+  }
+  return params.get("code")?.trim() ? undefined : "Missing authorization code"
+}
+
+function exchangeCode(http: HttpClient.HttpClient, input: { code: string; redirect: string; verifier: string }) {
+  return Effect.gen(function* () {
+    const response = yield* http
+      .execute(
+        HttpClientRequest.post("https://api.poe.com/token").pipe(
+          HttpClientRequest.bodyUrlParams({
+            grant_type: "authorization_code",
+            client_id: clientID,
+            code: input.code,
+            redirect_uri: input.redirect,
+            code_verifier: input.verifier,
+          }),
+        ),
+      )
+      .pipe(Effect.mapError(() => new Error("Poe token exchange request failed")))
+    if (response.status < 200 || response.status >= 300) {
+      const error = Option.getOrUndefined(decodeError(yield* response.text.pipe(Effect.orElseSucceed(() => ""))))
+      const detail = error?.error_description || error?.error
+      return yield* Effect.fail(
+        new Error(
+          detail && ![input.code, input.verifier].some((secret) => detail.includes(secret))
+            ? `Poe token exchange failed: ${detail}`
+            : `Poe token exchange failed (${response.status})`,
+        ),
+      )
+    }
+    const token = yield* HttpClientResponse.schemaBodyJson(Token)(response).pipe(
+      Effect.mapError(() => new Error("Invalid Poe token response")),
+    )
+    const expires =
+      token.api_key_expires_in == null ? maxExpiry : (yield* Clock.currentTimeMillis) + token.api_key_expires_in * 1000
+    if (!Number.isSafeInteger(expires) || expires > maxExpiry)
+      return yield* Effect.fail(new Error("Invalid Poe API key expiry"))
+    return Credential.OAuth.make({ type: "oauth", methodID, access: token.api_key, refresh: "", expires })
+  })
+}

--- a/packages/core/src/plugin/provider/poe.ts
+++ b/packages/core/src/plugin/provider/poe.ts
@@ -1,0 +1,114 @@
+import { define } from "@opencode/plugin/effect/plugin"
+import { Clock, Deferred, Effect, Schema } from "effect"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { Credential } from "../../credential.js"
+import { Integration } from "../../integration.js"
+import { OauthCallbackPage } from "../../oauth/page.js"
+
+const integrationID = Integration.ID.make("poe")
+const methodID = Integration.MethodID.make("browser")
+const clientID = "client_728290227fc048cc9262091a1ea197ea"
+const Token = Schema.Struct({
+  api_key: Schema.NonEmptyString,
+  api_key_expires_in: Schema.optional(Schema.NullOr(Schema.Number)),
+})
+
+export const PoePlugin = define({
+  id: "opencode.provider.poe",
+  effect: Effect.fn(function* (ctx) {
+    const http = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
+    yield* ctx.integration.transform((editor) => {
+      editor.method.update({
+        integrationID,
+        method: { id: methodID, type: "oauth", label: "Login with Poe (browser)" },
+        // Poe-issued API keys remain usable until expiry, then require another login.
+        refresh: (value) =>
+          Clock.currentTimeMillis.pipe(
+            Effect.flatMap((now) =>
+              value.expires > now
+                ? Effect.succeed(value)
+                : Effect.fail(new Error("Poe API key expired. Log in with Poe again.")),
+            ),
+          ),
+        authorize: () =>
+          Effect.gen(function* () {
+            const verifier = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64url")
+            const challenge = Buffer.from(
+              yield* Effect.promise(() => crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier))),
+            ).toString("base64url")
+            const state = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64url")
+            const code = yield* Deferred.make<string, Error>()
+            const { createServer } = yield* Effect.promise(() => import("node:http"))
+            const { EventEmitter } = yield* Effect.promise(() => import("node:events"))
+            const server = createServer((request, response) => {
+              const url = new URL(request.url ?? "/", "http://127.0.0.1")
+              if (request.method !== "GET" || url.pathname !== "/callback") {
+                response.writeHead(404).end()
+                return
+              }
+              const value = url.searchParams.get("code")
+              const error =
+                url.searchParams.get("state") !== state
+                  ? "Invalid OAuth state"
+                  : url.searchParams.get("error_description") ||
+                    url.searchParams.get("error") ||
+                    (!value ? "Missing authorization code" : undefined)
+              Effect.runFork(error ? Deferred.fail(code, new Error(error)) : Deferred.succeed(code, value ?? ""))
+              response
+                .writeHead(error ? 400 : 200, { "Content-Type": "text/html" })
+                .end(
+                  error
+                    ? OauthCallbackPage.error(error, { provider: "Poe" })
+                    : OauthCallbackPage.success({ provider: "Poe" }),
+                )
+            })
+            yield* Effect.addFinalizer(() => Effect.sync(() => server.close()))
+            yield* Effect.tryPromise(() => EventEmitter.once(server.listen(0, "127.0.0.1"), "listening"))
+            const address = server.address()
+            if (!address || typeof address === "string")
+              return yield* Effect.fail(new Error("Missing OAuth callback port"))
+            const redirect = `http://127.0.0.1:${address.port}/callback`
+            return {
+              mode: "auto" as const,
+              url: `https://poe.com/oauth/authorize?${new URLSearchParams({
+                response_type: "code",
+                client_id: clientID,
+                redirect_uri: redirect,
+                scope: "apikey:create",
+                code_challenge: challenge,
+                code_challenge_method: "S256",
+                state,
+              }).toString()}`,
+              instructions: "Complete authorization in your browser. This window will close automatically.",
+              callback: Effect.gen(function* () {
+                const value = yield* Deferred.await(code)
+                const token = yield* http
+                  .execute(
+                    HttpClientRequest.post("https://api.poe.com/token").pipe(
+                      HttpClientRequest.bodyUrlParams({
+                        grant_type: "authorization_code",
+                        client_id: clientID,
+                        code: value,
+                        redirect_uri: redirect,
+                        code_verifier: verifier,
+                      }),
+                    ),
+                  )
+                  .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(Token)))
+                return Credential.OAuth.make({
+                  type: "oauth",
+                  methodID,
+                  access: token.api_key,
+                  refresh: "",
+                  expires:
+                    token.api_key_expires_in == null
+                      ? Number.MAX_SAFE_INTEGER
+                      : (yield* Clock.currentTimeMillis) + token.api_key_expires_in * 1000,
+                })
+              }),
+            }
+          }),
+      })
+    })
+  }),
+})

--- a/packages/core/test/plugin/provider-poe.test.ts
+++ b/packages/core/test/plugin/provider-poe.test.ts
@@ -1,0 +1,215 @@
+import { LLM } from "@opencode/ai"
+import { LLMClient, RequestExecutor } from "@opencode/ai/route"
+import { Catalog } from "@opencode/core/catalog"
+import { Credential } from "@opencode/core/credential"
+import { Integration } from "@opencode/core/integration"
+import { Model } from "@opencode/core/model"
+import { ModelResolver } from "@opencode/core/model-resolver"
+import { Plugin } from "@opencode/core/plugin"
+import { PluginHost } from "@opencode/core/plugin/host"
+import { ProviderPlugins } from "@opencode/core/plugin/provider"
+import { PoePlugin } from "@opencode/core/plugin/provider/poe"
+import { Provider } from "@opencode/core/provider"
+import { expect } from "bun:test"
+import { Clock, Effect, Layer, Schedule, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { testEffect } from "../lib/effect"
+import { PluginTestLayer } from "./fixture"
+
+const it = testEffect(PluginTestLayer)
+const integrationID = Integration.ID.make("poe")
+const providerID = Provider.ID.make("poe")
+const methodID = Integration.MethodID.make("browser")
+const modelID = Model.ID.make("test-model")
+
+const fixture = Effect.gen(function* () {
+  const requests: Request[] = []
+  const replies: Response[] = []
+  const http = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      requests.push(yield* HttpClientRequest.toWeb(request).pipe(Effect.orDie))
+      const response = replies.shift()
+      if (!response) throw new Error(`Unexpected request: ${request.url}`)
+      return HttpClientResponse.fromWeb(request, response)
+    }),
+  )
+  const integrations = yield* Integration.Service
+  const credentials = yield* Credential.Service
+  const catalog = yield* Catalog.Service
+  yield* integrations.transform((editor) => {
+    editor.method.update({ integrationID, method: { type: "key" } })
+    editor.method.update({ integrationID, method: { type: "env", names: ["POE_API_KEY"] } })
+  })
+  yield* catalog.transform((editor) => {
+    editor.provider.update(providerID, (provider) => {
+      provider.package = Provider.aisdk("@ai-sdk/openai-compatible")
+      provider.settings = { baseURL: "https://api.poe.com/v1" }
+    })
+    editor.model.update(providerID, modelID, () => {})
+  })
+  const plugin = yield* Plugin.Service
+  const host = yield* PluginHost.make(plugin)
+  yield* PoePlugin.effect(host).pipe(Effect.provideService(HttpClient.HttpClient, http))
+  const status = (attemptID: Integration.AttemptID) =>
+    integrations.oauth.status({ integrationID, attemptID }).pipe(
+      Effect.repeat({
+        until: (value) => value.status !== "pending",
+        schedule: Schedule.spaced("1 millis"),
+        times: 100,
+      }),
+    )
+  const send = Effect.gen(function* () {
+    const resolver = yield* ModelResolver.Service
+    const resolved = yield* resolver.resolve(Model.Ref.make({ providerID, id: modelID }))
+    if (!resolved) throw new Error("Expected Poe model")
+    expect(resolved.model.route.id).toBe("openai-compatible-chat")
+    return yield* LLMClient.stream(LLM.request({ model: resolved.model, prompt: "Hello" })).pipe(
+      Stream.runCollect,
+      Effect.provide(LLMClient.layer.pipe(Layer.provide(RequestExecutor.layer), Layer.fresh)),
+      Effect.provideService(HttpClient.HttpClient, http),
+    )
+  }).pipe(Effect.provide(ModelResolver.layer))
+  return { requests, replies, integrations, credentials, status, send }
+})
+
+it.effect("registers Poe browser OAuth alongside generic key and environment methods without fetching", () =>
+  Effect.gen(function* () {
+    const test = yield* fixture
+    expect(ProviderPlugins).toContain(PoePlugin)
+    expect((yield* test.integrations.get(integrationID))?.methods).toEqual([
+      { type: "key" },
+      { type: "env", names: ["POE_API_KEY"] },
+      { id: methodID, type: "oauth", label: "Login with Poe (browser)" },
+    ])
+    expect(test.requests).toHaveLength(0)
+  }),
+)
+
+for (const expiry of [3600, null, undefined]) {
+  it.live(`exchanges a PKCE code for a native Poe credential (expiry: ${expiry})`, () =>
+    Effect.gen(function* () {
+      const test = yield* fixture
+      const attempt = yield* test.integrations.oauth.connect({ integrationID, methodID })
+      const url = new URL(attempt.url)
+      expect(url.origin + url.pathname).toBe("https://poe.com/oauth/authorize")
+      expect(Object.fromEntries(url.searchParams)).toMatchObject({
+        response_type: "code",
+        client_id: "client_728290227fc048cc9262091a1ea197ea",
+        scope: "apikey:create",
+        code_challenge_method: "S256",
+      })
+      const callback = new URL(url.searchParams.get("redirect_uri") ?? "")
+      expect(callback.hostname).toBe("127.0.0.1")
+      expect(callback.pathname).toBe("/callback")
+      expect(url.searchParams.get("state")).toBeTruthy()
+      callback.searchParams.set("state", url.searchParams.get("state") ?? "")
+      callback.searchParams.set("code", "auth-code")
+      test.replies.push(Response.json({ api_key: "poe-key", api_key_expires_in: expiry }))
+      const now = Date.now()
+      expect((yield* Effect.promise(() => fetch(callback, { headers: { Connection: "close" } }))).status).toBe(200)
+      expect((yield* test.status(attempt.attemptID)).status).toBe("complete")
+      const exchange = test.requests[0]
+      expect(exchange.url).toBe("https://api.poe.com/token")
+      expect(exchange.headers.get("content-type")).toContain("application/x-www-form-urlencoded")
+      const form = new URLSearchParams(yield* Effect.promise(() => exchange.text()))
+      expect(Object.fromEntries(form)).toMatchObject({
+        grant_type: "authorization_code",
+        client_id: "client_728290227fc048cc9262091a1ea197ea",
+        code: "auth-code",
+        redirect_uri: url.searchParams.get("redirect_uri"),
+      })
+      expect(url.searchParams.get("code_challenge")).toBe(
+        Buffer.from(
+          yield* Effect.promise(() =>
+            crypto.subtle.digest("SHA-256", new TextEncoder().encode(form.get("code_verifier") ?? "")),
+          ),
+        ).toString("base64url"),
+      )
+      const saved = (yield* test.credentials.list(integrationID))[0]?.value
+      if (saved?.type !== "oauth") throw new Error("Expected OAuth credential")
+      expect(saved.access).toBe("poe-key")
+      expect(saved.refresh).toBe("")
+      if (expiry == null) expect(saved.expires).toBe(Number.MAX_SAFE_INTEGER)
+      if (expiry != null) {
+        expect(saved.expires).toBeGreaterThanOrEqual(now + expiry * 1000)
+        expect(saved.expires).toBeLessThanOrEqual(Date.now() + expiry * 1000)
+      }
+      test.replies.push(
+        new Response(
+          'data: {"choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+          {
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        ),
+      )
+      expect(yield* test.send).toContainEqual(expect.objectContaining({ type: "text-delta", text: "Hello" }))
+      expect(test.requests[1].url).toBe("https://api.poe.com/v1/chat/completions")
+      expect(test.requests[1].headers.get("authorization")).toBe("Bearer poe-key")
+    }),
+  )
+}
+
+it.live("rejects a forged callback before exchanging a code and closes cancelled listeners", () =>
+  Effect.gen(function* () {
+    const test = yield* fixture
+    const attempt = yield* test.integrations.oauth.connect({ integrationID, methodID })
+    const callback = new URL(new URL(attempt.url).searchParams.get("redirect_uri") ?? "")
+    callback.searchParams.set("state", "wrong")
+    callback.searchParams.set("code", "forged")
+    expect((yield* Effect.promise(() => fetch(callback, { headers: { Connection: "close" } }))).status).toBe(400)
+    expect(yield* test.status(attempt.attemptID)).toMatchObject({ status: "failed", message: "Invalid OAuth state" })
+    const next = yield* test.integrations.oauth.connect({ integrationID, methodID })
+    yield* test.integrations.oauth.cancel({ integrationID, attemptID: next.attemptID })
+    const cancelled = new URL(next.url).searchParams.get("redirect_uri") ?? ""
+    expect((yield* Effect.tryPromise(() => fetch(cancelled)).pipe(Effect.exit))._tag).toBe("Failure")
+    expect(test.requests).toHaveLength(0)
+    expect(yield* test.credentials.list(integrationID)).toEqual([])
+  }),
+)
+
+for (const response of [
+  { status: 400, body: { error: "invalid_grant" } },
+  { status: 200, body: {} },
+]) {
+  it.live(`does not save failed or invalid token exchanges (${response.status})`, () =>
+    Effect.gen(function* () {
+      const test = yield* fixture
+      const attempt = yield* test.integrations.oauth.connect({ integrationID, methodID })
+      const url = new URL(attempt.url)
+      const callback = new URL(url.searchParams.get("redirect_uri") ?? "")
+      callback.searchParams.set("state", url.searchParams.get("state") ?? "")
+      callback.searchParams.set("code", "auth-code")
+      test.replies.push(Response.json(response.body, { status: response.status }))
+      yield* Effect.promise(() => fetch(callback, { headers: { Connection: "close" } }))
+      expect((yield* test.status(attempt.attemptID)).status).toBe("failed")
+      expect(yield* test.credentials.list(integrationID)).toEqual([])
+    }),
+  )
+}
+
+it.effect("keeps near-expiry keys usable and requires a new login after expiry", () =>
+  Effect.gen(function* () {
+    const test = yield* fixture
+    const saved = yield* test.credentials.create({
+      integrationID,
+      value: Credential.OAuth.make({
+        type: "oauth",
+        methodID,
+        access: "poe-key",
+        refresh: "",
+        expires: (yield* Clock.currentTimeMillis) + 120_000,
+      }),
+    })
+    const connection = { type: "credential" as const, id: saved.id, label: saved.label }
+    expect(yield* test.integrations.connection.resolve(connection)).toEqual(saved.value)
+    yield* TestClock.adjust("2 minutes")
+    const error = yield* test.integrations.connection.resolve(connection).pipe(Effect.flip)
+    expect(error.cause).toEqual(new Error("Poe API key expired. Log in with Poe again."))
+    yield* test.integrations.connection.key({ integrationID, key: "manual-key" })
+    const active = yield* test.integrations.connection.active(integrationID)
+    if (!active) throw new Error("Expected key connection")
+    expect(yield* test.integrations.connection.resolve(active)).toEqual({ type: "key", key: "manual-key" })
+    expect(test.requests).toHaveLength(0)
+  }),
+)

--- a/packages/core/test/plugin/provider-poe.test.ts
+++ b/packages/core/test/plugin/provider-poe.test.ts
@@ -11,7 +11,7 @@ import { ProviderPlugins } from "@opencode/core/plugin/provider"
 import { PoePlugin } from "@opencode/core/plugin/provider/poe"
 import { Provider } from "@opencode/core/provider"
 import { expect } from "bun:test"
-import { Clock, Effect, Layer, Schedule, Stream } from "effect"
+import { Clock, Deferred, Effect, Fiber, Layer, Schedule, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { testEffect } from "../lib/effect"
@@ -25,13 +25,13 @@ const modelID = Model.ID.make("test-model")
 
 const fixture = Effect.gen(function* () {
   const requests: Request[] = []
-  const replies: Response[] = []
+  const replies: (Response | Effect.Effect<Response>)[] = []
   const http = HttpClient.make((request) =>
     Effect.gen(function* () {
       requests.push(yield* HttpClientRequest.toWeb(request).pipe(Effect.orDie))
       const response = replies.shift()
       if (!response) throw new Error(`Unexpected request: ${request.url}`)
-      return HttpClientResponse.fromWeb(request, response)
+      return HttpClientResponse.fromWeb(request, yield* Effect.isEffect(response) ? response : Effect.succeed(response))
     }),
   )
   const integrations = yield* Integration.Service
@@ -59,6 +59,14 @@ const fixture = Effect.gen(function* () {
         times: 100,
       }),
     )
+  const connect = Effect.gen(function* () {
+    const attempt = yield* integrations.oauth.connect({ integrationID, methodID, label: "Poe browser" })
+    const url = new URL(attempt.url)
+    const callback = new URL(url.searchParams.get("redirect_uri") ?? "")
+    callback.searchParams.set("state", url.searchParams.get("state") ?? "")
+    callback.searchParams.set("code", "auth-code")
+    return { attempt, url, callback }
+  })
   const send = Effect.gen(function* () {
     const resolver = yield* ModelResolver.Service
     const resolved = yield* resolver.resolve(Model.Ref.make({ providerID, id: modelID }))
@@ -70,7 +78,7 @@ const fixture = Effect.gen(function* () {
       Effect.provideService(HttpClient.HttpClient, http),
     )
   }).pipe(Effect.provide(ModelResolver.layer))
-  return { requests, replies, integrations, credentials, status, send }
+  return { requests, replies, integrations, credentials, status, connect, send }
 })
 
 it.effect("registers Poe browser OAuth alongside generic key and environment methods without fetching", () =>
@@ -90,8 +98,11 @@ for (const expiry of [3600, null, undefined]) {
   it.live(`exchanges a PKCE code for a native Poe credential (expiry: ${expiry})`, () =>
     Effect.gen(function* () {
       const test = yield* fixture
-      const attempt = yield* test.integrations.oauth.connect({ integrationID, methodID })
-      const url = new URL(attempt.url)
+      yield* test.integrations.connection.key({ integrationID, key: "previous-key", label: "Previous account" })
+      const previous = yield* test.integrations.connection.active(integrationID)
+      const login = yield* test.connect
+      expect(yield* test.integrations.connection.active(integrationID)).toEqual(previous)
+      const url = login.url
       expect(url.origin + url.pathname).toBe("https://poe.com/oauth/authorize")
       expect(Object.fromEntries(url.searchParams)).toMatchObject({
         response_type: "code",
@@ -99,16 +110,16 @@ for (const expiry of [3600, null, undefined]) {
         scope: "apikey:create",
         code_challenge_method: "S256",
       })
-      const callback = new URL(url.searchParams.get("redirect_uri") ?? "")
+      const callback = login.callback
       expect(callback.hostname).toBe("127.0.0.1")
       expect(callback.pathname).toBe("/callback")
       expect(url.searchParams.get("state")).toBeTruthy()
-      callback.searchParams.set("state", url.searchParams.get("state") ?? "")
-      callback.searchParams.set("code", "auth-code")
-      test.replies.push(Response.json({ api_key: "poe-key", api_key_expires_in: expiry }))
+      // Both issuer-bearing and documented issuer-less callbacks must work.
+      if (expiry != null) callback.searchParams.set("iss", "https://poe.com")
+      test.replies.push(Response.json({ api_key: " poe-key ", api_key_expires_in: expiry }))
       const now = Date.now()
       expect((yield* Effect.promise(() => fetch(callback, { headers: { Connection: "close" } }))).status).toBe(200)
-      expect((yield* test.status(attempt.attemptID)).status).toBe("complete")
+      expect((yield* test.status(login.attempt.attemptID)).status).toBe("complete")
       const exchange = test.requests[0]
       expect(exchange.url).toBe("https://api.poe.com/token")
       expect(exchange.headers.get("content-type")).toContain("application/x-www-form-urlencoded")
@@ -126,11 +137,19 @@ for (const expiry of [3600, null, undefined]) {
           ),
         ).toString("base64url"),
       )
-      const saved = (yield* test.credentials.list(integrationID))[0]?.value
+      const records = yield* test.credentials.list(integrationID)
+      const active = records.find((credential) => credential.label === "Poe browser")
+      expect(records).toHaveLength(2)
+      expect(yield* test.integrations.connection.active(integrationID)).toMatchObject({
+        type: "credential",
+        id: active?.id,
+        label: "Poe browser",
+      })
+      const saved = active?.value
       if (saved?.type !== "oauth") throw new Error("Expected OAuth credential")
       expect(saved.access).toBe("poe-key")
       expect(saved.refresh).toBe("")
-      if (expiry == null) expect(saved.expires).toBe(Number.MAX_SAFE_INTEGER)
+      if (expiry == null) expect(saved.expires).toBe(8_640_000_000_000_000)
       if (expiry != null) {
         expect(saved.expires).toBeGreaterThanOrEqual(now + expiry * 1000)
         expect(saved.expires).toBeLessThanOrEqual(Date.now() + expiry * 1000)
@@ -146,44 +165,144 @@ for (const expiry of [3600, null, undefined]) {
       expect(yield* test.send).toContainEqual(expect.objectContaining({ type: "text-delta", text: "Hello" }))
       expect(test.requests[1].url).toBe("https://api.poe.com/v1/chat/completions")
       expect(test.requests[1].headers.get("authorization")).toBe("Bearer poe-key")
+      yield* test.integrations.oauth.complete({ integrationID, attemptID: login.attempt.attemptID })
+      expect(yield* test.credentials.list(integrationID)).toEqual(records)
+      expect(test.requests).toHaveLength(2)
     }),
   )
 }
 
-it.live("rejects a forged callback before exchanging a code and closes cancelled listeners", () =>
+it.live("isolates overlapping login attempts and closes cancelled listeners", () =>
   Effect.gen(function* () {
     const test = yield* fixture
-    const attempt = yield* test.integrations.oauth.connect({ integrationID, methodID })
-    const callback = new URL(new URL(attempt.url).searchParams.get("redirect_uri") ?? "")
-    callback.searchParams.set("state", "wrong")
-    callback.searchParams.set("code", "forged")
-    expect((yield* Effect.promise(() => fetch(callback, { headers: { Connection: "close" } }))).status).toBe(400)
-    expect(yield* test.status(attempt.attemptID)).toMatchObject({ status: "failed", message: "Invalid OAuth state" })
-    const next = yield* test.integrations.oauth.connect({ integrationID, methodID })
-    yield* test.integrations.oauth.cancel({ integrationID, attemptID: next.attemptID })
-    const cancelled = new URL(next.url).searchParams.get("redirect_uri") ?? ""
-    expect((yield* Effect.tryPromise(() => fetch(cancelled)).pipe(Effect.exit))._tag).toBe("Failure")
+    const first = yield* test.connect
+    const next = yield* test.connect
+    expect(first.callback.origin).not.toBe(next.callback.origin)
+    expect(first.url.searchParams.get("code_challenge")).not.toBe(next.url.searchParams.get("code_challenge"))
+    expect(first.url.searchParams.get("state")).not.toBe(next.url.searchParams.get("state"))
+    first.callback.searchParams.set("state", next.url.searchParams.get("state") ?? "")
+    expect((yield* Effect.promise(() => fetch(first.callback, { headers: { Connection: "close" } }))).status).toBe(400)
+    expect(yield* test.status(first.attempt.attemptID)).toMatchObject({
+      status: "failed",
+      message: "Invalid OAuth state",
+    })
+    expect((yield* test.integrations.oauth.status({ integrationID, attemptID: next.attempt.attemptID })).status).toBe(
+      "pending",
+    )
+    yield* test.integrations.oauth.cancel({ integrationID, attemptID: next.attempt.attemptID })
+    expect((yield* Effect.tryPromise(() => fetch(next.callback)).pipe(Effect.exit))._tag).toBe("Failure")
     expect(test.requests).toHaveLength(0)
     expect(yield* test.credentials.list(integrationID)).toEqual([])
   }),
 )
 
-for (const response of [
-  { status: 400, body: { error: "invalid_grant" } },
-  { status: 200, body: {} },
+for (const invalid of [
+  { params: { state: "" }, message: "Invalid OAuth state" },
+  { params: { iss: "https://other.example", error: "access_denied" }, message: "Invalid OAuth issuer" },
+  { params: { iss: "https://poe.com/" }, message: "Invalid OAuth issuer" },
+  { params: { iss: "" }, message: "Invalid OAuth issuer" },
+  { params: { code: "" }, message: "Missing authorization code" },
+  { params: { error: "access_denied", error_description: "User declined access" }, message: "User declined access" },
 ]) {
-  it.live(`does not save failed or invalid token exchanges (${response.status})`, () =>
+  it.live(`rejects invalid or denied callbacks (${JSON.stringify(invalid.params)})`, () =>
     Effect.gen(function* () {
       const test = yield* fixture
-      const attempt = yield* test.integrations.oauth.connect({ integrationID, methodID })
-      const url = new URL(attempt.url)
-      const callback = new URL(url.searchParams.get("redirect_uri") ?? "")
-      callback.searchParams.set("state", url.searchParams.get("state") ?? "")
-      callback.searchParams.set("code", "auth-code")
-      test.replies.push(Response.json(response.body, { status: response.status }))
-      yield* Effect.promise(() => fetch(callback, { headers: { Connection: "close" } }))
-      expect((yield* test.status(attempt.attemptID)).status).toBe("failed")
+      const login = yield* test.connect
+      Object.entries(invalid.params).forEach(([key, value]) => login.callback.searchParams.set(key, value))
+      const response = yield* Effect.promise(() => fetch(login.callback, { headers: { Connection: "close" } }))
+      expect(response.status).toBe(400)
+      expect(yield* Effect.promise(() => response.text())).toContain("Authorization failed")
+      expect(yield* test.status(login.attempt.attemptID)).toMatchObject({ status: "failed", message: invalid.message })
+      expect(test.requests).toHaveLength(0)
       expect(yield* test.credentials.list(integrationID)).toEqual([])
+    }),
+  )
+}
+
+for (const response of [
+  {
+    status: 400,
+    body: JSON.stringify({ error: "invalid_grant", error_description: "Code expired" }),
+    message: "Poe token exchange failed: Code expired",
+  },
+  {
+    status: 400,
+    body: JSON.stringify({ error: "invalid_grant" }),
+    message: "Poe token exchange failed: invalid_grant",
+  },
+  { status: 502, body: "Bad gateway", message: "Poe token exchange failed (502)" },
+  {
+    status: 400,
+    body: JSON.stringify({ error_description: "Rejected auth-code" }),
+    message: "Poe token exchange failed (400)",
+  },
+  ...[
+    "{}",
+    "{",
+    '{"api_key":"   "}',
+    '{"api_key":"poe-key","api_key_expires_in":-1}',
+    '{"api_key":"poe-key","api_key_expires_in":1.5}',
+    '{"api_key":"poe-key","api_key_expires_in":1e309}',
+  ].map((body) => ({ status: 200, body, message: "Invalid Poe token response" })),
+  {
+    status: 200,
+    body: '{"api_key":"poe-key","api_key_expires_in":8640000000000}',
+    message: "Invalid Poe API key expiry",
+  },
+]) {
+  it.live(`preserves the active connection after a failed token exchange (${response.status}: ${response.body})`, () =>
+    Effect.gen(function* () {
+      const test = yield* fixture
+      yield* test.integrations.connection.key({ integrationID, key: "previous-key" })
+      const previous = yield* test.integrations.connection.active(integrationID)
+      const saved = yield* test.credentials.list(integrationID)
+      const login = yield* test.connect
+      test.replies.push(new Response(response.body, { status: response.status }))
+      const page = yield* Effect.promise(() => fetch(login.callback, { headers: { Connection: "close" } }))
+      expect(page.status).toBe(400)
+      expect(yield* Effect.promise(() => page.text())).toContain(response.message)
+      expect(yield* test.status(login.attempt.attemptID)).toMatchObject({ status: "failed", message: response.message })
+      expect(yield* test.credentials.list(integrationID)).toEqual(saved)
+      expect(yield* test.integrations.connection.active(integrationID)).toEqual(previous)
+    }),
+  )
+}
+
+for (const cancel of [false, true]) {
+  it.live(`waits for the token exchange and consumes the callback once (cancel: ${cancel})`, () =>
+    Effect.gen(function* () {
+      const test = yield* fixture
+      const login = yield* test.connect
+      const started = yield* Deferred.make<void>()
+      const token = yield* Deferred.make<Response>()
+      test.replies.push(Deferred.succeed(started, undefined).pipe(Effect.andThen(Deferred.await(token))))
+      const page = yield* Effect.tryPromise(() => fetch(login.callback, { headers: { Connection: "close" } })).pipe(
+        Effect.exit,
+        Effect.forkScoped,
+      )
+      yield* Deferred.await(started)
+      expect(
+        (yield* test.integrations.oauth.status({ integrationID, attemptID: login.attempt.attemptID })).status,
+      ).toBe("pending")
+      expect(yield* test.credentials.list(integrationID)).toEqual([])
+      expect((yield* Effect.promise(() => fetch(login.callback, { headers: { Connection: "close" } }))).status).toBe(
+        409,
+      )
+      expect(test.requests).toHaveLength(1)
+      if (cancel) {
+        yield* test.integrations.oauth.cancel({ integrationID, attemptID: login.attempt.attemptID })
+        yield* Deferred.succeed(token, Response.json({ api_key: "cancelled-key" }))
+        expect((yield* Fiber.join(page))._tag).toBe("Failure")
+        expect(yield* test.credentials.list(integrationID)).toEqual([])
+        return
+      }
+      yield* Deferred.succeed(token, Response.json({ api_key: "poe-key" }))
+      const result = yield* Fiber.join(page)
+      const response = yield* result
+      expect(response.status).toBe(200)
+      expect(yield* Effect.promise(() => response.text())).toContain("Authorization successful")
+      expect((yield* test.status(login.attempt.attemptID)).status).toBe("complete")
+      expect(yield* test.credentials.list(integrationID)).toHaveLength(1)
     }),
   )
 }


### PR DESCRIPTION
## Summary

Port Poe browser authentication into V2's integration lifecycle, using the existing native OpenAI-compatible inference path. Audited against Poe's documentation, the V1 dependencies (`opencode-poe-auth@0.0.1` / `poe-oauth@0.0.8`), and current upstream code.

- Register browser OAuth alongside the existing models.dev catalog and key/environment methods.
- Use the existing public client ID, `apikey:create` scope, authorization/token endpoints, PKCE S256, and an attempt-scoped ephemeral loopback listener.
- Bind every callback to its initiating state. Validate a supplied `iss` with exact comparison against `https://poe.com` before processing either success or error callbacks.
- Decode API keys and expiration at the token-response boundary. Preserve finite/null/omitted expiry; reject blank keys, invalid durations, and unrepresentable expiration timestamps. Expired keys require another login.
- Preserve Poe's exchange error details without echoing the code or verifier. Render browser success only after a successful exchange; exchange failures render the error page.
- Consume a callback once and release listeners/responses on cancellation. Shared V2 integration code persists and activates the new credential before reporting the attempt complete.

## Documentation and upstream audit

| Area | Findings and implementation |
| --- | --- |
| Authorization and exchange | [Poe's OAuth guide](https://creator.poe.com/docs/external-applications/sign-in-with-poe) requires PKCE S256, `response_type=code`, `scope=apikey:create`, and a form-encoded exchange with the same client ID and redirect URI. These are exercised through a real loopback callback and inspected token request. |
| Issuer validation | [Current upstream authorization code](https://github.com/poe-platform/poe-code/blob/db72de23d58c07416d1cb249a4ced1e8941fd0fb/packages/poe-oauth/src/oauth-client.ts) binds the authorization origin as issuer with `requireIssuer: false`. Unlike the old published dependency, it enables issuer validation. This PR now pins `https://poe.com` and rejects any supplied mismatch, including empty values, on success and error callbacks. |
| Optional issuer | Poe's public guide does not promise an `iss` parameter. We follow upstream's optional-issuer policy, using exact comparison as described by [RFC 9207 §2.4](https://www.rfc-editor.org/rfc/rfc9207.html#section-2.4). A missing `iss` remains supported. The public metadata probes did not yield metadata (404 on poe.com, 403 on api.poe.com); the pinned expected value comes from upstream's implementation. |
| Connection ownership | [V2 plugin integrations](https://opencode.ai/v2/docs/build/plugins#integrations) own attempts; `Credential.create` saves and activates within one transaction. Tests start with an existing connection, verify it remains active during login/failure, and verify native inference uses the newly activated credential on success. Overlapping attempts have independent listeners, state, and PKCE values. |
| Account lookup | `checkAuth()` is a separate `/usage/current_balance` utility, not a step required by Poe's OAuth guide or called by its OpenCode wrapper. [Upstream records that this endpoint no longer returns email](https://github.com/poe-platform/poe-code/commit/6f2a7e9c43f7a75e3f1130b821f738083da0f685). A balance lookup cannot establish which account the user intended to choose. Poe's consent screen selects the account; the bound exchange supplies its credential. |
| Inference setup | [Poe's OpenAI-compatible guide](https://creator.poe.com/docs/external-applications/openai-compatible-api) specifies `https://api.poe.com/v1` and bearer authentication. The existing native remapping handles this; tests exercise it with the OAuth-issued key. |
| Library options | Upstream's optional manual-paste callback and customizable endpoints/browser/server are library composition features. Its [OpenCode wrapper](https://github.com/poe-platform/poe-code/blob/db72de23d58c07416d1cb249a4ced1e8941fd0fb/packages/opencode-poe-auth/src/poe-auth-plugin.ts) exposes browser login and API-key entry. V2 owns browser opening and cancellation through its client/integration lifecycle. |

No new dependencies or AI SDK hooks. Plugin setup performs no network requests.

## Verification

Run from `packages/core`:

- `bun typecheck` — passed.
- `bun test test/plugin/provider-poe.test.ts test/plugin/provider-openai-compatible.test.ts test/integration.test.ts test/model-resolver.test.ts` — **84 pass, 511 assertions**, including 25 Poe tests.
- Focused type-aware lint, Prettier check, and `git diff --check` — passed.

Poe tests cover PKCE, present/absent/mismatched issuer, callback denial, invalid exchanges/expiry, activation over an existing connection, independent attempts, one-time consumption, cancellation during token exchange, native inference, and expiry-based re-login. Real loopback HTTP is exercised with scripted remote token/model responses. Cancellation coverage found and fixed Bun leaving unanswered callback responses pending after `server.closeAllConnections()`.

Live authorization with a Poe account remains unverified.
