### PR TITLE
feat(opencode): add graphql language server

### DIFF
--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -58,6 +58,7 @@ export const builtinServerIds = [
   "tinymist",
   "haskell-language-server",
   "julials",
+  "graphql",
 ]
 
 export const requiresExtensionsForCustomServers = Schema.makeFilter<

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -118,4 +118,6 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".nix": "nix",
   ".typ": "typst",
   ".typc": "typst",
+  ".graphql": "graphql",
+  ".gql": "graphql",
 } as const

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1965,6 +1965,40 @@ export const HLS: Info = {
   },
 }
 
+export const GraphQL: Info = {
+  id: "graphql",
+  extensions: [".graphql", ".gql"],
+  // Gated on a GraphQL config so a stray .graphql file does not pull the server down.
+  root: StrictNearestRoot([
+    ".graphqlrc",
+    ".graphqlrc.json",
+    ".graphqlrc.yml",
+    ".graphqlrc.yaml",
+    ".graphqlrc.js",
+    ".graphqlrc.ts",
+    "graphql.config.js",
+    "graphql.config.ts",
+    "graphql.config.json",
+    "graphql.config.yml",
+    "graphql.config.yaml",
+  ]),
+  async spawn(root, _ctx, flags) {
+    let binary = which("graphql-lsp")
+    if (!binary) {
+      if (flags.disableLspDownload) return
+      const resolved = await Npm.which("graphql-language-service-cli", "graphql-lsp")
+      if (!resolved) return
+      binary = resolved
+    }
+    return {
+      // Defaults to a node IPC channel; "stream" is the stdio transport this client speaks.
+      process: spawn(binary, ["server", "-m", "stream"], {
+        cwd: root,
+      }),
+    }
+  },
+}
+
 export const JuliaLS: Info = {
   id: "julials",
   extensions: [".jl"],

--- a/packages/opencode/test/lsp/graphql-root.test.ts
+++ b/packages/opencode/test/lsp/graphql-root.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect, afterAll } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import os from "os"
+import * as LSPServer from "@/lsp/server"
+import type { InstanceContext } from "@/project/instance-context"
+
+const tmpBase = path.join(os.tmpdir(), "opencode-graphql-test")
+
+function makeCtx(directory: string): InstanceContext {
+  return { directory, worktree: "/", project: {} as any }
+}
+
+async function touch(p: string) {
+  await fs.mkdir(path.dirname(p), { recursive: true })
+  await fs.writeFile(p, "", "utf-8")
+}
+
+afterAll(async () => {
+  await fs.rm(tmpBase, { recursive: true, force: true }).catch(() => {})
+})
+
+describe("GraphQL", () => {
+  test("handles .graphql and .gql files", () => {
+    expect(LSPServer.GraphQL.extensions).toEqual([".graphql", ".gql"])
+  })
+
+  test("nearest graphql config wins over the workspace root", async () => {
+    const workspace = path.join(tmpBase, "config-in-subdir")
+    const projectDir = path.join(workspace, "api")
+    await touch(path.join(projectDir, ".graphqlrc.yml"))
+    await touch(path.join(projectDir, "schema.graphql"))
+
+    const result = await LSPServer.GraphQL.root(path.join(projectDir, "schema.graphql"), makeCtx(workspace))
+    expect(result).toBe(projectDir)
+  })
+
+  test("graphql.config.ts is recognized", async () => {
+    const workspace = path.join(tmpBase, "config-ts")
+    await touch(path.join(workspace, "graphql.config.ts"))
+    await touch(path.join(workspace, "query.gql"))
+
+    const result = await LSPServer.GraphQL.root(path.join(workspace, "query.gql"), makeCtx(workspace))
+    expect(result).toBe(workspace)
+  })
+
+  test("does not start without a graphql config", async () => {
+    const workspace = path.join(tmpBase, "no-config")
+    await touch(path.join(workspace, "schema.graphql"))
+
+    const result = await LSPServer.GraphQL.root(path.join(workspace, "schema.graphql"), makeCtx(workspace))
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -25,6 +25,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installed                                         |
 | gleam              | .gleam                                                              | `gleam` command available                                    |
 | gopls              | .go                                                                 | `go` command available                                       |
+| graphql            | .graphql, .gql                                                      | Auto-installs for projects with a GraphQL config             |
 | hls                | .hs, .lhs                                                           | `haskell-language-server-wrapper` command available          |
 | jdtls              | .java                                                               | `Java SDK (version 21+)` installed                           |
 | julials            | .jl                                                                 | `julia` and `LanguageServer.jl` installed                    |


### PR DESCRIPTION
### Issue for this PR

No open issue. Prior art: #9310 added the same server and was closed by the stale bot after 60 days, not rejected on review, a closing message invited a new PR.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `graphql-language-service-cli` as a built-in LSP for `.graphql` / `.gql`. Prettier already formats those extensions and biome claims them, but nothing provides GraphQL diagnostics or completion.

It follows the same npm auto-install shape as `yaml-ls` and `dockerfile`. Two details worth mentioning here for review:

- The server defaults to a **node IPC** channel, so it is started with `-m stream` to get stdio. Without that flag it starts but the problem is that it never answers the client.
- Root detection uses `StrictNearestRoot` on `.graphqlrc.*` / `graphql.config.*`, so a stray `.graphql` file in an unrelated project doesnt trigger a nearly 240-package install. No config, no server.

Also registers the id in `builtinServerIds` and maps the extensions in `LANGUAGE_EXTENSIONS`, which the server needs to be configurable and to send a correct languageId.

### How did you verify your code works?

Fully tested against a real project, including the unit tests:

1. Wrote a `.graphqlrc.yml` plus a deliberately broken `schema.graphql` (`type Query {` / `  hello: Strin`) in a temp instance, called `lsp.touchFile`, and polled `lsp.diagnostics()`. opencode auto-installed the package, spawned the server, and returned:
   `Syntax Error: Expected Name, found <EOF>` (severity 1, source "GraphQL: Syntax").
2. Verified the `initialize` handshake directly over stdio: advertises hover, completion, definition, and documentSymbol.
3. Verified the peer dependency: the CLI throws `Cannot find module 'graphql'` if peers are skipped, and confirmed npm's default resolution installs it.
4. `bun test test/lsp/ test/config/lsp.test.ts`  70 pass, 0 fail. Added `test/lsp/graphql-root.test.ts` covering the config gating, including that it does not start without a config.

### Screenshots / recordings

N/A , because there are no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
