### PR TITLE
fix(desktop): skip differential updates when the cache is stale

### DIFF
--- a/packages/desktop/src/main/updater/index.test.ts
+++ b/packages/desktop/src/main/updater/index.test.ts
@@ -9,7 +9,8 @@ afterEach(async () => {
 })
 
 // Drives the updater the way the app does: start or check, then install like a button click. `calls` records the platform
-// operations in order; installs record the staged version they would apply.
+// operations in order; downloads record whether a differential download was allowed and installs record the staged
+// version they would apply.
 function setup(input?: {
   currentVersion?: string
   ready?: { version: string }
@@ -29,10 +30,11 @@ function setup(input?: {
         },
         catch: (error) => error,
       }),
-      stageUpdate: Effect.tryPromise(async () => {
-        calls.push("download")
-        await input?.stage?.()
-      }),
+      stageUpdate: (options) =>
+        Effect.tryPromise(async () => {
+          calls.push(options.differential ? "download" : "download:full")
+          await input?.stage?.()
+        }),
       installAndRestart: Effect.suspend(() => {
         calls.push(`install:${ready?.version}`)
         return Effect.tryPromise({
@@ -76,6 +78,7 @@ describe("updater", () => {
 
     await app.updater.start()
 
+    expect(app.calls).toEqual(["check", "download"])
     expect(await app.updater.getState()).toEqual({ status: "ready", version: "2.0.0" })
     expect(app.getReady()).toEqual({ version: "2.0.0" })
   })
@@ -90,13 +93,35 @@ describe("updater", () => {
     expect(app.getReady()).toBeUndefined()
   })
 
-  test("revalidates a persisted target through the updater cache on launch", async () => {
+  test("revalidates a persisted target through the updater cache on launch without a differential download", async () => {
     const app = setup({ ready: { version: "2.0.0" } })
 
     await app.updater.start()
 
-    expect(app.calls).toEqual(["check", "download"])
+    expect(app.calls).toEqual(["check", "download:full"])
     expect(await app.updater.getState()).toEqual({ status: "ready", version: "2.0.0" })
+  })
+
+  test("keeps differential downloads after the persisted target was installed", async () => {
+    const app = setup({ currentVersion: "2.0.0", ready: { version: "2.0.0" }, latest: () => "3.0.0" })
+
+    await app.updater.start()
+
+    expect(app.calls).toEqual(["check", "download"])
+    expect(await app.updater.getState()).toEqual({ status: "ready", version: "3.0.0" })
+    expect(app.getReady()).toEqual({ version: "3.0.0" })
+  })
+
+  test("downloads newer releases in full once one is staged", async () => {
+    let latest = "2.0.0"
+    const app = setup({ latest: () => latest })
+    await app.updater.start()
+
+    latest = "3.0.0"
+    await app.updater.check()
+
+    expect(app.calls).toEqual(["check", "download", "check", "download:full"])
+    expect(await app.updater.getState()).toEqual({ status: "ready", version: "3.0.0" })
   })
 
   test("concurrent checks share one platform check", async () => {
@@ -140,7 +165,7 @@ describe("updater", () => {
 
     expect(await app.updater.getState()).toEqual({ status: "installing", version: "2.0.0" })
     await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(app.calls).toEqual(["check", "download", "check", "download", "prepare", "install:3.0.0"])
+    expect(app.calls).toEqual(["check", "download", "check", "download:full", "prepare", "install:3.0.0"])
     expect(await app.updater.getState()).toEqual({ status: "installing", version: "3.0.0" })
   })
 
@@ -220,7 +245,7 @@ describe("updater", () => {
     await refresh
     expect(await app.updater.getState()).toEqual({ status: "installing", version: "3.0.0" })
     await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(app.calls).toEqual(["check", "download", "check", "download", "prepare", "install:3.0.0"])
+    expect(app.calls).toEqual(["check", "download", "check", "download:full", "prepare", "install:3.0.0"])
   })
 
   test("returns to ready after a failed installation and allows a retry", async () => {

--- a/packages/desktop/src/main/updater/index.ts
+++ b/packages/desktop/src/main/updater/index.ts
@@ -8,7 +8,7 @@ import { emitIpcEvent } from "../ipc-events"
 
 export type Platform = {
   readonly checkForUpdate: Effect.Effect<string | undefined, unknown>
-  readonly stageUpdate: Effect.Effect<unknown, unknown>
+  readonly stageUpdate: (options: { readonly differential: boolean }) => Effect.Effect<unknown, unknown>
   readonly installAndRestart: Effect.Effect<never, unknown>
   readonly dispose: () => void
 }
@@ -55,6 +55,22 @@ export const make = Effect.fn("Updater.make")(function* (dependencies: Dependenc
     listeners.forEach((listener) => listener(state))
     return state
   }
+  // electron-updater builds NSIS deltas against the installer of the running version but reads the "old" blockmap from
+  // the last download. Once a release is staged without installing, the two no longer match and every later delta fails
+  // its checksum before falling back to a full download, so remember which release the cache holds and skip the attempt.
+  let downloaded: string | undefined
+  const stage = (platform: Platform, version: string) =>
+    Effect.gen(function* () {
+      if (downloaded)
+        yield* Effect.logInfo("skipping differential download, updater cache is stale", {
+          current: dependencies.currentVersion,
+          staged: downloaded,
+          version,
+        })
+      yield* platform.stageUpdate({ differential: !downloaded })
+      downloaded = version
+      yield* dependencies.persistence.set({ version })
+    })
   const findAndStage = (platform: Platform) =>
     Effect.gen(function* () {
       yield* Effect.sync(() => transition({ status: "checking" }))
@@ -64,8 +80,7 @@ export const make = Effect.fn("Updater.make")(function* (dependencies: Dependenc
         return transition({ status: "up-to-date" })
       }
       transition({ status: "downloading", version })
-      yield* platform.stageUpdate
-      yield* dependencies.persistence.set({ version })
+      yield* stage(platform, version)
       return transition({ status: "ready", version })
     }).pipe(
       Effect.catch((error) =>
@@ -78,8 +93,7 @@ export const make = Effect.fn("Updater.make")(function* (dependencies: Dependenc
     Effect.gen(function* () {
       const version = yield* platform.checkForUpdate
       if (!version || version === staged || version === dependencies.currentVersion) return state
-      yield* platform.stageUpdate
-      yield* dependencies.persistence.set({ version })
+      yield* stage(platform, version)
       return transition({ status: installing ? "installing" : "ready", version })
     }).pipe(
       Effect.catch((error) =>
@@ -137,6 +151,8 @@ export const make = Effect.fn("Updater.make")(function* (dependencies: Dependenc
   const start = Effect.gen(function* () {
     const ready = yield* dependencies.persistence.get
     if (ready?.version === dependencies.currentVersion) yield* dependencies.persistence.clear
+    // Any other persisted target was downloaded by an earlier launch and never installed, so its blockmap is cached.
+    if (ready && ready.version !== dependencies.currentVersion) downloaded = ready.version
     yield* check
   })
   const unsubscribe = (id: number) => {

--- a/packages/desktop/src/main/updater/platform.ts
+++ b/packages/desktop/src/main/updater/platform.ts
@@ -37,16 +37,21 @@ export const make = Effect.gen(function* () {
       },
       catch: (error) => error,
     }),
-    stageUpdate: stageUpdate(),
+    stageUpdate,
     installAndRestart,
     dispose: () => autoUpdater.off("before-quit-for-update", beforeQuit),
   } satisfies Platform
 })
 
-function stageUpdate() {
+function stageUpdate(options: { readonly differential: boolean }) {
   if (process.platform !== "darwin")
     return Effect.tryPromise({
-      try: () => updateClient.downloadUpdate(),
+      try: () => {
+        // Only the NSIS cache goes stale: macOS refreshes its cached zip with every download and AppImage reads the
+        // blockmap embedded in the running file.
+        updateClient.disableDifferentialDownload = process.platform === "win32" && !options.differential
+        return updateClient.downloadUpdate()
+      },
       catch: (error) => error,
     }).pipe(Effect.asVoid)
 


### PR DESCRIPTION
## Root cause

- electron-updater's NSIS differential download computes the delta against `<cache>/installer.exe`, which the NSIS installer writes at **install** time, so it always describes the running version.
- The "old" blockmap comes from `<cache>/current.blockmap`, which `executeDownload` overwrites with the blockmap of every **downloaded** version.
- The desktop updater stages downloads without installing and keeps refreshing the staged release every 10 minutes. After the first staged download the cached blockmap describes the staged installer, not the running one, so every later delta fails with `sha512 checksum mismatch` and falls back to a full download.
- Production `main.log` for a single day: 4 failed deltas (≈20–52 MB each) followed by 4 full ≈200 MB installers, ≈800 MB in total.

## Fix

`Platform.stageUpdate` now takes `{ differential }`. The updater remembers which release the cache holds (a persisted `ready` version that is not the running one, or any release staged in this process) and turns differential downloads off while that is the case.

```ts
const stage = (platform: Platform, version: string) =>
  Effect.gen(function* () {
    if (downloaded)
      yield* Effect.logInfo("skipping differential download, updater cache is stale", {
        current: dependencies.currentVersion,
        staged: downloaded,
        version,
      })
    yield* platform.stageUpdate({ differential: !downloaded })
    downloaded = version
    yield* dependencies.persistence.set({ version })
  })
```

```ts
// platform.ts
updateClient.disableDifferentialDownload = process.platform === "win32" && !options.differential
return updateClient.downloadUpdate()
```

```mermaid
flowchart LR
  A[check every 10 min] --> B{newer version?}
  B -- no --> Z[keep state]
  B -- yes --> C{cache holds another<br/>downloaded release?}
  C -- no --> D[stage with differential]
  C -- yes --> E[log skip, stage full download]
  D --> F[remember downloaded version]
  E --> F
```

- macOS and AppImage are unaffected: macOS refreshes its cached zip and blockmap on every download, and AppImage reads the blockmap embedded in the running file, so the flag is only applied on Windows.
- The 10-minute cadence and the staging policy are unchanged.

## Before / after (one production day, four staged releases)

|        | Failed delta attempts | Wasted delta payload | Full downloads | Total downloaded |
| ------ | --------------------- | -------------------- | -------------- | ---------------- |
| Before | 4                     | ≈20–52 MB each       | 4 × ≈200 MB    | ≈900–1000 MB     |
| After  | 0                     | 0                    | 4 × ≈200 MB    | ≈800 MB          |
