### PR TITLE
fix(app): use HTTP-safe attachment and mutation IDs

### DIFF
--- a/packages/app/src/composer/attachments/attachments.ts
+++ b/packages/app/src/composer/attachments/attachments.ts
@@ -1,5 +1,7 @@
 import { onCleanup, onMount } from "solid-js"
 import { makeEventListener } from "@solid-primitives/event-listener"
+import { createBlobReference } from "@/runtime/persistence/drafts"
+import { uuid } from "@/runtime/persistence/uuid"
 import type { ComposerAttachment, ComposerPrompt } from "../types"
 
 const accepted = [
@@ -107,7 +109,7 @@ export function createComposerAttachments(
       if (toast) input.warn()
       return false
     }
-    const blob = input.store ? await input.store(file) : await blobReference(file)
+    const blob = input.store ? await input.store(file) : await createBlobReference(file)
     const sourcePath = input.getPathForFile?.(file) || undefined
     // Native clipboard images arrive with a fresh timestamped filename on every paste, so identical
     // clipboard content is matched on bytes alone.
@@ -127,7 +129,7 @@ export function createComposerAttachments(
     }
     const attachment: ComposerAttachment = {
       type: "image",
-      id: crypto.randomUUID(),
+      id: uuid(),
       filename: file.name,
       sourcePath,
       mime,
@@ -230,12 +232,6 @@ export function createComposerAttachments(
 
 const imageMimes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"])
 
-async function blobReference(file: File) {
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", await file.arrayBuffer())))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-  return { id, url: URL.createObjectURL(file) }
-}
 const imageExtensions = new Map([
   ["gif", "image/gif"],
   ["jpeg", "image/jpeg"],

--- a/packages/app/src/runtime/server/data.ts
+++ b/packages/app/src/runtime/server/data.ts
@@ -2,6 +2,7 @@ import type { Data } from "@opencode/client/solid"
 import type { SessionInfo } from "@opencode/client/promise"
 import { onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
+import { uuid } from "@/runtime/persistence/uuid"
 
 type SessionMutation = { readonly id: string; readonly type: "remove"; readonly sessionID: string }
 
@@ -35,7 +36,7 @@ export function createSessionMutations(remove: (sessionID: string) => Promise<vo
       return removed.size === 0 ? [...sessions] : sessions.filter((session) => !removed.has(session.id))
     },
     remove(sessionID: string) {
-      const mutation = { id: crypto.randomUUID(), type: "remove" as const, sessionID }
+      const mutation = { id: uuid(), type: "remove" as const, sessionID }
       setStore("session", (current) => [...current, mutation])
       return Promise.resolve()
         .then(() => remove(sessionID))


### PR DESCRIPTION
### Issue for this PR

Reported directly: the web UI should work over HTTP on non-localhost origins.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Use the existing HTTP-safe `uuid()` helper for attachment IDs and session-deletion mutation IDs. Both called `crypto.randomUUID()` directly, which is unavailable in insecure contexts.

Also reuse `createBlobReference()` for attachments without a draft store. It already falls back to `crypto.getRandomValues()` when `crypto.subtle` is unavailable.

### How did you verify your code works?

- App typecheck and pre-push workspace typechecks passed.
- 19 existing UUID, draft-storage, session-mutation, and attachment tests passed.
- Temporarily disabled `randomUUID` and `subtle`: reproduced all four failures before the fix, then verified session deletion/rollback, attachment ownership, and attachment creation without a draft store pass. Temporary checks removed.
- Production build and home-to-session navigation benchmark passed before/after (3 serial samples each, same installed Chromium). Median first-observed: 124.5 → 118.8 ms; median stable-observed: 138.0 → 159.3 ms. Small diagnostic sample, not a performance conclusion.

### Screenshots / recordings

No visual changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR