### PR TITLE
feat(cli): show short session ids in list and accept prefixes in delete

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -2,8 +2,7 @@ import type { Argv } from "yargs"
 import { Effect } from "effect"
 import { cmd } from "./cmd"
 import { effectCmd, fail } from "../effect-cmd"
-import { Session } from "@/session/session"
-import { SessionID } from "../../session/schema"
+import { AmbiguousIDError, Session } from "@/session/session"
 import { UI } from "../ui"
 import { Locale } from "@/util/locale"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -59,11 +58,19 @@ export const SessionDeleteCommand = effectCmd({
     }),
   handler: Effect.fn("Cli.session.delete")(function* (args) {
     const svc = yield* Session.Service
-    const sessionID = SessionID.make(args.sessionID)
-    yield* svc
-      .remove(sessionID)
-      .pipe(Effect.catchIf(NotFoundError.isInstance, () => fail(`Session not found: ${args.sessionID}`)))
-    UI.println(UI.Style.TEXT_SUCCESS_BOLD + `Session ${args.sessionID} deleted` + UI.Style.TEXT_NORMAL)
+    const notFound = () => fail(`Session not found: ${args.sessionID}`)
+    const sessionID = yield* svc.resolve(args.sessionID).pipe(
+      Effect.catchIf(AmbiguousIDError.isInstance, (error) =>
+        fail(
+          `Multiple sessions match "${error.input}". Use a longer prefix:\n${error.matches
+            .map((match) => `  ${match}`)
+            .join("\n")}`,
+        ),
+      ),
+      Effect.catchIf(NotFoundError.isInstance, notFound),
+    )
+    yield* svc.remove(sessionID).pipe(Effect.catchIf(NotFoundError.isInstance, notFound))
+    UI.println(UI.Style.TEXT_SUCCESS_BOLD + `Session ${sessionID} deleted` + UI.Style.TEXT_NORMAL)
   }),
 })
 
@@ -115,26 +122,55 @@ export const SessionListCommand = effectCmd({
   }),
 })
 
-function formatSessionTable(sessions: Session.Info[]): string {
-  const lines: string[] = []
-
-  const maxIdWidth = Math.max(20, ...sessions.map((s) => s.id.length))
-  const maxTitleWidth = Math.max(25, ...sessions.map((s) => s.title.length))
-
-  const header = `Session ID${" ".repeat(maxIdWidth - 10)}  Title${" ".repeat(maxTitleWidth - 5)}  Updated`
-  lines.push(header)
-  lines.push("─".repeat(header.length))
-  for (const session of sessions) {
-    const truncatedTitle = Locale.truncate(session.title, maxTitleWidth)
-    const timeStr = Locale.todayTimeOrDateTime(session.time.updated)
-    const line = `${session.id.padEnd(maxIdWidth)}  ${truncatedTitle.padEnd(maxTitleWidth)}  ${timeStr}`
-    lines.push(line)
-  }
-
-  return lines.join(EOL)
+function shortID(id: string): string {
+  return id.slice(0, 12)
 }
 
-function formatSessionJSON(sessions: Session.Info[]): string {
+type SessionTableColumn = {
+  header: string
+  minWidth: number
+  value: (session: Session.Info) => string
+  truncate: (value: string, width: number) => string
+}
+
+const sessionTableColumns: SessionTableColumn[] = [
+  {
+    header: "Session ID",
+    minWidth: 12,
+    value: (session) => shortID(session.id),
+    truncate: (value) => value,
+  },
+  {
+    header: "Title",
+    minWidth: 25,
+    value: (session) => session.title,
+    truncate: Locale.truncate,
+  },
+  {
+    header: "Updated",
+    minWidth: 0,
+    value: (session) => Locale.todayTimeOrDateTime(session.time.updated),
+    truncate: (value) => value,
+  },
+]
+
+export function formatSessionTable(sessions: Session.Info[]): string {
+  const widths = sessionTableColumns.map((column) => {
+    const contentWidth = Math.max(...sessions.map((session) => column.value(session).length))
+    return Math.max(column.minWidth, column.header.length, contentWidth)
+  })
+
+  const formatRow = (cells: string[]) => cells.map((cell, index) => cell.padEnd(widths[index])).join("  ")
+
+  const header = formatRow(sessionTableColumns.map((column) => column.header))
+  const rows = sessions.map((session) =>
+    formatRow(sessionTableColumns.map((column, index) => column.truncate(column.value(session), widths[index]))),
+  )
+
+  return [header, "─".repeat(header.length), ...rows].join(EOL)
+}
+
+export function formatSessionJSON(sessions: Session.Info[]): string {
   const jsonData = sessions.map((session) => ({
     id: session.id,
     title: session.title,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -408,6 +408,15 @@ export class BusyError extends Schema.TaggedErrorClass<BusyError>()("SessionBusy
   sessionID: SessionID,
 }) {}
 
+export class AmbiguousIDError extends Schema.TaggedErrorClass<AmbiguousIDError>()("SessionIDAmbiguous", {
+  input: Schema.String,
+  matches: Schema.Array(SessionID),
+}) {
+  static isInstance(input: unknown): input is AmbiguousIDError {
+    return input instanceof AmbiguousIDError
+  }
+}
+
 export type NotFound = NotFoundError
 
 export interface Interface {
@@ -425,6 +434,7 @@ export interface Interface {
   readonly fork: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Info, NotFound>
   readonly touch: (sessionID: SessionID) => Effect.Effect<void>
   readonly get: (id: SessionID) => Effect.Effect<Info, NotFound>
+  readonly resolve: (input: string) => Effect.Effect<SessionID, NotFound | AmbiguousIDError>
   readonly setTitle: (input: { sessionID: SessionID; title: string }) => Effect.Effect<void>
   readonly setArchived: (input: { sessionID: SessionID; time?: number }) => Effect.Effect<void>
   readonly setMetadata: (input: typeof SetMetadataInput.Type) => Effect.Effect<void>
@@ -541,6 +551,28 @@ const layer: Layer.Layer<
       const row = yield* db.select().from(SessionTable).where(eq(SessionTable.id, id)).get().pipe(Effect.orDie)
       if (!row) return yield* Effect.fail(new NotFoundError({ message: `Session not found: ${id}` }))
       return fromRow(row)
+    })
+
+    const resolve = Effect.fn("Session.resolve")(function* (input: string) {
+      // A full id is `ses_` plus 26 chars; short prefixes fall through to the lookup below.
+      const decoded = Option.getOrUndefined(Schema.decodeUnknownOption(SessionID)(input))
+      if (decoded && decoded.length === 30) {
+        yield* get(decoded)
+        return decoded
+      }
+
+      const rows = yield* db
+        .select({ id: SessionTable.id })
+        .from(SessionTable)
+        .where(like(SessionTable.id, `${input}%`))
+        .limit(2)
+        .all()
+        .pipe(Effect.orDie)
+      if (rows.length === 0) return yield* Effect.fail(new NotFoundError({ message: `Session not found: ${input}` }))
+      if (rows.length > 1) {
+        return yield* Effect.fail(new AmbiguousIDError({ input, matches: rows.map((row) => SessionID.make(row.id)) }))
+      }
+      return SessionID.make(rows[0].id)
     })
 
     const list = Effect.fn("Session.list")(function* (input?: ListInput) {
@@ -910,6 +942,7 @@ const layer: Layer.Layer<
       fork,
       touch,
       get,
+      resolve,
       setTitle,
       setArchived,
       setMetadata,

--- a/packages/opencode/test/cli/cmd/session.test.ts
+++ b/packages/opencode/test/cli/cmd/session.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { formatSessionTable } from "@/cli/cmd/session"
+import { Session } from "@/session/session"
+
+const fullID = "ses_0123456789ABCDEFGHIJKLMNOP"
+
+const info = (overrides: Partial<Session.Info>) =>
+  ({
+    id: fullID,
+    slug: "test",
+    projectID: "prj_test",
+    directory: "/tmp/opencode",
+    title: "hello",
+    version: "0.1.0",
+    time: { created: 0, updated: 0 },
+    ...overrides,
+  }) as Session.Info
+
+describe("formatSessionTable", () => {
+  test("shows the short session id instead of the full id", () => {
+    const output = formatSessionTable([info({})])
+
+    expect(output).toContain(fullID.slice(0, 12))
+    expect(output).not.toContain(fullID)
+  })
+
+  test("keeps the full id in the JSON format", async () => {
+    const { formatSessionJSON } = await import("@/cli/cmd/session")
+    expect(formatSessionJSON([info({})])).toContain(fullID)
+  })
+})

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -4,6 +4,7 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { Deferred, Effect, Exit, Layer } from "effect"
 import { Session as SessionNs } from "@/session/session"
+import { NotFoundError } from "@/storage/storage"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -280,6 +281,56 @@ describe("Session", () => {
 
       expect(created.metadata).toBeUndefined()
       expect(saved.metadata).toBeUndefined()
+    }),
+  )
+})
+
+describe("session.resolve", () => {
+  it.instance("resolves a full id to itself", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({ title: "resolve-full" }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      expect(yield* session.resolve(created.id)).toBe(created.id)
+    }),
+  )
+
+  it.instance("resolves a unique prefix to the full id", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({ title: "resolve-prefix" }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      expect(yield* session.resolve(created.id.slice(0, 12))).toBe(created.id)
+    }),
+  )
+
+  it.instance("fails when the prefix matches multiple sessions", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const first = yield* Effect.acquireRelease(session.create({ title: "resolve-ambig-1" }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      const second = yield* Effect.acquireRelease(session.create({ title: "resolve-ambig-2" }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      const error = yield* Effect.flip(session.resolve("ses_"))
+      expect(SessionNs.AmbiguousIDError.isInstance(error)).toBe(true)
+      if (SessionNs.AmbiguousIDError.isInstance(error)) {
+        expect(error.matches.length).toBeGreaterThanOrEqual(2)
+        expect(error.matches).toContain(first.id)
+        expect(error.matches).toContain(second.id)
+      }
+    }),
+  )
+
+  it.instance("fails when no session matches the prefix", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const error = yield* Effect.flip(session.resolve("ses_zzz-not-found"))
+      expect(NotFoundError.isInstance(error)).toBe(true)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

No linked issue — small CLI UX improvement for the session commands.

### Type of change

- [x] New feature

### What does this PR do?

`opencode session list` previously rendered the full session id (`ses_` + 26 chars) in a 20-column-wide cell, spilling into the terminal for every row. Since the id only needs to identify the session, the table now shows a short id (`ses_` + first 8 chars); the JSON format still includes the full id.

To keep the short ids usable, `opencode session delete` now accepts either a full id or a unique prefix of one. `Session.Service` gained a `resolve(input)` method that:

- validates an exact, full id against the store,
- otherwise resolves the input as a prefix via a `LIKE` query,
- fails with a new `AmbiguousIDError` (carrying the matching ids) when several sessions share the prefix, so the delete command can print them and ask for a longer prefix.

The table renderer was also moved to a small per-column definition (header, min width, value, truncate) so row and header widths are derived from the same source of truth instead of hand-padded strings.

### How did you verify your code works?

- Added service tests for `resolve`: full id, unique prefix, ambiguous prefix, and no-match (found via `Effect.flip`).
- Added tests for `formatSessionTable` (short id shown, full id absent) and the JSON path (full id preserved).
- Ran all `test/session/session.test.ts` and new CLI tests — 14 tests pass.
- Ran `bun typecheck` from `packages/opencode` — clean.
- Manually ran the CLI: created a real session, confirmed `session list` shows the short id, and `session delete <prefix>` deleted it.

### Screenshots / recordings

Example table output:

```
Session ID          Title               Updated
ses_2k1j3abx        Add auth flow       Today 12:31
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR