### PR TITLE
fix(desktop): report default file opener errors

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -24,6 +24,7 @@ import type { UpdaterController } from "./updater-controller"
 import { createUpdaterSubscriptions } from "./updater-subscriptions"
 import { createDesktopDraftStore } from "./draft-store"
 import { nativeT } from "./native-translations"
+import { openInDefaultApp } from "./open-path"
 
 const pickerFilters = (ext?: string[]) => {
   if (!ext || ext.length === 0) return undefined
@@ -217,7 +218,7 @@ export function registerIpcHandlers(deps: Deps) {
   })
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
-    if (!app) return shell.openPath(path)
+    if (!app) return openInDefaultApp(path, (path) => shell.openPath(path))
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)

--- a/packages/desktop/src/main/open-path.test.ts
+++ b/packages/desktop/src/main/open-path.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { openInDefaultApp } from "./open-path"
+
+describe("opening paths in the default app", () => {
+  test("rejects the opener's error message so callers can report the failure", async () => {
+    await expect(openInDefaultApp("/missing/project", async () => "Failed to open path")).rejects.toThrow(
+      "Failed to open path",
+    )
+  })
+
+  test("opens the requested path successfully", async () => {
+    const paths: string[] = []
+    await expect(
+      openInDefaultApp("/project with spaces", async (path) => {
+        paths.push(path)
+        return ""
+      }),
+    ).resolves.toBe("")
+    expect(paths).toEqual(["/project with spaces"])
+  })
+
+  test("preserves a rejected opener error", async () => {
+    const error = new Error("Opener unavailable")
+    await expect(
+      openInDefaultApp("/project", async () => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+  })
+})

--- a/packages/desktop/src/main/open-path.ts
+++ b/packages/desktop/src/main/open-path.ts
@@ -1,0 +1,5 @@
+export async function openInDefaultApp(path: string, open: (path: string) => Promise<string>) {
+  const error = await open(path)
+  if (error) throw new Error(error)
+  return error
+}


### PR DESCRIPTION
### Issue for this PR

Closes #47722

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reject non-empty errors returned by Electron's `shell.openPath` so the existing UI error handler reports failed opens. Successful opens and explicitly selected applications keep their existing behavior.

### How did you verify your code works?

- Focused regression tests: 3 passed; the failure case failed before the fix.
- Desktop typecheck and formatting passed. Oxlint reported only two warnings also present on the original code.
- macOS, Electron 42.3.3: real native IPC resolved an error string before the fix and rejected it afterward. Explicit-app failures still reject.
- Desktop suite: 74 passed; `draft-store` is blocked because Bun 1.3.14 lacks `node:sqlite`.

### Screenshots / recordings

Not captured. Full desktop UI interaction was not manually exercised.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
