### PR TITLE
fix(core): close websocket after provider error frame

### DIFF
--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -147,7 +147,6 @@ export const makeLayer = (connector: WebSocketConnector) =>
         channel.closing = true
         yield* Effect.logDebug("session websocket poisoned", {
           sessionTransport: "websocket",
-          phase: error.reason._tag === "Transport" && error.reason.phase === "close" ? "close" : "receive",
           code: error.reason._tag === "Transport" ? error.reason.code : error.reason._tag,
           active: channel.active !== undefined,
         })
@@ -394,13 +393,10 @@ export const makeLayer = (connector: WebSocketConnector) =>
               if (terminal && pending === 0) {
                 yield* metric("terminal", { type: terminal.type })
                 if (terminal.type === "rejected") yield* metric("rejection", { recovery: terminal.recovery })
-                // Providers close the socket after an error frame. Drop it now so the next exchange
-                // reconnects instead of racing that close and failing with an ambiguous delivery.
-                if (
-                  terminal.type === "provider-failure" ||
-                  (terminal.type === "rejected" && terminal.recovery === "rotate-and-retry-full")
-                )
-                  yield* closeChannel(owner, channel)
+                // The Codex backend stops serving a connection after any error frame: the next request is
+                // never answered and the socket dies with 1006. api.openai.com keeps it open, so reconnecting
+                // costs one handshake there. Drop the socket after every error so retries never race that.
+                if (terminal.type !== "completed" && terminal.type !== "incomplete") yield* closeChannel(owner, channel)
                 return
               }
               yield* metric("cancellation")

--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -316,6 +316,11 @@ export const makeLayer = (connector: WebSocketConnector) =>
           Effect.onInterrupt(() => closeChannel(owner, channel)),
         )
         if (create.mode === "full") channel.checkpoint = undefined
+        yield* Effect.logDebug("session websocket sending", {
+          sessionTransport: "websocket",
+          phase: "send",
+          mode: create.mode,
+        })
         const active: Active = {
           queue: yield* Queue.bounded<string, AIError>(INBOUND_CAPACITY),
           delivery: "send-attempted",

--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -145,6 +145,12 @@ export const makeLayer = (connector: WebSocketConnector) =>
         if (owner.channel === channel) owner.channel = undefined
         if (channel.closing) return
         channel.closing = true
+        yield* Effect.logDebug("session websocket poisoned", {
+          sessionTransport: "websocket",
+          phase: error.reason._tag === "Transport" && error.reason.phase === "close" ? "close" : "receive",
+          code: error.reason._tag === "Transport" ? error.reason.code : error.reason._tag,
+          active: channel.active !== undefined,
+        })
         if (channel.active) Queue.failCauseUnsafe(channel.active.queue, Cause.fail(error))
         yield* metric(
           error.reason._tag === "Transport" && error.reason.code === "queue-overflow"
@@ -388,7 +394,12 @@ export const makeLayer = (connector: WebSocketConnector) =>
               if (terminal && pending === 0) {
                 yield* metric("terminal", { type: terminal.type })
                 if (terminal.type === "rejected") yield* metric("rejection", { recovery: terminal.recovery })
-                if (terminal.type === "rejected" && terminal.recovery === "rotate-and-retry-full")
+                // Providers close the socket after an error frame. Drop it now so the next exchange
+                // reconnects instead of racing that close and failing with an ambiguous delivery.
+                if (
+                  terminal.type === "provider-failure" ||
+                  (terminal.type === "rejected" && terminal.recovery === "rotate-and-retry-full")
+                )
                   yield* closeChannel(owner, channel)
                 return
               }

--- a/packages/core/test/session-model-transport-live.test.ts
+++ b/packages/core/test/session-model-transport-live.test.ts
@@ -225,7 +225,7 @@ describe("SessionModelTransport local WebSocket server", () => {
           expect(requests).toHaveLength(3)
           expect(requests[1]).toHaveProperty("previous_response_id", "resp_1")
           expect(requests[2]).not.toHaveProperty("previous_response_id")
-          expect(server.state.opens).toBe(1)
+          expect(server.state.opens).toBe(2)
         }),
     )
   })

