### PR TITLE
mini: add clear-screen command

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -46,6 +46,7 @@ export const Definitions = {
   leader: keybind(LeaderDefault, "Leader key for keybind combinations"),
 
   "app.exit": keybind("ctrl+c,ctrl+d,<leader>q", "Exit the application"),
+  "app.clear": keybind("ctrl+l", "Clear the screen in mini"),
   "app.debug": keybind("none", "Toggle debug panel"),
   "app.console": keybind("none", "Toggle console"),
   "app.scrap": keybind("none", "Open scrap screen"),

--- a/packages/tui/src/mini/footer.command.tsx
+++ b/packages/tui/src/mini/footer.command.tsx
@@ -45,6 +45,7 @@ type CommandEntry =
   | (PanelEntry & { action: "variant.list" })
   | (PanelEntry & { action: "settings" })
   | (PanelEntry & { action: "slash"; name: string })
+  | (PanelEntry & { action: "clear" })
   | (PanelEntry & { action: "exit" })
 
 type ModelEntry = PanelEntry & {
@@ -411,7 +412,9 @@ export function RunCommandMenuBody(props: {
   onSettings: () => void
   onCommand: (name: string) => void
   onNew: () => void
+  onClear?: () => void
   onExit: () => void
+  clearShortcut?: string
   mono?: boolean
 }) {
   const skills = createMemo(() => (props.commands() ?? []).filter((item) => item.source === "skill"))
@@ -525,6 +528,13 @@ export function RunCommandMenuBody(props: {
       ...prompt,
       ...agent,
       {
+        action: "clear",
+        category: "System",
+        display: "Clear screen",
+        footer: props.clearShortcut,
+        keywords: "clear screen cls redraw",
+      },
+      {
         action: "settings",
         category: "System",
         display: "Settings",
@@ -582,6 +592,11 @@ export function RunCommandMenuBody(props: {
 
     if (item.action === "settings") {
       props.onSettings()
+      return
+    }
+
+    if (item.action === "clear") {
+      props.onClear?.()
       return
     }
 

--- a/packages/tui/src/mini/footer.view.tsx
+++ b/packages/tui/src/mini/footer.view.tsx
@@ -546,6 +546,26 @@ export function RunFooterView(props: RunFooterViewProps) {
     props.onRequestExit?.(undefined)
   })
 
+  const clearScreen = () => {
+    if (renderer.isDestroyed) return
+    if (renderer.screenMode !== "split-footer") return
+    if (renderer.externalOutputMode !== "capture-stdout") return
+    if (renderer.currentControlState === "explicit_suspended") return
+    // Home, erase the visible display, keep terminal scrollback, then repaint the footer.
+    renderer.resetSplitFooterForReplay({ clearSavedLines: false })
+  }
+
+  Keymap.createLayer(() => ({
+    commands: [
+      {
+        id: "app.clear",
+        title: "Clear screen",
+        group: "System",
+        run: clearScreen,
+      },
+    ],
+  }))
+
   Keymap.createLayer(() => ({
     enabled: active().type === "prompt" && route().type === "composer" && !composer.visible(),
     commands: [
@@ -831,7 +851,12 @@ export function RunFooterView(props: RunFooterViewProps) {
                               composer.submitText("/new")
                               closePanel()
                             }}
+                            onClear={() => {
+                              closePanel()
+                              clearScreen()
+                            }}
                             onExit={props.onExit}
+                            clearShortcut={shortcut("app.clear")}
                             mono={props.mono}
                           />
                         </Match>

--- a/packages/tui/test/mini/footer.responsive.test.tsx
+++ b/packages/tui/test/mini/footer.responsive.test.tsx
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
 import { RGBA, TextAttributes } from "@opentui/core"
 import { createTestRenderer } from "@opentui/core/testing"
 import { RunFooter } from "../../src/mini/footer"
@@ -143,6 +143,35 @@ test.each([false, true])(
     }
   },
 )
+
+test("ctrl+l clears the split-footer screen without wiping scrollback", async () => {
+  const app = await setup()
+  try {
+    const clear = spyOn(app.renderer, "resetSplitFooterForReplay").mockImplementation(() => {})
+    await app.settle()
+    app.mockInput.pressKey("l", { ctrl: true })
+    expect(clear).toHaveBeenCalledWith({ clearSavedLines: false })
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("command palette can clear the screen", async () => {
+  const app = await setup()
+  try {
+    const clear = spyOn(app.renderer, "resetSplitFooterForReplay").mockImplementation(() => {})
+    await app.settle()
+    app.mockInput.pressKey("p", { ctrl: true })
+    await app.settle()
+    await app.mockInput.typeText("clear screen")
+    await app.settle()
+    expect(app.selected()).toContain("Clear screen")
+    app.mockInput.pressEnter()
+    expect(clear).toHaveBeenCalledWith({ clearSavedLines: false })
+  } finally {
+    app.cleanup()
+  }
+})
 
 test.each([false, true])("production command menu keeps navigation visible across resizes (mono=%s)", async (mono) => {
   const app = await setup(mono)

--- a/packages/tui/test/mini/runtime.boot.test.ts
+++ b/packages/tui/test/mini/runtime.boot.test.ts
@@ -20,6 +20,7 @@ describe("run runtime boot", () => {
     expect(result.keybinds.get("prompt.history.previous")?.[0]?.key).toBe("up")
     expect(result.keybinds.get("prompt.history.next")?.[0]?.key).toBe("down")
     expect(result.keybinds.get("prompt.clear")?.[0]?.key).toBe("ctrl+c")
+    expect(result.keybinds.get("app.clear")?.[0]?.key).toBe("ctrl+l")
     expect(result.keybinds.get("input.submit")?.[0]?.key).toBe("return")
     expect(result.keybinds.get("input.newline")?.[0]?.key).toBe("shift+return,ctrl+return,alt+return,ctrl+j")
     expect(result.keybinds.get("prompt.queue")?.[0]?.key).toBe("<leader>return")

--- a/services/www/src/docs/content/cli/keybinds.mdx
+++ b/services/www/src/docs/content/cli/keybinds.mdx
@@ -99,6 +99,22 @@ Unknown command IDs are rejected.
 | `service.restart`          | `none`                    | Restart service                     |
 | `permission.mode`          | `none`                    | Toggle auto-approve permissions     |
 
+## Mini
+
+The `app.clear` command works only in [`opencode2 mini`](/cli). Press `ctrl+l` to clear the visible screen and draw the prompt again. The terminal keeps the scrollback.
+
+```json title="cli.json"
+{
+  "keybinds": {
+    "app.clear": "ctrl+l"
+  }
+}
+```
+
+| ID          | Default  | Description      |
+| ----------- | -------- | ---------------- |
+| `app.clear` | `ctrl+l` | Clear the screen |
+
 ## Diff Viewer
 
 Press `d` (`diff.switch_source`) to choose **All**, **Committed**, or **Uncommitted**, or select **Base** to change the comparison branch. Choices are remembered until the TUI exits. Set the initial scope with [`diffs.source` in `cli.json`](/cli/config#diffs).


### PR DESCRIPTION
Clear visible display when Ctrl+L is pressed, but keep scrollback.
