### PR TITLE
fix(project): anchor non-git project identity to directory, not filesystem root

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -109,7 +109,16 @@ const layer = Layer.effect(
 
     const resolve = Effect.fn("Project.resolve")(function* (input: AbsolutePath) {
       const repo = yield* git.repo.discover(input)
-      if (!repo) return { id: ID.global, directory: AbsolutePath.make(path.parse(input).root), vcs: undefined }
+      if (!repo) {
+        const resolved = yield* fs.resolve(input)
+        const root = path.parse(resolved).root
+        // Reserve ID.global for the literal filesystem root (or explicit no-project
+        // cases upstream). Every other directory gets a stable identity derived from
+        // its own path, so unrelated non-git directories never collapse into one
+        // shared "global" project/session bucket just because git discovery failed.
+        if (resolved === root) return { id: ID.global, directory: AbsolutePath.make(root), vcs: undefined }
+        return { id: ID.make(Hash.fast(`directory:${resolved}`)), directory: AbsolutePath.make(resolved), vcs: undefined }
+      }
 
       const previous = yield* cached(repo.commonDirectory)
       const id = (yield* remote(repo)) ?? previous ?? (yield* root(repo))

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -39,7 +39,7 @@ async function rootCommit(dir: string) {
 }
 
 describe("ProjectV2.resolve", () => {
-  it.live("returns global for non-git directory", () =>
+  it.live("derives a stable directory-based id for non-git directory", () =>
     Effect.gen(function* () {
       const tmp = yield* Effect.acquireRelease(
         Effect.promise(() => tmpdir()),
@@ -48,10 +48,43 @@ describe("ProjectV2.resolve", () => {
       const project = yield* ProjectV2.Service
 
       const result = yield* project.resolve(abs(tmp.path))
+      const again = yield* project.resolve(abs(tmp.path))
 
-      expect(result.id).toBe(ProjectV2.ID.make("global"))
-      expect(path.resolve(result.directory)).toBe(path.parse(tmp.path).root)
+      expect(result.id).not.toBe(ProjectV2.ID.global)
+      expect(result.id).toBe(again.id)
+      expect(result.directory).toBe(yield* real(tmp.path))
       expect(result.previous).toBeUndefined()
+      expect(result.vcs).toBeUndefined()
+    }),
+  )
+
+  it.live("gives unrelated non-git directories distinct ids", () =>
+    Effect.gen(function* () {
+      const a = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const b = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const project = yield* ProjectV2.Service
+
+      const resultA = yield* project.resolve(abs(a.path))
+      const resultB = yield* project.resolve(abs(b.path))
+
+      expect(resultA.id).not.toBe(resultB.id)
+      expect(resultA.directory).not.toBe(resultB.directory)
+    }),
+  )
+
+  it.live("still returns global for the literal filesystem root", () =>
+    Effect.gen(function* () {
+      const project = yield* ProjectV2.Service
+
+      const result = yield* project.resolve(abs(path.parse(process.cwd()).root))
+
+      expect(result.id).toBe(ProjectV2.ID.global)
       expect(result.vcs).toBeUndefined()
     }),
   )

--- a/packages/opencode/src/project/instance-context.ts
+++ b/packages/opencode/src/project/instance-context.ts
@@ -17,8 +17,9 @@ export const context = LocalContext.create<InstanceContext>("instance")
  */
 export function containsPath(filepath: string, ctx: InstanceContext): boolean {
   if (FSUtil.contains(ctx.directory, filepath)) return true
-  // Non-git projects set worktree to "/" which would match ANY absolute path.
-  // Skip worktree check in this case to preserve external_directory permissions.
+  // Legacy persisted rows (from before non-git projects got their own directory
+  // as worktree) may still have worktree "/", which would match ANY absolute path.
+  // Keep this guard so old data can't make the filesystem root count as in-project.
   if (ctx.worktree === "/") return false
   return FSUtil.contains(ctx.worktree, filepath)
 }

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -116,6 +116,8 @@ describe("Project.fromDirectory", () => {
       const result = yield* project.fromDirectory(tmp)
 
       expect(result.project).toBeDefined()
+      // No commits yet: git.history.rootCommits() finds nothing, so this still
+      // falls back to ID.global, same as before. VCS metadata is still git.
       expect(result.project.id).toBe(ProjectV2.ID.global)
       expect(result.project.vcs).toBe("git")
       expect(result.project.worktree).toBe(tmp)
@@ -139,12 +141,28 @@ describe("Project.fromDirectory", () => {
     }),
   )
 
-  it.live("returns global for non-git directory", () =>
+  it.live("derives a stable directory-based project id for non-git directory", () =>
     Effect.gen(function* () {
       const project = yield* Project.Service
       const tmp = yield* tmpdirScoped()
       const result = yield* project.fromDirectory(tmp)
-      expect(result.project.id).toBe(ProjectV2.ID.global)
+      expect(result.project.id).not.toBe(ProjectV2.ID.global)
+      expect(result.project.worktree).toBe(tmp)
+    }),
+  )
+
+  it.live("keeps unrelated non-git directories on separate projects/sessions", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const a = yield* tmpdirScoped()
+      const b = yield* tmpdirScoped()
+
+      const resultA = yield* project.fromDirectory(a)
+      const resultB = yield* project.fromDirectory(b)
+
+      expect(resultA.project.id).not.toBe(resultB.project.id)
+      expect(resultA.project.worktree).toBe(a)
+      expect(resultB.project.worktree).toBe(b)
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #47885

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ProjectV2.resolve()` in `packages/core/src/project.ts` falls back to `{ id: ID.global, directory: path.parse(input).root }` whenever `git.repo.discover()` returns null (non-git directory, uninitialized repo, transient discovery failure). Since `path.parse(input).root` is always `/` on POSIX, every directory that hits this fallback gets the exact same directory value and the exact same project id, so two completely unrelated non-git directories become indistinguishable as "the same project." Downstream this collapses their sessions into one shared bucket in the `/sessions` list (filtering is by `project_id`, see `listByProject` in `packages/opencode/src/session/session.ts`), and it makes tool permission paths resolve relative to `/` instead of the actual directory.

This was already reported and root-caused in #24694, with a working fix in #33668 that normalized the worktree/sandbox path. Both were auto-closed by the 60-day stale bot, not by a maintainer decision, and that fix only addressed the worktree path, not the project id collision itself (both directories would still land on `ID.global`).

The fix: when git discovery fails, resolve the real absolute directory path (`fs.resolve`, matches what the git-repo path already does via `repo.worktree`) and derive a stable id from it with the same hashing approach already used for git-remote-based ids (`Hash.fast`). `ID.global` is now reserved for the case where the resolved path actually is the filesystem root. Git discovery still works exactly as before for git repos; this only changes the non-git fallback.

### How did you verify your code works?

- `bun test packages/core/test/project.test.ts` (12 pass, added 2 new cases: unrelated non-git dirs get distinct ids, literal root still returns global)
- `bun test packages/opencode/test/project/` (89 pass, 1 skip — updated 2 existing assertions that expected `ID.global` for plain non-git dirs, added a case asserting two non-git dirs get separate project ids)
- `bun test packages/opencode/test/tool/read.test.ts packages/opencode/test/tool/external-directory.test.ts` (permission path scoping unaffected, still pass)
- `bun run typecheck` in `packages/core` and `packages/opencode` (clean)

### Screenshots / recordings

Not applicable, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
