### PR TITLE
fix(client): coalesce catalog refetches after event bursts

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -1142,13 +1142,16 @@ export function createData(config: CreateDataInput) {
         return
     }
 
+    // Catalog events arrive in bursts. A Desktop capture showed catalog.updated, integration.updated,
+    // and credential.updated for one location within ~190 ms, each refetching the same ~270 KB model
+    // list. The catalogs below invalidate now and settle into one refetch per resource and location.
     if (event.type === "credential.updated" || event.type === "credential.switched") {
       Object.keys(store.location).forEach((key) => {
         const ref = JSON.parse(key) as [string, string | null]
         const location = { directory: ref[0], workspaceID: ref[1] ?? undefined }
         if (event.type === "credential.updated") {
           result.location.integration.invalidate(location)
-          refresh(() => result.location.integration.sync(location))
+          settle(`location.integration:${key}`, () => result.location.integration.sync(location))
           return
         }
         setStore("location", key, (data) => ({
@@ -1166,7 +1169,8 @@ export function createData(config: CreateDataInput) {
         }))
         result.location.model.invalidate(location)
         result.location.provider.invalidate(location)
-        refresh(() => Promise.all([result.location.model.sync(location), result.location.provider.sync(location)]))
+        settle(`location.model:${key}`, () => result.location.model.sync(location))
+        settle(`location.provider:${key}`, () => result.location.provider.sync(location))
       })
       return
     }
@@ -1177,19 +1181,20 @@ export function createData(config: CreateDataInput) {
       case "catalog.updated":
         result.location.model.invalidate(location)
         result.location.provider.invalidate(location)
-        refresh(() => Promise.all([result.location.model.sync(location), result.location.provider.sync(location)]))
+        settle(`location.model:${locationKey(location)}`, () => result.location.model.sync(location))
+        settle(`location.provider:${locationKey(location)}`, () => result.location.provider.sync(location))
         break
       case "agent.updated":
         result.location.agent.invalidate(location)
-        refresh(() => result.location.agent.sync(location))
+        settle(`location.agent:${locationKey(location)}`, () => result.location.agent.sync(location))
         break
       case "command.updated":
         result.location.command.invalidate(location)
-        refresh(() => result.location.command.sync(location))
+        settle(`location.command:${locationKey(location)}`, () => result.location.command.sync(location))
         break
       case "skill.updated":
         result.location.skill.invalidate(location)
-        refresh(() => result.location.skill.sync(location))
+        settle(`location.skill:${locationKey(location)}`, () => result.location.skill.sync(location))
         break
       case "vcs.branch.updated":
         setStore("location", locationKey(location), (data) => ({
@@ -1224,39 +1229,35 @@ export function createData(config: CreateDataInput) {
         break
       case "reference.updated":
         result.location.reference.invalidate(location)
-        refresh(() => result.location.reference.sync(location))
+        settle(`location.reference:${locationKey(location)}`, () => result.location.reference.sync(location))
         break
       case "integration.updated":
         result.location.integration.invalidate(location)
         result.location.model.invalidate(location)
         result.location.provider.invalidate(location)
-        refresh(() =>
-          Promise.all([
-            result.location.integration.sync(location),
-            result.location.model.sync(location),
-            result.location.provider.sync(location),
-          ]),
-        )
+        settle(`location.integration:${locationKey(location)}`, () => result.location.integration.sync(location))
+        settle(`location.model:${locationKey(location)}`, () => result.location.model.sync(location))
+        settle(`location.provider:${locationKey(location)}`, () => result.location.provider.sync(location))
         break
       case "config.updated":
         result.location.config.invalidate(location)
         if (result.location.config.list(location) !== undefined || sync.has(`location.config:${locationKey(location)}`))
-          refresh(() => result.location.config.sync(location))
-        refresh(() => result.location.websearch.refresh(location))
+          settle(`location.config:${locationKey(location)}`, () => result.location.config.sync(location))
+        settle(`location.websearch:${locationKey(location)}`, () => result.location.websearch.refresh(location))
         break
       case "websearch.updated":
-        refresh(() => result.location.websearch.refresh(location))
+        settle(`location.websearch:${locationKey(location)}`, () => result.location.websearch.refresh(location))
         break
       // Authenticating an MCP integration reconnects its server, which emits mcp.status.changed,
       // so the mcp list syncs here rather than off integration.updated. The server emits one event
       // per MCP server as each settles, so a location booting nine servers emitted nine refetches.
       case "mcp.status.changed":
         result.location.mcp.server.invalidate(location)
-        settle(`mcp.status:${locationKey(location)}`, () => result.location.mcp.server.sync(location))
+        settle(`location.mcpServer:${locationKey(location)}`, () => result.location.mcp.server.sync(location))
         break
       case "mcp.resources.changed":
         result.location.mcp.resource.invalidate(location)
-        refresh(() => result.location.mcp.resource.sync(location))
+        settle(`location.mcpResource:${locationKey(location)}`, () => result.location.mcp.resource.sync(location))
         break
     }
   }

--- a/packages/client/test/solid-refresh.test.ts
+++ b/packages/client/test/solid-refresh.test.ts
@@ -153,11 +153,14 @@ test.each(["reconnecting", "disposed"] as const)("background reads respect %s ow
     data: {},
   }
   listeners.forEach((listener) => listener({ name: event.type, details: event }))
+  expect(state.requests).toBe(0)
+  await new Promise((resolve) => setTimeout(resolve, settleMs * 2))
   if (mode === "reconnecting") {
     expect(state.requests).toBe(0)
     setup.dispose()
     return
   }
+  expect(state.requests).toBe(1)
   const joined = setup.data.location.command.sync()
   setup.dispose()
   pending.reject(new TypeError("Failed to fetch"))
@@ -202,6 +205,67 @@ test("a burst of mcp.status.changed events refetches the server list once it set
     expect(requests.filter((path) => path === "/api/mcp")).toHaveLength(1)
     await new Promise((resolve) => setTimeout(resolve, settleMs * 2))
     expect(requests.filter((path) => path === "/api/mcp")).toHaveLength(2)
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("a burst of catalog, integration, and credential events refetches each catalog once per location", async () => {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const requests: string[] = []
+  const location = { directory: "/project" }
+  const other = { directory: "/other", workspaceID: "workspace-other" }
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      const url = new URL(request.url)
+      requests.push(`${url.pathname} ${url.searchParams.get("location[directory]")}`)
+      return Response.json({
+        location: {
+          directory: url.searchParams.get("location[directory]"),
+          workspaceID: url.searchParams.get("location[workspace]") ?? undefined,
+        },
+        data: [],
+      })
+    },
+  })
+  const setup = createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: location.directory,
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+    }),
+    dispose,
+  }))
+  const emit = (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details }))
+  try {
+    await Promise.all(
+      [location, other].flatMap((ref) => [
+        setup.data.location.integration.sync(ref),
+        setup.data.location.model.sync(ref),
+        setup.data.location.provider.sync(ref),
+      ]),
+    )
+    requests.length = 0
+    emit({ id: "evt_catalog", created: 1, type: "catalog.updated", location, data: {} })
+    emit({ id: "evt_integration", created: 2, type: "integration.updated", location, data: {} })
+    emit({ id: "evt_credential", created: 3, type: "credential.updated", data: {} })
+    emit({ id: "evt_catalog_again", created: 4, type: "catalog.updated", location, data: {} })
+    expect(requests).toEqual([])
+    await new Promise((resolve) => setTimeout(resolve, settleMs * 2))
+    expect(requests.toSorted()).toEqual([
+      "/api/integration /other",
+      "/api/integration /project",
+      "/api/model /project",
+      "/api/provider /project",
+    ])
   } finally {
     setup.dispose()
   }

