### PR TITLE
docs: add DaoXE to the providers list

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -734,6 +734,35 @@ Cloudflare Workers AI lets you run AI models on Cloudflare's global network dire
 
 ---
 
+### DaoXE
+
+[DaoXE](https://daoxe.com) is an OpenAI-compatible, multi-protocol LLM gateway (Chat Completions, OpenAI Responses, and Anthropic Messages) that exposes Claude, GPT, Gemini, DeepSeek, Kimi and more behind a single API key. It's already in the [models.dev](https://models.dev) catalog opencode reads.
+
+1. Head over to [DaoXE](https://daoxe.com), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **DaoXE**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your DaoXE API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### DeepSeek
 
 1. Head over to the [DeepSeek console](https://platform.deepseek.com/), create an account, and click **Create new API key**.


### PR DESCRIPTION
### Issue for this PR

Closes # N/A — docs-only. Provider registration was anomalyco/models.dev#3199 (merged),
so DaoXE already appears in `/connect` and `/models`.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a **DaoXE** section to `docs/providers`, between Cortecs and DeepSeek.

DaoXE is an OpenAI-compatible multi-protocol gateway (Chat Completions, Responses,
Anthropic Messages) with a single key across many models. Models resolve from the live
catalog; no static model list is added here.

Disclosure: I maintain the DaoXE gateway and work on its public integrations. Same
disclosure shape as the Eden AI and SCX.ai additions to this page.

### How did you verify your code works?

- Section structure copied from the adjacent provider entries (`/connect` + `/models`
  flow).
- All links in the section return 200.
- Rendered the edited file with `@mdx-js/mdx` v3 — parses clean.

### Screenshots / recordings

N/A — text-only docs change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
