### PR TITLE
fix(opencode): normalise windows permission path patterns through realpath

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -4,6 +4,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { Wildcard } from "@opencode-ai/core/util/wildcard"
 import { Deferred, Effect, Layer, Context } from "effect"
 import os from "os"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { EventV2Bridge } from "@/event-v2-bridge"
 
@@ -175,11 +176,16 @@ const layer = Layer.effect(
   }),
 )
 
-function expand(pattern: string): string {
-  if (pattern.startsWith("~/")) return os.homedir() + pattern.slice(1)
-  if (pattern === "~") return os.homedir()
-  if (pattern.startsWith("$HOME/")) return os.homedir() + pattern.slice(5)
-  if (pattern.startsWith("$HOME")) return os.homedir() + pattern.slice(5)
+export function expand(pattern: string): string {
+  if (pattern.startsWith("~/")) pattern = os.homedir() + pattern.slice(1)
+  if (pattern === "~") pattern = os.homedir()
+  if (pattern.startsWith("$HOME/")) pattern = os.homedir() + pattern.slice(5)
+  if (pattern.startsWith("$HOME")) pattern = os.homedir() + pattern.slice(5)
+  // On Windows, normalise absolute path patterns through the same realpath pass
+  // the runtime applies to ask targets. Otherwise whitelist entries written as
+  // symlinked/junction paths (e.g. ~/.claude resolving to ~/.codex) never match
+  // the canonicalised request and every external read prompts anyway.
+  if (process.platform === "win32" && /^[A-Za-z]:[\\/]/.test(pattern)) return FSUtil.normalizePathPattern(pattern)
   return pattern
 }
 

--- a/packages/opencode/test/permission/expand.test.ts
+++ b/packages/opencode/test/permission/expand.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { Permission } from "../../src/permission"
+
+describe("Permission.expand", () => {
+  test("keeps non-path permission patterns untouched", () => {
+    expect(Permission.expand("ls")).toBe("ls")
+    expect(Permission.expand("*.env")).toBe("*.env")
+    expect(Permission.expand("src/index.ts")).toBe("src/index.ts")
+  })
+
+  test("expands tilde and $HOME to the home directory", () => {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? ""
+    expect(Permission.expand("~/foo").startsWith(home)).toBe(true)
+    expect(Permission.expand("$HOME/foo").startsWith(home)).toBe(true)
+    expect(Permission.expand("~/foo")).toContain("foo")
+  })
+
+  if (process.platform === "win32") {
+    test("normalises a windows drive whitelist path via realpath (junction-resolving)", () => {
+      const resolved = Permission.expand("C:/Users/test/.claude/skills/skill/*")
+      // Either the real path resolves (junction) or it stays as given — the drive
+      // prefix and trailing wildcard must survive.
+      expect(resolved).toMatch(/^[A-Za-z]:[\\/]/)
+      expect(resolved.replaceAll("\\", "/").endsWith("*")).toBe(true)
+    })
+  }
+})

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -4,6 +4,7 @@ import os from "os"
 import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Permission } from "../../src/permission"
 import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { InstanceStore } from "../../src/project/instance-store"
@@ -110,17 +111,22 @@ test("fromConfig - empty object", () => {
 
 test("fromConfig - expands tilde to home directory", () => {
   const result = Permission.fromConfig({ external_directory: { "~/projects/*": "allow" } })
-  expect(result).toEqual([{ permission: "external_directory", pattern: `${os.homedir()}/projects/*`, action: "allow" }])
+  const expected =
+    process.platform === "win32" ? FSUtil.normalizePathPattern(`${os.homedir()}/projects/*`) : `${os.homedir()}/projects/*`
+  expect(result).toEqual([{ permission: "external_directory", pattern: expected, action: "allow" }])
 })
 
 test("fromConfig - expands $HOME to home directory", () => {
   const result = Permission.fromConfig({ external_directory: { "$HOME/projects/*": "allow" } })
-  expect(result).toEqual([{ permission: "external_directory", pattern: `${os.homedir()}/projects/*`, action: "allow" }])
+  const expected =
+    process.platform === "win32" ? FSUtil.normalizePathPattern(`${os.homedir()}/projects/*`) : `${os.homedir()}/projects/*`
+  expect(result).toEqual([{ permission: "external_directory", pattern: expected, action: "allow" }])
 })
 
 test("fromConfig - expands $HOME without trailing slash", () => {
   const result = Permission.fromConfig({ external_directory: { $HOME: "allow" } })
-  expect(result).toEqual([{ permission: "external_directory", pattern: os.homedir(), action: "allow" }])
+  const expected = process.platform === "win32" ? FSUtil.normalizePath(`${os.homedir()}`) : os.homedir()
+  expect(result).toEqual([{ permission: "external_directory", pattern: expected, action: "allow" }])
 })
 
 test("fromConfig - does not expand tilde in middle of path", () => {


### PR DESCRIPTION
### Issue for this PR

Fixes #36681

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Permission whitelist entries written as absolute Windows paths were never
compared against the runtime's normalised path form, so a fully-specified
`external_directory` allow block still prompted on every external read.

`Permission.expand()` expandes `~/…`, `$HOME/…` and keeps the literal string for
drive-letter patterns. The runtime (`external-directory.ts`) canonicalises ask
targets on Windows via `FSUtil.normalizePathPattern` — which resolves symlinks
and junctions (e.g. `~/.claude` resolving to `~/.codex`) and normalises
separators. A config entry such as `C:\Users\User\.config\opencode` therefore
never string-matched the `C:\Users\…\config\*` request glob, so the gate fell
through to the `ask` default: the documented allow block silently did not apply.

This change sends the same realpath pass over absolute Windows whitelist
patterns in `expand()`, so config patterns and request globs collapse onto the
same canonical prefix. Non-path patterns (`ls`, `*.env`, relative paths) are
left untouched; the drive-letter guard keeps the normalisation scoped to
absolute Windows paths.

### How did you verify your code works?

- New `Permission.expand` tests cover untouched non-path patterns, tilde/`$HOME`
  expansion, and (on Windows) drive-prefix + trailing-wildcard survival through
  the realpath pass.
- Updated `fromConfig` tilde/`$HOME` expectations to be platform-tolerant
  (Windows requests the normalised form).
- `bun typecheck` and `bun test test/permission/` in `packages/opencode`:
  88 pass / 0 fail.

### Screenshots / recordings

N/A — not a UI change.

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...expand-windows-paths
- Relation to open PR #40149: this fixes the config/pattern side (Windows
  realpath normalisation in `expand`), while #40149 fixes the tool/request side
  (external targets sent absolute instead of workspace-relative). The two are
  complementary; this PR does not modify tool call sites or `external-directory.ts`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR