### PR TITLE
fix(opencode): surface 2xx-but-not-200 HTTP status in webfetch output

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -107,12 +107,24 @@ export const WebFetchTool = Tool.define(
           const mime = contentType.split(";")[0]?.trim().toLowerCase() || ""
           const title = `${params.url} (${contentType})`
 
+          // A non-200 success (202 Accepted, 204 No Content, ...) often carries a throttle
+          // or interstitial page instead of the requested content. Only `output` reaches the
+          // model, so the status has to be stated there for it to adapt.
+          const statusNotice =
+            response.status === 200
+              ? ""
+              : `[HTTP ${response.status} — response may be a throttle or interstitial page, not the requested content]\n\n`
+
+          const result = (output: string) => ({
+            output: statusNotice + output,
+            title,
+            metadata: { status: response.status },
+          })
+
           if (isImageAttachment(mime)) {
             const base64Content = Buffer.from(arrayBuffer).toString("base64")
             return {
-              title,
-              output: "Image fetched successfully",
-              metadata: {},
+              ...result("Image fetched successfully"),
               attachments: [
                 {
                   type: "file" as const,
@@ -130,25 +142,21 @@ export const WebFetchTool = Tool.define(
             case "markdown":
               if (contentType.includes("text/html")) {
                 const markdown = convertHTMLToMarkdown(content)
-                return {
-                  output: markdown,
-                  title,
-                  metadata: {},
-                }
+                return result(markdown)
               }
-              return { output: content, title, metadata: {} }
+              return result(content)
 
             case "text":
               if (contentType.includes("text/html")) {
-                return { output: extractTextFromHTML(content), title, metadata: {} }
+                return result(extractTextFromHTML(content))
               }
-              return { output: content, title, metadata: {} }
+              return result(content)
 
             case "html":
-              return { output: content, title, metadata: {} }
+              return result(content)
 
             default:
-              return { output: content, title, metadata: {} }
+              return result(content)
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -1,7 +1,7 @@
 - Fetches content from a specified URL
 - Takes a URL and optional format as input
 - Fetches the URL content, converts to requested format (markdown by default)
-- Returns the content in the specified format
+- Returns the content in the specified format, preceded by a plain-text status notice if the response status is not 200
 - Use this tool when you need to retrieve and analyze web content
 
 Usage notes:
@@ -11,4 +11,4 @@ Usage notes:
   - Format options: "markdown" (default), "text", or "html"
   - This tool is read-only and does not modify any files
   - Results may be summarized if the content is very large
-  - If the response status is not 200, the output starts with an "[HTTP <status> ...]" notice; the body may be a throttle or interstitial page rather than the requested content
+  - If the response status is not 200, a plain-text "[HTTP <status> ...]" line precedes the body regardless of the requested format; the body may be a throttle or interstitial page rather than the requested content

--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -11,3 +11,4 @@ Usage notes:
   - Format options: "markdown" (default), "text", or "html"
   - This tool is read-only and does not modify any files
   - Results may be summarized if the content is very large
+  - If the response status is not 200, the output starts with an "[HTTP <status> ...]" notice; the body may be a throttle or interstitial page rather than the requested content

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -98,6 +98,55 @@ describe("tool.webfetch", () => {
     ),
   )
 
+  it.instance("notes a non-200 status ahead of the body", () =>
+    withFetch(
+      () =>
+        new Response("<p>throttled</p>", {
+          status: 202,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      (url) =>
+        Effect.gen(function* () {
+          const result = yield* exec({ url: new URL("/page.html", url).toString(), format: "text" })
+          expect(result.output.startsWith("[HTTP 202")).toBe(true)
+          expect(result.output).toContain("throttled")
+          expect(result.metadata.status).toBe(202)
+        }),
+    ),
+  )
+
+  it.instance("surfaces the notice alone when a throttled response has no body", () =>
+    withFetch(
+      () =>
+        new Response("", {
+          status: 202,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      (url) =>
+        Effect.gen(function* () {
+          const result = yield* exec({ url: new URL("/page.html", url).toString(), format: "text" })
+          expect(result.output.startsWith("[HTTP 202")).toBe(true)
+          expect(result.output.trim().endsWith("]")).toBe(true)
+        }),
+    ),
+  )
+
+  it.instance("leaves 200 responses unannotated", () =>
+    withFetch(
+      () =>
+        new Response("<p>hello</p>", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      (url) =>
+        Effect.gen(function* () {
+          const result = yield* exec({ url: new URL("/page.html", url).toString(), format: "text" })
+          expect(result.output).toBe("hello")
+          expect(result.metadata.status).toBe(200)
+        }),
+    ),
+  )
+
   it.instance("extracts text from html without scripts or styles", () =>
     withFetch(
       () =>


### PR DESCRIPTION
### Issue for this PR

Closes #47897 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`webfetch` puts the content-type in `title` and returns `metadata: {}`. Neither
reaches the model — a completed tool part is turned into a model message from
`state.output` alone (`session/message-v2.ts`), so the model only ever sees the body.

That makes a 2xx-but-not-200 response indistinguishable from a successful fetch:

- a `202 Accepted` throttle or interstitial page (common when a shared egress IP is
  being rate-limited) arrives as if it were the page itself
- a `204 No Content` arrives as an empty page

Non-2xx is already fine — `filterStatusOk` fails and the status is in the error
message. The gap is 202 / 203 / 204 / 206.

This prefixes `output` with `[HTTP <status> ...]` when the status is not 200, and
records the status in `metadata` for the UI. 200 responses are untouched, so
existing output is unchanged.

#45937 covers the error path (keeping the specific failure message); this one covers
the success path. They don't touch the same lines.

### How did you verify your code works?

- `bun test test/tool/webfetch.test.ts` in `packages/opencode`: 7 pass / 0 fail.
- The three new tests are discriminating: with only `webfetch.ts` reverted, 4 pass / 3 fail.
- `bun run typecheck` in `packages/opencode` gives byte-identical output with and
  without my change — `dev` already has one pre-existing error in `src/bus/global.ts`.
- `prettier --check` clean on both changed files.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR