### PR TITLE
fix(sdk): handle SSE cancellation rejection

### DIFF
--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -112,6 +112,20 @@ if (sseTypesPatched === sseTypesSource) {
 }
 await Bun.write(sseTypesPath, sseTypesPatched)
 
+// Abort handlers cannot await ReadableStreamDefaultReader.cancel(), but the
+// returned promise can reject after the body stream has already errored.
+const sseClientPath = "./src/v2/gen/core/serverSentEvents.gen.ts"
+const sseClientFile = Bun.file(sseClientPath)
+const sseClientSource = await sseClientFile.text()
+const sseClientPatched = sseClientSource.replace(
+  "            reader.cancel()",
+  "            void reader.cancel().catch(() => {})",
+)
+if (sseClientPatched === sseClientSource) {
+  throw new Error(`SSE cancel patch did not apply; @hey-api/openapi-ts output may have changed (${sseClientPath})`)
+}
+await Bun.write(sseClientPath, sseClientPatched)
+
 await $`bun prettier --write src/gen`
 await $`bun prettier --write src/v2`
 await $`rm -rf dist`

--- a/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
@@ -111,7 +111,7 @@ export const createSseClient = <TData = unknown>({
 
         const abortHandler = () => {
           try {
-            void reader.cancel()
+            void reader.cancel().catch(() => {})
           } catch {
             // noop
           }

--- a/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
@@ -138,7 +138,7 @@ export const createSseClient = <TData = unknown>({
 
         const abortHandler = () => {
           try {
-            reader.cancel()
+            void reader.cancel().catch(() => {})
           } catch {
             // noop
           }

--- a/packages/sdk/js/test/server-sent-events.test.ts
+++ b/packages/sdk/js/test/server-sent-events.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { createSseClient } from "../src/v2/gen/core/serverSentEvents.gen"
+
+test("observes reader cancellation errors when an SSE request is aborted", async () => {
+  const abort = new AbortController()
+  const result = createSseClient({
+    fetch: async () =>
+      new Response(
+        new ReadableStream({
+          start: (controller) =>
+            abort.signal.addEventListener("abort", () =>
+              controller.error(new DOMException("The operation was aborted", "AbortError")),
+            ),
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    method: "GET",
+    signal: abort.signal,
+    sseMaxRetryAttempts: 1,
+    url: "http://localhost/events",
+  })
+
+  const next = result.stream.next()
+  // Let the generator park in reader.read() before erroring the body stream.
+  await Bun.sleep(10)
+  abort.abort()
+  expect(await next).toEqual({ done: true, value: undefined })
+  // Give any unobserved cancellation rejection time to reach Bun's test runner.
+  await Bun.sleep(10)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #47963

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The SSE abort handler called `reader.cancel()` without observing its promise, so Bun could report an unhandled `AbortError` after the body stream had already errored.

This observes the cancellation rejection in both generated SDK clients and patches the v2 generation step so regeneration preserves the fix.

### How did you verify your code works?

- Ran `./script/generate.ts` to regenerate the SDK and confirm the patch is preserved.
- Ran `bun test` and `bun typecheck` from `packages/sdk/js`.
- Added a regression test that errors the body stream while `reader.read()` is pending. The test fails with the previous implementation because Bun sees the unhandled rejection.

### Screenshots / recordings

Not applicable; this is an SDK-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
