### PR TITLE
fix(opencode): reject stale patch sources after approval

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -53,6 +53,7 @@ export const ApplyPatchTool = Tool.define(
       }
 
       const instance = yield* InstanceState.context
+      const originals: Array<{ filePath: string; content: Uint8Array }> = []
 
       // Validate file paths and check permissions
       const fileChanges: Array<{
@@ -113,6 +114,7 @@ export const ApplyPatchTool = Tool.define(
             }
 
             const source = yield* Bom.readFile(afs, filePath)
+            originals.push({ filePath, content: source.content })
             const oldContent = source.text
             let newContent = oldContent
             let bom = source.bom
@@ -168,6 +170,7 @@ export const ApplyPatchTool = Tool.define(
                 ),
               ),
             )
+            originals.push({ filePath, content: source.content })
             const contentToDelete = source.text
             const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
 
@@ -213,6 +216,25 @@ export const ApplyPatchTool = Tool.define(
           files,
         },
       })
+
+      // Approval can outlive the contents used to prepare the patch. Check every
+      // source before writing any file so a stale later hunk leaves earlier ones untouched.
+      for (const original of originals) {
+        const current = yield* afs
+          .readFile(original.filePath)
+          .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
+        if (
+          !current ||
+          current.length !== original.content.length ||
+          !current.every((byte, index) => byte === original.content[index])
+        ) {
+          return yield* Effect.fail(
+            new Error(
+              `apply_patch verification failed: File changed since it was read: ${original.filePath}. No patch changes were applied. Read the file again and retry.`,
+            ),
+          )
+        }
+      }
 
       // Apply the changes
       const updates: Array<{ file: string; event: "add" | "change" | "unlink" }> = []

--- a/packages/opencode/src/util/bom.ts
+++ b/packages/opencode/src/util/bom.ts
@@ -16,7 +16,8 @@ export function join(text: string, bom: boolean) {
 }
 
 export const readFile = Effect.fn("Bom.readFile")(function* (fs: FSUtil.Interface, filePath: string) {
-  return split(new TextDecoder("utf-8", { ignoreBOM: true }).decode(yield* fs.readFile(filePath)))
+  const content = yield* fs.readFile(filePath)
+  return { content, ...split(new TextDecoder("utf-8", { ignoreBOM: true }).decode(content)) }
 })
 
 export const syncFile = Effect.fn("Bom.syncFile")(function* (fs: FSUtil.Interface, filePath: string, bom: boolean) {

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -401,6 +401,108 @@ describe("tool.apply_patch freeform", () => {
     }),
   )
 
+  for (const operation of ["update", "delete", "move"] as const) {
+    it.instance(`rejects a stale ${operation} source before applying any file changes`, () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const first = path.join(test.directory, "first.txt")
+        const second = path.join(test.directory, "second.txt")
+        const destination = path.join(test.directory, "moved.txt")
+        yield* writeText(first, "first\n")
+        yield* writeText(second, "second\n")
+
+        const hunk =
+          operation === "delete"
+            ? "*** Delete File: second.txt\n"
+            : `*** Update File: second.txt\n${operation === "move" ? "*** Move to: moved.txt\n" : ""}@@\n-second\n+patched\n`
+        const patchText = `*** Begin Patch\n*** Update File: first.txt\n@@\n-first\n+patched\n${hunk}*** End Patch`
+        const ctx: ToolCtx = {
+          ...baseCtx,
+          ask: () => writeText(second, "edited during approval\n"),
+        }
+
+        yield* expectFailure(execute({ patchText }, ctx), "File changed since it was read")
+        expect(yield* readText(first)).toBe("first\n")
+        expect(yield* readText(second)).toBe("edited during approval\n")
+        yield* expectReadFailure(destination)
+      }),
+    )
+  }
+
+  it.instance("rejects a BOM-only change during approval before creating any files", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const target = path.join(test.directory, "source.txt")
+      yield* writeText(target, "original\n")
+      const ctx: ToolCtx = {
+        ...baseCtx,
+        ask: () => writeText(target, "\uFEFForiginal\n"),
+      }
+
+      yield* expectFailure(
+        execute(
+          {
+            patchText:
+              "*** Begin Patch\n*** Add File: created.txt\n+created\n*** Update File: source.txt\n@@\n-original\n+patched\n*** End Patch",
+          },
+          ctx,
+        ),
+        "File changed since it was read",
+      )
+      expect(yield* readText(target)).toBe("\uFEFForiginal\n")
+      yield* expectReadFailure(path.join(test.directory, "created.txt"))
+    }),
+  )
+
+  it.instance("rejects a source removed during approval before changing earlier files", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const first = path.join(test.directory, "first.txt")
+      const second = path.join(test.directory, "second.txt")
+      yield* writeText(first, "first\n")
+      yield* writeText(second, "second\n")
+      const ctx: ToolCtx = {
+        ...baseCtx,
+        ask: () => Effect.promise(() => fs.unlink(second)),
+      }
+
+      yield* expectFailure(
+        execute(
+          {
+            patchText:
+              "*** Begin Patch\n*** Update File: first.txt\n@@\n-first\n+patched\n*** Delete File: second.txt\n*** End Patch",
+          },
+          ctx,
+        ),
+        "File changed since it was read",
+      )
+      expect(yield* readText(first)).toBe("first\n")
+      yield* expectReadFailure(second)
+    }),
+  )
+
+  it.instance("rejects byte changes hidden by UTF-8 replacement during approval", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const afs = yield* FSUtil.Service
+      const target = path.join(test.directory, "source.txt")
+      yield* afs.writeFile(target, new Uint8Array([0x80, 0x0a]))
+      const ctx: ToolCtx = {
+        ...baseCtx,
+        ask: () => afs.writeFile(target, new Uint8Array([0x81, 0x0a])).pipe(Effect.orDie),
+      }
+
+      yield* expectFailure(
+        execute(
+          { patchText: "*** Begin Patch\n*** Update File: source.txt\n@@\n-\uFFFD\n+patched\n*** End Patch" },
+          ctx,
+        ),
+        "File changed since it was read",
+      )
+      expect(Array.from(yield* afs.readFile(target))).toEqual([0x81, 0x0a])
+    }),
+  )
+
   it.instance("supports end of file anchor", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Fixes #31776. This remains reproducible on `dev` at `d6855b6`; the previously cited #31893 closed unmerged and did not change `apply_patch.ts`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

If a source file changes while patch approval is pending, `apply_patch` currently overwrites or deletes the newer content. It now retains the original bytes and rechecks every update/delete/move source after approval, before applying any file changes. A mismatch or missing source rejects the patch with a path and retry guidance.

This adapts [nl-veil's validate-all-before-mutation principle](https://github.com/gary23w/nl-veil/blob/1455d51cd1282bd49feccf4706cb56bdefeb0492/src/worker/hashline.zig#L424). Commit remains sequential; this does not add rollback or eliminate races after preflight.

### How did you verify your code works?

On Windows with Bun 1.3.14:

- Regression tests change a later source inside the approval callback and assert earlier files remain untouched. Cases cover update/delete/move, disappearance, BOM changes, and malformed UTF-8 bytes. The original update/delete/move/BOM regressions all fail on the base implementation.
- From `packages/opencode`: `bun test --timeout 30000 test/tool/apply_patch.test.ts test/tool/edit.test.ts test/tool/write.test.ts` — 78 passed.
- `bun typecheck` passes; Prettier passes. Changed-file lint has zero errors and four existing warnings.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
