### PR TITLE
feat(tui): show live token speed in status bar

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -39,6 +39,7 @@ import { type AutocompleteRef, Autocomplete } from "./autocomplete"
 import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { AssistantMessage, FilePart, UserMessage } from "@opencode-ai/sdk/v2"
 import { Locale } from "../../util/locale"
+import { Tps } from "../../util/tps"
 import { errorMessage } from "../../util/error"
 import { formatDuration } from "../../util/format"
 import { createColors, createFrames } from "../../ui/spinner"
@@ -279,6 +280,55 @@ export function Prompt(props: PromptProps) {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
     }
+  })
+
+  const [turnStart, setTurnStart] = createSignal(0)
+  const [tick, setTick] = createSignal(0)
+
+  createEffect(() => {
+    if (status().type !== "idle") {
+      if (turnStart() === 0) setTurnStart(Date.now())
+      return
+    }
+    if (turnStart() !== 0) setTurnStart(0)
+  })
+
+  createEffect(() => {
+    if (status().type === "idle") return
+    const timer = setInterval(() => setTick((value) => value + 1), 500)
+    onCleanup(() => clearInterval(timer))
+  })
+
+  const streamedChars = createMemo(() => {
+    if (!props.sessionID) return 0
+    const messages = sync.data.message[props.sessionID] ?? []
+    const current = messages.findLast((item) => item.role === "assistant")
+    if (!current) return 0
+    const parts = sync.data.part[current.id] ?? []
+    return parts.reduce((sum, part) => {
+      if (part.type === "text" && !part.synthetic) return sum + part.text.length
+      if (part.type === "reasoning") return sum + part.text.length
+      return sum
+    }, 0)
+  })
+
+  // Live estimate while streaming (exact counts only land at step-finish),
+  // exact per-response average once the turn completes.
+  const speed = createMemo(() => {
+    if (status().type !== "idle") {
+      tick()
+      const start = turnStart()
+      if (!start) return undefined
+      const elapsed = Date.now() - start
+      if (elapsed < 500) return undefined
+      return Tps.formatTps(Tps.calcTps(Tps.estimateOutputTokens(streamedChars()), elapsed))
+    }
+    const messages = props.sessionID ? (sync.data.message[props.sessionID] ?? []) : []
+    const last = messages.findLast(
+      (item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0,
+    )
+    if (!last?.time.completed) return undefined
+    return Tps.formatTps(Tps.calcTps(last.tokens.output, last.time.completed - last.time.created))
   })
 
   const [store, setStore] = createStore<{
@@ -1590,6 +1640,13 @@ export function Prompt(props: PromptProps) {
                     {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
                   </span>
                 </text>
+                <Show when={speed()}>
+                  {(value) => (
+                    <text fg={theme.textMuted} wrapMode="none">
+                      · {value()}
+                    </text>
+                  )}
+                </Show>
               </box>
             </Match>
             <Match when={workspace.notice()}>
@@ -1665,7 +1722,7 @@ export function Prompt(props: PromptProps) {
                     <Match when={usage()}>
                       {(item) => (
                         <text fg={theme.textMuted} wrapMode="none">
-                          {[item().context, item().cost].filter(Boolean).join(" · ")}
+                          {[item().context, item().cost, speed()].filter(Boolean).join(" · ")}
                         </text>
                       )}
                     </Match>

--- a/packages/tui/src/util/tps.ts
+++ b/packages/tui/src/util/tps.ts
@@ -1,0 +1,21 @@
+// Average characters per output token. Used to estimate live generation
+// throughput while exact token counts are still streaming (they only
+// materialize at step-finish). Final averages always use real counts.
+export const CHARS_PER_TOKEN = 4
+
+export function estimateOutputTokens(chars: number) {
+  if (!chars) return 0
+  return Math.floor(chars / CHARS_PER_TOKEN)
+}
+
+export function calcTps(outputTokens: number, elapsedMs: number) {
+  if (outputTokens <= 0 || elapsedMs <= 0) return 0
+  return outputTokens / (elapsedMs / 1000)
+}
+
+export function formatTps(tps: number) {
+  if (!Number.isFinite(tps) || tps <= 0) return undefined
+  return `${tps.toFixed(1)} t/s`
+}
+
+export * as Tps from "./tps"

--- a/packages/tui/test/util/tps.test.ts
+++ b/packages/tui/test/util/tps.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { calcTps, CHARS_PER_TOKEN, estimateOutputTokens, formatTps } from "../../src/util/tps"
+
+describe("util.tps", () => {
+  describe("estimateOutputTokens", () => {
+    test("estimates from character count", () => {
+      expect(CHARS_PER_TOKEN).toBe(4)
+      expect(estimateOutputTokens(0)).toBe(0)
+      expect(estimateOutputTokens(2)).toBe(0)
+      expect(estimateOutputTokens(8)).toBe(2)
+    })
+  })
+
+  describe("calcTps", () => {
+    test("returns zero for empty input", () => {
+      expect(calcTps(0, 1000)).toBe(0)
+      expect(calcTps(100, 0)).toBe(0)
+      expect(calcTps(-5, 1000)).toBe(0)
+      expect(calcTps(100, -1)).toBe(0)
+    })
+
+    test("computes tokens per second", () => {
+      expect(calcTps(150, 1000)).toBe(150)
+      expect(calcTps(75, 5000)).toBe(15)
+    })
+  })
+
+  describe("formatTps", () => {
+    test("formats with one decimal", () => {
+      expect(formatTps(15.24)).toBe("15.2 t/s")
+      expect(formatTps(150)).toBe("150.0 t/s")
+    })
+
+    test("returns undefined for non-positive values", () => {
+      expect(formatTps(0)).toBeUndefined()
+      expect(formatTps(-1)).toBeUndefined()
+      expect(formatTps(Number.NaN)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
﻿Closes #47914

Shows real-time token generation speed in the TUI prompt status bar, Hermes-style (`15.2 t/s`).

- While streaming: rolling estimate from streamed text (`chars / 4` per token) over elapsed turn time, refreshed every 500ms next to the `esc interrupt` hint. Exact counts only materialize at step-finish, so live values are estimates by design.
- After the turn completes: exact per-response average from `tokens.output / (completed - created)`, appended to the existing usage line (`12.3K (42%) · `$0.12` · 48.0 t/s`).
- New pure helpers in `packages/tui/src/util/tps.ts` with unit tests (`estimateOutputTokens`, `calcTps`, `formatTps`).

Verification:
- `bun typecheck` in `packages/tui`: clean.
- `bun test` in `packages/tui`: 197 pass, 1 pre-existing Windows-only failure in `test/runtime.test.tsx` (path separator, fails on clean tree too).

Follow-ups (not in scope): subagent footer parity, `--mini` run footer, session-wide average, `display.show_output_speed` toggle if maintainers want it opt-in.
