### PR TITLE
fix(session-ui): stop refetching missing shell output

### DIFF
--- a/packages/session-ui/src/tools/shell-output.test.ts
+++ b/packages/session-ui/src/tools/shell-output.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test, vi } from "bun:test"
+import type { ShellOutputInput, ShellOutputOutput } from "@opencode/client/promise"
+import { followShellOutput, SHELL_OUTPUT_TAIL_BYTES } from "./shell-output"
+
+const location = { directory: "/repo", project: { id: "project", directory: "/repo", canonical: "/repo" } }
+
+// Serves the current text from the requested cursor, at most one page per request.
+function server(text: () => string, page = Infinity) {
+  const cursors: number[] = []
+  return {
+    cursors,
+    load: (input: ShellOutputInput): Promise<ShellOutputOutput> => {
+      const cursor = input.cursor ?? 0
+      cursors.push(cursor)
+      const full = text()
+      const output = full.slice(cursor, cursor + page)
+      return Promise.resolve({
+        location,
+        data: { output, cursor: cursor + output.length, size: full.length, truncated: false },
+      })
+    },
+  }
+}
+
+// Reads settle within a few microtasks; timers are faked so this never waits on the clock.
+async function flush() {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+
+describe("followShellOutput", () => {
+  test("stops polling a missing shell and never requests it again", async () => {
+    vi.useFakeTimers()
+    try {
+      const cursors: number[] = []
+      const load = (input: ShellOutputInput): Promise<ShellOutputOutput> => {
+        cursors.push(input.cursor ?? 0)
+        return Promise.reject({ _tag: "ShellNotFoundError", id: input.id, message: "Shell command not found" })
+      }
+      const follow = () =>
+        followShellOutput({ id: "shell_missing", directory: "/repo", running: true, load, onOutput() {} })
+
+      const stop = follow()
+      await flush()
+      expect(cursors).toEqual([0])
+
+      vi.advanceTimersByTime(10_000)
+      await flush()
+      expect(cursors).toEqual([0])
+
+      stop()
+      const remounted = follow()
+      await flush()
+      vi.advanceTimersByTime(10_000)
+      remounted()
+      expect(cursors).toEqual([0])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test("polls a running shell once per second and resumes from the cached cursor after a remount", async () => {
+    vi.useFakeTimers()
+    try {
+      let text = "hello\n"
+      const shell = server(() => text)
+      const outputs: string[] = []
+      const follow = (running: boolean) =>
+        followShellOutput({
+          id: "shell_live",
+          directory: "/repo",
+          running,
+          load: shell.load,
+          onOutput: (output) => outputs.push(output),
+        })
+
+      const first = follow(true)
+      await flush()
+      expect(outputs.at(-1)).toBe("hello\n")
+
+      text += "world\n"
+      vi.advanceTimersByTime(1_000)
+      await flush()
+      expect(shell.cursors).toEqual([0, 6])
+      expect(outputs.at(-1)).toBe("hello\nworld\n")
+
+      first()
+      text += "done\n"
+      const second = follow(true)
+      await flush()
+      expect(shell.cursors).toEqual([0, 6, 12])
+      expect(outputs.at(-1)).toBe("hello\nworld\ndone\n")
+
+      second()
+      const exited = follow(false)
+      await flush()
+      exited()
+      expect(shell.cursors).toEqual([0, 6, 12, 17])
+
+      outputs.length = 0
+      follow(false)()
+      await flush()
+      expect(shell.cursors).toEqual([0, 6, 12, 17])
+      expect(outputs).toEqual(["hello\nworld\ndone\n"])
+
+      // The running-shell inventory can arrive late; a complete shell believed to be live is re-read from its cursor.
+      follow(true)()
+      expect(shell.cursors).toEqual([0, 6, 12, 17, 17])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test("keeps only the most recent tail of a large output", async () => {
+    const shell = server(() => "a".repeat(SHELL_OUTPUT_TAIL_BYTES) + "tail", SHELL_OUTPUT_TAIL_BYTES)
+    const outputs: string[] = []
+    followShellOutput({
+      id: "shell_large",
+      directory: "/repo",
+      running: false,
+      load: shell.load,
+      onOutput: (output) => outputs.push(output),
+    })
+    await flush()
+    expect(shell.cursors).toEqual([0, SHELL_OUTPUT_TAIL_BYTES])
+    expect(outputs.at(-1)?.length).toBe(SHELL_OUTPUT_TAIL_BYTES)
+    expect(outputs.at(-1)?.endsWith("a".repeat(8) + "tail")).toBe(true)
+  })
+})

--- a/packages/session-ui/src/tools/shell-output.ts
+++ b/packages/session-ui/src/tools/shell-output.ts
@@ -1,0 +1,74 @@
+import { isShellNotFoundError, type ShellOutputInput, type ShellOutputOutput } from "@opencode/client/promise"
+
+// Same page size as the TUI shell output viewer; only this much recent output is retained and rendered.
+export const SHELL_OUTPUT_TAIL_BYTES = 64 * 1024
+const PROGRESS_LIMIT = 32
+
+type Progress = { cursor: number; output: string; state: "partial" | "complete" | "missing" }
+
+// Virtualized timelines remount shell tools frequently. Progress is remembered per shell so a
+// remount resumes from its cursor instead of re-reading from zero, and so a shell the server no
+// longer knows is never requested again.
+const progress = new Map<string, Progress>()
+
+function remember(id: string, entry: Progress) {
+  progress.delete(id)
+  progress.set(id, entry)
+  if (progress.size <= PROGRESS_LIMIT) return
+  const oldest = progress.keys().next().value
+  if (oldest !== undefined) progress.delete(oldest)
+}
+
+export function followShellOutput(input: {
+  id: string
+  directory: string
+  running: boolean
+  load: (input: ShellOutputInput) => Promise<ShellOutputOutput>
+  onOutput: (output: string) => void
+}) {
+  const cached = progress.get(input.id)
+  if (cached) {
+    remember(input.id, cached)
+    input.onOutput(cached.output)
+  }
+  // A missing shell never comes back. A complete one is only re-read while the shell is believed to be
+  // running, because the running-shell inventory can arrive after history has already rendered.
+  if (cached?.state === "missing" || (cached?.state === "complete" && !input.running)) return () => {}
+  let cursor = cached?.cursor ?? 0
+  let text = cached?.output ?? ""
+  let loading = false
+  let disposed = false
+  const read = async () => {
+    if (loading) return
+    loading = true
+    while (true) {
+      const page = await input.load({ id: input.id, location: { directory: input.directory }, cursor }).then(
+        (response) => response.data,
+        (cause: unknown) => (isShellNotFoundError(cause) ? "missing" : undefined),
+      )
+      if (disposed) break
+      if (page === "missing") {
+        // The server drops exited shells past its retention limit; stop asking for this one.
+        remember(input.id, { cursor, output: text, state: "missing" })
+        clearInterval(interval)
+        break
+      }
+      if (!page) break
+      const advanced = page.cursor > cursor
+      cursor = Math.max(cursor, page.cursor)
+      text = (text + page.output).slice(-SHELL_OUTPUT_TAIL_BYTES)
+      const complete = !input.running && cursor >= page.size
+      remember(input.id, { cursor, output: text, state: complete ? "complete" : "partial" })
+      input.onOutput(text)
+      if (input.running || complete || !advanced) break
+    }
+    loading = false
+  }
+  void read()
+  // Refresh the final snapshot on exit, but poll only while the shell is live.
+  const interval = input.running ? setInterval(() => void read(), 1_000) : undefined
+  return () => {
+    disposed = true
+    clearInterval(interval)
+  }
+}

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -51,6 +51,7 @@ import {
   executeToolFailed,
 } from "../message/current-tool-state"
 import { AssistantReasoningContent, writeClipboard } from "../message/message-content"
+import { followShellOutput } from "./shell-output"
 
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
@@ -1629,33 +1630,9 @@ ToolRegistry.register({
     createEffect(() => {
       if (saved() !== undefined) return
       const id = props.metadata.shellID
-      const shellOutput = data.shellOutput
-      if (typeof id !== "string" || !shellOutput) return
-      const directory = data.directory
-      const running = pending()
-      let cursor = 0
-      let loading = false
-      let disposed = false
-      const load = async () => {
-        if (loading) return
-        loading = true
-        do {
-          const response = await shellOutput({ id, location: { directory }, cursor }).catch(() => undefined)
-          if (disposed || !response) break
-          setStreamed((output) => (cursor === 0 ? response.data.output : output + response.data.output))
-          if (response.data.cursor <= cursor) break
-          cursor = response.data.cursor
-          if (running || cursor >= response.data.size) break
-        } while (!disposed)
-        loading = false
-      }
-      void load()
-      // Refresh the final snapshot on exit, but poll only while the shell is live.
-      const interval = running ? setInterval(() => void load(), 1_000) : undefined
-      onCleanup(() => {
-        disposed = true
-        clearInterval(interval)
-      })
+      const load = data.shellOutput
+      if (typeof id !== "string" || !load) return
+      onCleanup(followShellOutput({ id, directory: data.directory, running: pending(), load, onOutput: setStreamed }))
     })
     const command = () => {
       if (typeof props.input.command === "string") return props.input.command


### PR DESCRIPTION
The shell tool in the session timeline re-downloaded output from `cursor=0` on every remount and kept polling a shell the server had already forgotten. This moves the polling into `followShellOutput` (`packages/session-ui/src/tools/shell-output.ts`), which treats not-found as terminal, resumes from a per-shell cursor, and keeps only a bounded tail.

## Production numbers

| | Before | After |
| --- | --- | --- |
| Missing shell (`ShellNotFoundError`, 404) | 89 requests for one shell ID in 15 min (105 total), error swallowed, 1s interval kept running | 1 request, then stop; remounts do not ask again |
| Remount of a completed shell in the virtualized timeline | Same output URL fetched 10× from `cursor=0` | Resume from the cached cursor; fully read shells are not refetched |
| Retained output | Unbounded string, `stripAnsi` over the whole thing on every update | Last 64 KiB (`SHELL_OUTPUT_TAIL_BYTES`, same as the TUI `PAGE_BYTES`), `stripAnsi` runs on the tail only |

## How it works

```mermaid
sequenceDiagram
  participant Tool as shell tool (remount)
  participant Cache as progress cache (LRU 32, by shell ID)
  participant API as GET /shell/:id/output
  Tool->>Cache: get(shellID)
  alt missing, or complete and not running
    Cache-->>Tool: cached output, no request
  else partial
    Cache-->>Tool: { cursor, output }
    Tool->>API: output?cursor=N
    alt 200
      API-->>Tool: page
      Tool->>Cache: { cursor, tail, partial | complete }
    else 404 ShellNotFoundError
      Tool->>Cache: state = missing
      Tool-->>Tool: clearInterval, never refetch
    end
  end
```

```ts
const page = await input.load({ id, location: { directory }, cursor }).then(
  (response) => response.data,
  (cause: unknown) => (isShellNotFoundError(cause) ? "missing" : undefined),
)
if (page === "missing") {
  remember(id, { cursor, output: text, state: "missing" })
  clearInterval(interval)
  break
}
text = (text + page.output).slice(-SHELL_OUTPUT_TAIL_BYTES)
remember(id, { cursor, output: text, state: !running && cursor >= page.size ? "complete" : "partial" })
```

- Not-found detection uses `isShellNotFoundError` from `@opencode/client/promise`, the same predicate the TUI `dialog-shell-output.tsx` already uses; session-ui does not import from the app.
- A `complete` shell is re-read from its cursor only while it is believed to be running, so a late-arriving running-shell inventory on initial load cannot freeze a live background shell.
- Unchanged: poll once per second only while running, one final read on exit, transient errors keep polling, and `saved()` output for direct-user terminal snapshots still wins.
