### PR TITLE
docs: add Infiknit local MCP plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -62,6 +62,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 | Name                                                                                       | Description                                                      |
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| [Infiknit](https://github.com/Synthenova/infiknit-mcp) | Local stdio launcher for Infiknit desktop image/video canvas workflows. Keep Infiknit open. Cloud agents cannot reach it. |
 | [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK       |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
 | [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |


### PR DESCRIPTION
Adds Infiknit under Projects.

Local stdio launcher for the Infiknit desktop app. Keep Infiknit open. Cloud agents cannot reach it.

Repo: https://github.com/Synthenova/infiknit-mcp
Official registry: io.github.Synthenova/infiknit
Homepage: https://infiknit.app
