### PR TITLE
fix(mcp): preserve tool discovery failure details

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -36,7 +36,10 @@ export async function paginate<T, R extends { nextCursor?: string }>(
 }
 
 export function defs(client: Client, timeout?: number) {
-  return listTools(client, timeout ?? DEFAULT_TIMEOUT).pipe(Effect.catch(() => Effect.void))
+  return listTools(client, timeout ?? DEFAULT_TIMEOUT).pipe(
+    Effect.mapError((error) => new Error(`Failed to get tools: ${error.message}`, { cause: error })),
+    Effect.tapError((error) => Effect.logWarning("failed to get tools", { error: error.message })),
+  )
 }
 
 export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: number): Tool {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -389,9 +389,6 @@ const layer = Layer.effect(
 
         return yield* Effect.gen(function* () {
           const listed = mcpClient.getServerCapabilities()?.tools ? yield* McpCatalog.defs(mcpClient, mcp.timeout) : []
-          if (!listed) {
-            return yield* Effect.fail(new Error("Failed to get tools"))
-          }
           return {
             mcpClient,
             status,
@@ -462,7 +459,9 @@ const layer = Layer.effect(
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
         if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
-        const listed = await bridge.promise(McpCatalog.defs(client, timeout))
+        const listed = await bridge.promise(
+          McpCatalog.defs(client, timeout).pipe(Effect.orElseSucceed(() => undefined)),
+        )
         if (!listed) return
         if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
@@ -873,6 +872,8 @@ const layer = Layer.effect(
       mcpName: string,
       onAuthorization?: (authorizationUrl: string) => void,
     ) {
+      const s = yield* InstanceState.get(state)
+      const previous = s.status[mcpName]
       const result = yield* startAuth(mcpName)
       if (!result.authorizationUrl) {
         const client = "client" in result ? result.client : undefined
@@ -880,19 +881,27 @@ const layer = Layer.effect(
           Effect.tapError(() => Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)),
         )
 
-        const listed = client
-          ? client.getServerCapabilities()?.tools
-            ? yield* McpCatalog.defs(client, mcpConfig.timeout)
-            : []
-          : undefined
-        if (!client || !listed) {
-          yield* Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)
+        if (!client) {
           return { status: "failed", error: "Failed to get tools" } satisfies Status
         }
 
-        const s = yield* InstanceState.get(state)
+        const listed = yield* (
+          client.getServerCapabilities()?.tools ? McpCatalog.defs(client, mcpConfig.timeout) : Effect.succeed([])
+        ).pipe(
+          Effect.match({
+            onFailure: (error) => ({ error }),
+            onSuccess: (defs) => ({ defs }),
+          }),
+        )
+        if ("error" in listed) {
+          yield* Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
+          const status = { status: "failed", error: listed.error.message } satisfies Status
+          // A newer add/connect may have already published a healthy connection.
+          if (s.status[mcpName] === previous) s.status[mcpName] = status
+          return status
+        }
         yield* auth.clearOAuthState(mcpName)
-        return yield* storeClient(s, mcpName, client, listed, client.getInstructions()?.trim(), mcpConfig.timeout)
+        return yield* storeClient(s, mcpName, client, listed.defs, client.getInstructions()?.trim(), mcpConfig.timeout)
       }
 
       const callbackPromise = McpOAuthCallback.waitForCallback(result.oauthState, mcpName)

--- a/packages/opencode/test/fixture/mcp-lifecycle-stdio.ts
+++ b/packages/opencode/test/fixture/mcp-lifecycle-stdio.ts
@@ -11,8 +11,10 @@ if (process.argv.includes("--hang")) {
 
 const server = new Server({ name: "mcp-lifecycle-stdio", version: "1.0.0" }, { capabilities: { tools: {} } })
 
-server.setRequestHandler(ListToolsRequestSchema, () =>
-  Promise.resolve({
+server.setRequestHandler(ListToolsRequestSchema, () => {
+  if (process.argv.includes("--tools-error")) throw new Error("fixture tool catalog unavailable")
+  if (process.argv.includes("--empty-tools")) return Promise.resolve({ tools: [] })
+  return Promise.resolve({
     tools: [
       {
         name: "current_directory",
@@ -20,7 +22,7 @@ server.setRequestHandler(ListToolsRequestSchema, () =>
         inputSchema: { type: "object", properties: {} },
       },
     ],
-  }),
-)
+  })
+})
 
 await server.connect(new StdioServerTransport())

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -2,11 +2,72 @@ import { describe, expect, test } from "bun:test"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from "@modelcontextprotocol/sdk/types.js"
 import { McpCatalog } from "@/mcp/catalog"
-import { Effect } from "effect"
+import { Effect, Logger } from "effect"
 
 const options = { toolCallId: "call_mcp", abortSignal: new AbortController().signal } as any
+
+describe("McpCatalog.defs", () => {
+  test("preserves a disconnected transport error", async () => {
+    const client = new Client({ name: "disconnected", version: "1.0.0" })
+    const error = await Effect.runPromise(McpCatalog.defs(client).pipe(Effect.flip))
+    expect(error.message).toContain("Not connected")
+  })
+
+  test.each([
+    { code: ErrorCode.MethodNotFound, message: "tools/list is not supported" },
+    { code: ErrorCode.InternalError, message: "catalog service unavailable" },
+  ])("preserves and logs protocol error: $message", async ({ code, message }) => {
+    const server = new Server({ name: "errors", version: "1.0.0" }, { capabilities: { tools: {} } })
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      throw new McpError(code, message)
+    })
+    const client = new Client({ name: "errors-test", version: "1.0.0" })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    const logs: unknown[] = []
+    try {
+      const error = await Effect.runPromise(
+        McpCatalog.defs(client).pipe(
+          Effect.flip,
+          Effect.provide(Logger.layer([Logger.make((entry) => logs.push(entry.message))])),
+        ),
+      )
+      expect(error.message).toContain(message)
+      expect(error.cause).toBeInstanceOf(McpError)
+      expect(JSON.stringify(logs)).toContain(message)
+    } finally {
+      await Promise.all([client.close(), server.close()])
+    }
+  })
+
+  test.each([
+    { name: "empty tools", delay: 0, tools: [], error: undefined },
+    { name: "invalid response schema", delay: 0, tools: [{ name: "broken" }], error: "inputSchema" },
+    { name: "request timeout", delay: 100, tools: [], error: "timed out" },
+  ])("handles $name", async ({ delay, tools, error }) => {
+    const server = new Server({ name: "catalog", version: "1.0.0" }, { capabilities: { tools: {} } })
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      if (delay) await Bun.sleep(delay)
+      return { tools }
+    })
+    const client = new Client({ name: "catalog-test", version: "1.0.0" })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    try {
+      const result = McpCatalog.defs(client, 30)
+      if (error) {
+        const failure = await Effect.runPromise(result.pipe(Effect.flip))
+        expect(failure.message).toContain(error)
+        return
+      }
+      expect(await Effect.runPromise(result)).toEqual([])
+    } finally {
+      await Promise.all([client.close(), server.close()])
+    }
+  })
+})
 
 function clientReturning(result: unknown) {
   return {

--- a/packages/opencode/test/mcp/http-status.test.ts
+++ b/packages/opencode/test/mcp/http-status.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test"
+import path from "node:path"
+import { Server } from "../../src/server/server"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+test("POST and GET /mcp retain tool discovery errors and accept an empty catalog", async () => {
+  await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
+  const listener = await Server.listen({ hostname: "127.0.0.1", port: 0 })
+  const headers = { "content-type": "application/json", "x-opencode-directory": tmp.path }
+  const fixture = path.join(import.meta.dir, "../fixture/mcp-lifecycle-stdio.ts")
+  try {
+    const broken = await fetch(new URL("/mcp", listener.url), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: "broken",
+        config: { type: "local", command: [process.execPath, fixture, "--tools-error"] },
+      }),
+    })
+    expect(broken.status).toBe(200)
+    const failure = { status: "failed", error: expect.stringContaining("fixture tool catalog unavailable") }
+    expect(await broken.json()).toMatchObject({ broken: failure })
+
+    const empty = await fetch(new URL("/mcp", listener.url), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: "empty",
+        config: { type: "local", command: [process.execPath, fixture, "--empty-tools"] },
+      }),
+    })
+    expect(empty.status).toBe(200)
+    expect(await empty.json()).toMatchObject({ empty: { status: "connected" } })
+
+    const readback = await fetch(new URL("/mcp", listener.url), { headers })
+    expect(readback.status).toBe(200)
+    expect(await readback.json()).toMatchObject({ broken: failure, empty: { status: "connected" } })
+  } finally {
+    await listener.stop(true)
+  }
+}, 30_000)

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -14,7 +14,7 @@ import {
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Cause, Effect, Exit } from "effect"
+import { Cause, Effect, Exit, Logger } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { MCP } from "../../src/mcp/index"
 import { McpOAuthCallback } from "../../src/mcp/oauth-callback"
@@ -236,6 +236,35 @@ it.instance("tools() reuses cached definitions until a protocol notification", (
   }),
 )
 
+it.instance("failed tool refresh logs its cause and preserves the last usable catalog", () => {
+  const logs: unknown[] = []
+  return Effect.gen(function* () {
+    const server = yield* lifecycleServer({ capabilities: { tools: { listChanged: true } } })
+    const mcp = yield* MCP.Service
+    yield* mcp.add("refresh-server", remote(server.url))
+    server.state.listToolsError = "catalog refresh unavailable"
+    yield* Effect.promise(server.sendToolListChanged)
+    yield* pollWithTimeout(
+      Effect.sync(() => (JSON.stringify(logs).includes("catalog refresh unavailable") ? true : undefined)),
+      "tool refresh failure was not logged",
+    )
+
+    expect((yield* mcp.status())["refresh-server"]?.status).toBe("connected")
+    expect(Object.keys(yield* mcp.tools())).toEqual(["refresh-server_test_tool"])
+
+    server.state.listToolsError = undefined
+    server.state.tools = [{ name: "recovered", inputSchema: { type: "object" } }]
+    yield* Effect.promise(server.sendToolListChanged)
+    yield* pollWithTimeout(
+      Effect.gen(function* () {
+        return (yield* mcp.tools())["refresh-server_recovered"]
+      }),
+      "tool refresh did not recover",
+    )
+    expect(Object.keys(yield* mcp.tools())).toEqual(["refresh-server_recovered"])
+  }).pipe(Effect.provide(Logger.layer([Logger.make((entry) => logs.push(entry.message))])))
+})
+
 it.instance("instructions() returns non-empty connected server instructions with tool names", () =>
   Effect.gen(function* () {
     const guide = yield* lifecycleServer({ instructions: "Use lookup before mutate." })
@@ -356,6 +385,10 @@ it.instance("one failed server does not affect another connected server", () =>
 
     expect((yield* mcp.status())["good-server"]?.status).toBe("connected")
     expect((yield* mcp.status())["bad-server"]?.status).toBe("failed")
+    expect((yield* mcp.status())["bad-server"]).toEqual({
+      status: "failed",
+      error: expect.stringContaining("listTools failed"),
+    })
     expect(Object.keys(yield* mcp.tools())).toEqual(["good-server_good_tool"])
   }),
 )
@@ -386,6 +419,10 @@ it.instance("does not fall back for protocol tool discovery errors", () =>
     const result = yield* mcp.add("broken-server", remote(server.url))
 
     expect(statusName(result.status, "broken-server")).toBe("failed")
+    expect((yield* mcp.status())["broken-server"]).toEqual({
+      status: "failed",
+      error: expect.stringContaining("transport closed"),
+    })
   }),
 )
 

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -1,11 +1,12 @@
 import { expect } from "bun:test"