--- a/packages/tui/test/cli/tui/dialog-integration.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-integration.test.tsx
@@ -66,9 +66,9 @@ test("switches the selected account with enter and keeps the reactive account ma
     expect(fixture.accounts.map((account) => account.id)).toEqual(["cred_work", "cred_personal"])
     const frame = fixture.app.captureCharFrame()
     expect(frame.indexOf("Personal")).toBeLessThan(frame.indexOf("Work"))
+    // The switch reorders connections optimistically; the catalog refetch lands once the event burst settles.
+    await fixture.app.waitFor(() => fixture.reads.model > 0 && fixture.reads.provider > 0)
     expect(fixture.reads.integration).toBe(1)
-    expect(fixture.reads.model).toBeGreaterThan(0)
-    expect(fixture.reads.provider).toBeGreaterThan(0)
   } finally {
     fixture.app.renderer.destroy()
   }


### PR DESCRIPTION
A 33-minute Desktop netlog showed `GET /api/model` fetched **16 times (~270 KB each, 4.3 MB decoded)** and `GET /api/provider` 16 times. One Location's model and provider catalogs were fetched **three times within ~190 ms** because `catalog.updated`, `integration.updated`, and `credential.updated` each answered with an immediate refetch. `/api/command` (24), `/api/mcp/resource` (22), `/api/agent`, `/api/skill`, and `/api/reference` saw the same burst pattern.

```mermaid
sequenceDiagram
  participant S as Server
  participant D as createData
  participant A as /api/model
  S->>D: catalog.updated
  S->>D: integration.updated
  S->>D: credential.updated
  Note over D: invalidate now, one settle timer per resource + Location
  D-->>D: 150 ms quiet
  D->>A: GET /api/model (once)
```

## Changes — `packages/client/src/solid/data.ts`

- Every per-Location catalog event now goes through `settle(key, load)` instead of `refresh(load)`: `catalog.updated`, `integration.updated`, `credential.updated`, `credential.switched`, `agent.updated`, `command.updated`, `skill.updated`, `reference.updated`, `config.updated`, `websearch.updated`, and `mcp.resources.changed`.
- Settle keys mirror the sync keys, `location.<field>:<locationKey>`, so different events that ask for the same catalog share one timer. `catalog.updated` and `integration.updated` for the same Location now coalesce into one model fetch and one provider fetch.
- `invalidate(...)` still runs immediately, so an explicit `sync()` during the window reads fresh data and already-published data stays visible until the reload lands. Session, permission, form, shell, and VCS handling is unchanged.

```ts
case "integration.updated":
  result.location.integration.invalidate(location)
  result.location.model.invalidate(location)
  result.location.provider.invalidate(location)
  settle(`location.integration:${locationKey(location)}`, () => result.location.integration.sync(location))
  settle(`location.model:${locationKey(location)}`, () => result.location.model.sync(location))
  settle(`location.provider:${locationKey(location)}`, () => result.location.provider.sync(location))
  break
```

| Scenario | Before | After |
| --- | --- | --- |
| `catalog.updated` + `integration.updated` + `credential.updated` for one Location in ~190 ms | 3 × `GET /api/model`, 3 × `GET /api/provider` | 1 × `GET /api/model`, 1 × `GET /api/provider` |
| 33-minute Desktop session | 16 × `GET /api/model` (4.3 MB decoded), 16 × `GET /api/provider` | 1 fetch per burst per Location |
| `/api/command`, `/api/mcp/resource`, `/api/agent`, `/api/skill`, `/api/reference` | one fetch per event (24 and 22 for the first two) | one fetch per burst per Location |

Follows #47561, which introduced `settle` for `mcp.status.changed`.