--- a/packages/core/test/session-model-transport.test.ts
+++ b/packages/core/test/session-model-transport.test.ts
@@ -243,7 +243,9 @@ describe("SessionModelTransport", () => {
         yield* collect(executor, item("retry"))
 
         expect(checkpoints).toEqual([undefined, candidate, undefined])
-        expect(fixture.connections).toHaveLength(1)
+        // Error frames end the connection on some backends, so the full retry uses a fresh one.
+        expect(fixture.connections).toHaveLength(2)
+        expect(fixture.connections[0]?.closed).toBe(1)
       }),
     )
   })
@@ -309,7 +311,6 @@ describe("SessionModelTransport", () => {
         expect(result._tag).toBe("Failure")
         expect(yield* collect(executor, exchange("next"))).toEqual(["completed:next"])
 
-        // The provider closes the socket after an error frame; a reused connection would race that close.
         expect(fixture.connections).toHaveLength(2)
         expect(fixture.connections[0]?.closed).toBe(1)
       }),

--- a/packages/core/test/session-model-transport.test.ts
+++ b/packages/core/test/session-model-transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { AIError, HttpContext, TransportError } from "@opencode/ai"
+import { AIError, HttpContext, InvalidRequestError, TransportError } from "@opencode/ai"
 import type {
   ChannelObservation,
   WebSocketChannelExchange,
@@ -280,6 +280,36 @@ describe("SessionModelTransport", () => {
         yield* Effect.result(collect(executor, rejected))
         yield* collect(executor, exchange("retry"))
 
+        expect(fixture.connections).toHaveLength(2)
+        expect(fixture.connections[0]?.closed).toBe(1)
+      }),
+    )
+  })
+
+  test("closes the connection after a provider error frame so the next call reconnects", async () => {
+    const fixture = automatic()
+    const failed: WebSocketChannelExchange = {
+      ...exchange("failed"),
+      driver: {
+        create: () => Effect.succeed({ message: "failed", mode: "full" }),
+        observe: () =>
+          Effect.succeed({
+            type: "provider-failure",
+            error: new AIError({ reason: new InvalidRequestError({ message: "unsupported model" }) }),
+          }),
+      },
+    }
+
+    await run(
+      fixture.connector,
+      Effect.gen(function* () {
+        const transport = yield* SessionModelTransport.Service
+        const executor = transport.bind(session)
+        const result = yield* Effect.result(collect(executor, failed))
+        expect(result._tag).toBe("Failure")
+        expect(yield* collect(executor, exchange("next"))).toEqual(["completed:next"])
+
+        // The provider closes the socket after an error frame; a reused connection would race that close.
         expect(fixture.connections).toHaveLength(2)
         expect(fixture.connections[0]?.closed).toBe(1)
       }),


### PR DESCRIPTION
## Summary
- After a Responses WebSocket `error` frame the transport kept the channel for reuse, so the next exchange could be written to a connection the server had already given up on and fail the step with `provider.transport: WebSocket closed with code 1000` — `delivery: ambiguous`, which is deliberately never retried. Seen live during a WebSocket soak against a ChatGPT Codex credential.
- Drop the channel after every error terminal (`provider-failure` and both `rejected` recoveries), so the runner's retry or the next step opens a fresh connection. The `rotate-and-retry-full` special case is subsumed.
- Add two debug lines needed to verify WebSocket behaviour from logs: `session websocket sending … mode=full|incremental` and `session websocket poisoned … code= active=`.

Probed both backends with a raw `response.create` socket after an error frame (`previous_response_not_found` and a bad model):
- `api.openai.com` keeps the socket open; a follow-up request on it succeeds. Reconnecting after an error costs one handshake there.
- `chatgpt.com/backend-api/codex` stops serving the connection after either error: the follow-up request is never answered and the socket dies with 1006 ~2.7 s later. That includes the stale-`previous_response_id` case, so `retry-full` on the same socket would have hung and failed the same way.

Groundwork for making the channel the default.

## Validation
- New test: `closes the connection after a provider error frame so the next call reconnects`; `clears a rejected checkpoint before the runner retries full` and the live `clears a rejected continuation …` test now expect the retry on a second connection.
- `session-model-transport`, `session-checkpoint-transport`, `session-model-transport-live`: 38 passed. Core suite via `bun run test`: 5,248 passed, 35 skipped. Core typecheck clean.

## Follow-up
Codex reports a stale continuation as `invalid_request_error` with message "Invalid `previous_response_id`." and no `code`, so `OpenResponsesContinuation` never classifies it as `retry-full` there; the step fails instead of retrying full.