+import path from "node:path"
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
 import { ListResourcesRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Effect } from "effect"
+import { Deferred, Effect, Fiber } from "effect"
 import { Config } from "../../src/config/config"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { McpAuth } from "../../src/mcp/auth"
@@ -22,6 +23,8 @@ const mcpTest = testEffect(
 
 interface OAuthMcpOptions {
   capabilities?: "tools" | "resources"
+  listToolsError?: string
+  beforeListTools?: () => Promise<void>
 }
 
 function serveOAuthMcp(options: OAuthMcpOptions = {}) {
@@ -40,8 +43,10 @@ function serveOAuthMcp(options: OAuthMcpOptions = {}) {
       let requiresAuth = true
 
       if (capabilities === "tools") {
-        protocol.setRequestHandler(ListToolsRequestSchema, () => {
+        protocol.setRequestHandler(ListToolsRequestSchema, async () => {
           listToolsCalls++
+          await options.beforeListTools?.()
+          if (options.listToolsError) throw new Error(options.listToolsError)
           return Promise.resolve({ tools: [{ name: "test_tool", inputSchema: { type: "object" } }] })
         })
       }
@@ -296,5 +301,57 @@ mcpTest.instance("authenticate() connects a resource-only server without listing
     expect((yield* mcp.authenticate(name)).status).toBe("connected")
     expect(server.listToolsCalls()).toBe(0)
     expect(Object.keys(yield* mcp.resources())).toEqual([`${name}:docs://readme`])
+  }),
+)
+
+mcpTest.instance("authenticate() preserves tool discovery failures after connecting", () =>
+  Effect.gen(function* () {
+    yield* stopOAuthCallback
+    const server = yield* serveOAuthMcp({ listToolsError: "tool catalog unavailable after authentication" })
+    const mcp = yield* MCP.Service
+    const name = "test-oauth-tool-error"
+    yield* mcp.add(name, remote(server.url))
+    server.allowAnonymous()
+
+    const status = yield* mcp.authenticate(name)
+    expect(status).toEqual({
+      status: "failed",
+      error: expect.stringContaining("tool catalog unavailable after authentication"),
+    })
+    expect((yield* mcp.status())[name]).toEqual(status)
+    expect(Object.keys(yield* mcp.tools())).toEqual([])
+  }),
+)
+
+mcpTest.instance("late authentication failure does not overwrite a newer connection", () =>
+  Effect.gen(function* () {
+    yield* stopOAuthCallback
+    const started = yield* Deferred.make<void>()
+    const released = yield* Deferred.make<void>()
+    const server = yield* serveOAuthMcp({
+      listToolsError: "old authentication catalog failed",
+      beforeListTools: () =>
+        Effect.runPromise(Deferred.succeed(started, undefined).pipe(Effect.andThen(Deferred.await(released)))),
+    })
+    yield* Effect.addFinalizer(() => Deferred.succeed(released, undefined))
+    const mcp = yield* MCP.Service
+    const name = "test-auth-replaced"
+    yield* mcp.add(name, remote(server.url))
+    server.allowAnonymous()
+    const attempt = yield* mcp.authenticate(name).pipe(Effect.forkScoped)
+    yield* Deferred.await(started)
+
+    yield* mcp.add(name, {
+      type: "local",
+      command: [process.execPath, path.join(import.meta.dir, "../fixture/mcp-lifecycle-stdio.ts")],
+    })
+    expect((yield* mcp.status())[name]?.status).toBe("connected")
+    yield* Deferred.succeed(released, undefined)
+    expect(yield* Fiber.join(attempt)).toEqual({
+      status: "failed",
+      error: expect.stringContaining("old authentication catalog failed"),
+    })
+    expect((yield* mcp.status())[name]?.status).toBe("connected")
+    expect(Object.keys(yield* mcp.tools())).toEqual([`${name}_current_directory`])
   }),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #47644

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keep the original `tools/list` failure in MCP status and logs. Preserve usable cached tools after a failed refresh, and prevent a late authentication failure from replacing a newer healthy connection's status.

### How did you verify your code works?

- `bun test test/mcp --timeout 30000`: 71 passed, including real HTTP `POST`/`GET /mcp`, a stdio fixture, empty catalogs, discovery failures, refresh recovery and concurrent authentication.
- Package `bun typecheck` and changed-scope lint passed; all 30 workspace typecheck tasks passed.
- The original Android connection failure is not reproduced; this fixes loss of its diagnostic cause.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
