### PR TITLE
feat(core): carry compaction usage on the compaction message

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -986,6 +986,15 @@ export type SessionLogOutput =
               | undefined
             readonly text: string
             readonly recent: string
+            readonly cost?: (number & Brand.Brand<"Money.USD">) | undefined
+            readonly tokens?:
+              | {
+                  readonly input: number
+                  readonly output: number
+                  readonly reasoning: number
+                  readonly cache: { readonly read: number; readonly write: number }
+                }
+              | undefined
           }
         }
       | {
@@ -1000,6 +1009,15 @@ export type SessionLogOutput =
             readonly reason: "auto" | "manual"
             readonly error: { readonly type: string; readonly message: string; readonly status?: number | undefined }
             readonly inputID?: SessionMessage.ID | undefined
+            readonly cost?: (number & Brand.Brand<"Money.USD">) | undefined
+            readonly tokens?:
+              | {
+                  readonly input: number
+                  readonly output: number
+                  readonly reasoning: number
+                  readonly cache: { readonly read: number; readonly write: number }
+                }
+              | undefined
           }
         }
       | {

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -127,17 +127,6 @@ export type ToolFileContent = { type: "file"; uri: string; mime: string; name?: 
 
 export type SessionStructuredError = { type: string; message: string; status?: number }
 
-export type SessionMessageCompactionRunning = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  status: "running"
-  reason: "auto" | "manual"
-  summary: string
-  recent: string
-}
-
 export type SessionProviderContextProvenance = {
   providerID: string
   provider: string
@@ -515,11 +504,26 @@ export type ToolContent = ToolTextContent | ToolFileContent
 
 export type SessionMessageAssistantRetry = { attempt: number; at: number; error: SessionStructuredError }
 
+export type SessionMessageCompactionRunning = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  cost?: MoneyUSD
+  tokens?: TokenUsageInfo
+  status: "running"
+  reason: "auto" | "manual"
+  summary: string
+  recent: string
+}
+
 export type SessionMessageCompactionFailed = {
   type: "compaction"
   id: string
   metadata?: { [x: string]: JsonValue }
   time: { created: number }
+  cost?: MoneyUSD
+  tokens?: TokenUsageInfo
   status: "failed"
   reason: "auto" | "manual"
   error: SessionStructuredError
@@ -808,7 +812,14 @@ export type SessionCompactionFailed = {
   type: "session.compaction.failed"
   durable: { aggregateID: string; seq: number; version: 1 }
   location?: LocationRef
-  data: { sessionID: string; reason: "auto" | "manual"; error: SessionStructuredError; inputID?: string }
+  data: {
+    sessionID: string
+    reason: "auto" | "manual"
+    error: SessionStructuredError
+    inputID?: string
+    cost?: MoneyUSD
+    tokens?: TokenUsageInfo
+  }
 }
 
 export type SessionRevertCleared = {
@@ -1731,6 +1742,8 @@ export type SessionMessageCompactionCompleted = {
   id: string
   metadata?: { [x: string]: JsonValue }
   time: { created: number }
+  cost?: MoneyUSD
+  tokens?: TokenUsageInfo
   status: "completed"
   reason: "auto" | "manual"
   model?: ModelRef
@@ -1755,6 +1768,8 @@ export type SessionCompactionEnded = {
     providerContext?: SessionProviderContext
     text: string
     recent: string
+    cost?: MoneyUSD
+    tokens?: TokenUsageInfo
   }
 }
 
@@ -3083,6 +3098,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "running"
               readonly reason: "auto" | "manual"
               readonly summary: string
@@ -3093,6 +3115,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "completed"
               readonly reason: "auto" | "manual"
               readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
@@ -3117,6 +3146,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "failed"
               readonly reason: "auto" | "manual"
               readonly error: { readonly type: string; readonly message: string; readonly status?: number }
@@ -3374,6 +3410,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "running"
               readonly reason: "auto" | "manual"
               readonly summary: string
@@ -3384,6 +3427,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "completed"
               readonly reason: "auto" | "manual"
               readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
@@ -3408,6 +3458,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "failed"
               readonly reason: "auto" | "manual"
               readonly error: { readonly type: string; readonly message: string; readonly status?: number }
@@ -3665,6 +3722,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "running"
               readonly reason: "auto" | "manual"
               readonly summary: string
@@ -3675,6 +3739,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "completed"
               readonly reason: "auto" | "manual"
               readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
@@ -3699,6 +3770,13 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
               readonly status: "failed"
               readonly reason: "auto" | "manual"
               readonly error: { readonly type: string; readonly message: string; readonly status?: number }

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -127,6 +127,17 @@ export type ToolFileContent = { type: "file"; uri: string; mime: string; name?: 
 
 export type SessionStructuredError = { type: string; message: string; status?: number }
 
+export type SessionMessageCompactionRunning = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  status: "running"
+  reason: "auto" | "manual"
+  summary: string
+  recent: string
+}
+
 export type SessionProviderContextProvenance = {
   providerID: string
   provider: string
@@ -504,29 +515,16 @@ export type ToolContent = ToolTextContent | ToolFileContent
 
 export type SessionMessageAssistantRetry = { attempt: number; at: number; error: SessionStructuredError }
 
-export type SessionMessageCompactionRunning = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  cost?: MoneyUSD
-  tokens?: TokenUsageInfo
-  status: "running"
-  reason: "auto" | "manual"
-  summary: string
-  recent: string
-}
-
 export type SessionMessageCompactionFailed = {
   type: "compaction"
   id: string
   metadata?: { [x: string]: JsonValue }
   time: { created: number }
-  cost?: MoneyUSD
-  tokens?: TokenUsageInfo
   status: "failed"
   reason: "auto" | "manual"
   error: SessionStructuredError
+  cost?: MoneyUSD
+  tokens?: TokenUsageInfo
 }
 
 export type SessionProviderContext = { version: 1; provenance: SessionProviderContextProvenance; messages: JsonValue }
@@ -1742,8 +1740,6 @@ export type SessionMessageCompactionCompleted = {
   id: string
   metadata?: { [x: string]: JsonValue }
   time: { created: number }
-  cost?: MoneyUSD
-  tokens?: TokenUsageInfo
   status: "completed"
   reason: "auto" | "manual"
   model?: ModelRef
@@ -1751,6 +1747,8 @@ export type SessionMessageCompactionCompleted = {
   summary: string
   recent: string
   providerContext?: SessionProviderContext
+  cost?: MoneyUSD
+  tokens?: TokenUsageInfo
 }
 
 export type SessionCompactionEnded = {
@@ -3098,13 +3096,6 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
-              readonly cost?: number
-              readonly tokens?: {
-                readonly input: number
-                readonly output: number
-                readonly reasoning: number
-                readonly cache: { readonly read: number; readonly write: number }
-              }
               readonly status: "running"
               readonly reason: "auto" | "manual"
               readonly summary: string
@@ -3115,13 +3106,6 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
-              readonly cost?: number
-              readonly tokens?: {
-                readonly input: number
-                readonly output: number
-                readonly reasoning: number
-                readonly cache: { readonly read: number; readonly write: number }
-              }
               readonly status: "completed"
               readonly reason: "auto" | "manual"
               readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
@@ -3140,12 +3124,6 @@ export type SessionImportInput = {
                 }
                 readonly messages: JsonValue
               }
-            }
-          | {
-              readonly type: "compaction"
-              readonly id: string
-              readonly metadata?: { readonly [x: string]: JsonValue }
-              readonly time: { readonly created: number }
               readonly cost?: number
               readonly tokens?: {
                 readonly input: number
@@ -3153,9 +3131,22 @@ export type SessionImportInput = {
                 readonly reasoning: number
                 readonly cache: { readonly read: number; readonly write: number }
               }
+            }
+          | {
+              readonly type: "compaction"
+              readonly id: string
+              readonly metadata?: { readonly [x: string]: JsonValue }
+              readonly time: { readonly created: number }
               readonly status: "failed"
               readonly reason: "auto" | "manual"
               readonly error: { readonly type: string; readonly message: string; readonly status?: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
             }
         )
     >
@@ -3410,13 +3401,6 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
-              readonly cost?: number
-              readonly tokens?: {
-                readonly input: number
-                readonly output: number
-                readonly reasoning: number
-                readonly cache: { readonly read: number; readonly write: number }
-              }
               readonly status: "running"
               readonly reason: "auto" | "manual"
               readonly summary: string
@@ -3427,13 +3411,6 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
-              readonly cost?: number
-              readonly tokens?: {
-                readonly input: number
-                readonly output: number
-                readonly reasoning: number
-                readonly cache: { readonly read: number; readonly write: number }
-              }
               readonly status: "completed"
               readonly reason: "auto" | "manual"
               readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
@@ -3452,12 +3429,6 @@ export type SessionImportInput = {
                 }
                 readonly messages: JsonValue
               }
-            }
-          | {
-              readonly type: "compaction"
-              readonly id: string
-              readonly metadata?: { readonly [x: string]: JsonValue }
-              readonly time: { readonly created: number }
               readonly cost?: number
               readonly tokens?: {
                 readonly input: number
@@ -3465,9 +3436,22 @@ export type SessionImportInput = {
                 readonly reasoning: number
                 readonly cache: { readonly read: number; readonly write: number }
               }
+            }
+          | {
+              readonly type: "compaction"
+              readonly id: string
+              readonly metadata?: { readonly [x: string]: JsonValue }
+              readonly time: { readonly created: number }
               readonly status: "failed"
               readonly reason: "auto" | "manual"
               readonly error: { readonly type: string; readonly message: string; readonly status?: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
             }
         )
     >
@@ -3722,13 +3706,6 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
-              readonly cost?: number
-              readonly tokens?: {
-                readonly input: number
-                readonly output: number
-                readonly reasoning: number
-                readonly cache: { readonly read: number; readonly write: number }
-              }
               readonly status: "running"
               readonly reason: "auto" | "manual"
               readonly summary: string
@@ -3739,13 +3716,6 @@ export type SessionImportInput = {
               readonly id: string
               readonly metadata?: { readonly [x: string]: JsonValue }
               readonly time: { readonly created: number }
-              readonly cost?: number
-              readonly tokens?: {
-                readonly input: number
-                readonly output: number
-                readonly reasoning: number
-                readonly cache: { readonly read: number; readonly write: number }
-              }
               readonly status: "completed"
               readonly reason: "auto" | "manual"
               readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
@@ -3764,12 +3734,6 @@ export type SessionImportInput = {
                 }
                 readonly messages: JsonValue
               }
-            }
-          | {
-              readonly type: "compaction"
-              readonly id: string
-              readonly metadata?: { readonly [x: string]: JsonValue }
-              readonly time: { readonly created: number }
               readonly cost?: number
               readonly tokens?: {
                 readonly input: number
@@ -3777,9 +3741,22 @@ export type SessionImportInput = {
                 readonly reasoning: number
                 readonly cache: { readonly read: number; readonly write: number }
               }
+            }
+          | {
+              readonly type: "compaction"
+              readonly id: string
+              readonly metadata?: { readonly [x: string]: JsonValue }
+              readonly time: { readonly created: number }
               readonly status: "failed"
               readonly reason: "auto" | "manual"
               readonly error: { readonly type: string; readonly message: string; readonly status?: number }
+              readonly cost?: number
+              readonly tokens?: {
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
             }
         )
     >

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -1083,8 +1083,11 @@ export function createData(config: CreateDataInput) {
               reason: event.data.reason,
               model: event.data.model,
               providerState: event.data.providerState,
+              providerContext: event.data.providerContext,
               summary: event.data.text,
               recent: event.data.recent,
+              cost: event.data.cost,
+              tokens: event.data.tokens,
             })
             return
           }
@@ -1095,8 +1098,11 @@ export function createData(config: CreateDataInput) {
             reason: event.data.reason,
             model: event.data.model,
             providerState: event.data.providerState,
+            providerContext: event.data.providerContext,
             summary: event.data.text,
             recent: event.data.recent,
+            cost: event.data.cost,
+            tokens: event.data.tokens,
             time: { created: event.created },
           })
         })
@@ -1116,6 +1122,8 @@ export function createData(config: CreateDataInput) {
               message: "Compaction failed before recording an error",
             },
             metadata: current?.type === "compaction" ? current.metadata : event.metadata,
+            cost: event.data.cost,
+            tokens: event.data.tokens,
             time: current?.type === "compaction" ? current.time : { created: event.created },
           }
           if (current?.type === "compaction") {

--- a/packages/client/test/solid-compaction.test.ts
+++ b/packages/client/test/solid-compaction.test.ts
@@ -100,13 +100,24 @@ test.each(["started", "cancelled", "failed"])(
       expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ type: "compaction", status: "running" }])
       const model = { providerID: "demo", id: "model" }
       const providerState = { responseId: "summary-response" }
+      const tokens = { input: 10, output: 4, reasoning: 0, cache: { read: 3, write: 0 } }
       fixture.emit({
         ...event,
         type: "session.compaction.ended",
-        data: { sessionID, reason: "manual", model, providerState, text: "Summary", recent: "Recent" },
+        data: {
+          sessionID,
+          reason: "manual",
+          model,
+          providerState,
+          text: "Summary",
+          recent: "Recent",
+          cost: 0.01,
+          tokens,
+        },
       })
+      // The live fold carries the request usage so the label matches a reloaded session.
       expect(fixture.data.session.message.list(sessionID)).toMatchObject([
-        { type: "compaction", status: "completed", summary: "Summary", model, providerState },
+        { type: "compaction", status: "completed", summary: "Summary", model, providerState, cost: 0.01, tokens },
       ])
     }
   },

--- a/packages/client/test/solid-compaction.test.ts
+++ b/packages/client/test/solid-compaction.test.ts
@@ -101,6 +101,18 @@ test.each(["started", "cancelled", "failed"])(
       const model = { providerID: "demo", id: "model" }
       const providerState = { responseId: "summary-response" }
       const tokens = { input: 10, output: 4, reasoning: 0, cache: { read: 3, write: 0 } }
+      const providerContext = {
+        version: 1 as const,
+        provenance: {
+          providerID: "demo",
+          provider: "demo",
+          modelID: "model",
+          route: "demo-responses",
+          protocol: "demo",
+          endpoint: "digest",
+        },
+        messages: [],
+      }
       fixture.emit({
         ...event,
         type: "session.compaction.ended",
@@ -109,15 +121,25 @@ test.each(["started", "cancelled", "failed"])(
           reason: "manual",
           model,
           providerState,
+          providerContext,
           text: "Summary",
           recent: "Recent",
           cost: 0.01,
           tokens,
         },
       })
-      // The live fold carries the request usage so the label matches a reloaded session.
+      // The live fold carries the provider window and request usage so the label matches a reloaded session.
       expect(fixture.data.session.message.list(sessionID)).toMatchObject([
-        { type: "compaction", status: "completed", summary: "Summary", model, providerState, cost: 0.01, tokens },
+        {
+          type: "compaction",
+          status: "completed",
+          summary: "Summary",
+          model,
+          providerState,
+          providerContext,
+          cost: 0.01,
+          tokens,
+        },
       ])
     }
   },

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -383,14 +383,7 @@ export const layer = Layer.effect(
         },
       }),
     })
-    const failed = Effect.fnUntraced(function* (input: {
-      readonly sessionID: SessionSchema.ID
-      readonly reason: SessionMessage.Compaction["reason"]
-      readonly error: SessionError.Error
-      readonly inputID?: SessionMessage.ID
-      readonly cost?: SessionUsage.Recorded["cost"]
-      readonly tokens?: SessionUsage.Recorded["tokens"]
-    }) {
+    const failed = Effect.fnUntraced(function* (input: SessionEvent.Compaction.Failed["data"]) {
       yield* bus.publish(SessionEvent.Compaction.Failed, input)
       return { status: "failed" as const, error: input.error }
     })
@@ -404,14 +397,13 @@ export const layer = Layer.effect(
             inputID: input.inputID,
           })
     // Manual controls settle through the inbox; only automatic work needs a durable interruption record.
-    const interrupted = (input: ExecuteInput, usage?: SessionUsage.Recorded) =>
+    const interrupted = (input: ExecuteInput) =>
       input.reason === "auto"
         ? failed({
             sessionID: input.context.session.id,
             reason: input.reason,
             inputID: input.inputID,
             error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
-            ...usage,
           }).pipe(Effect.asVoid)
         : Effect.void
     const compactionRequest = (
@@ -649,7 +641,7 @@ export const layer = Layer.effect(
               failure = toSessionError(error)
             }),
           ),
-          Effect.onInterrupt(() => recordUsage.pipe(Effect.andThen(interrupted(input, usage)))),
+          Effect.onInterrupt(() => recordUsage.pipe(Effect.andThen(interrupted(input)))),
         )
         if (failure || hasSummarySection(chunks.join(""))) break
       }

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -388,6 +388,8 @@ export const layer = Layer.effect(
       readonly reason: SessionMessage.Compaction["reason"]
       readonly error: SessionError.Error
       readonly inputID?: SessionMessage.ID
+      readonly cost?: SessionUsage.Recorded["cost"]
+      readonly tokens?: SessionUsage.Recorded["tokens"]
     }) {
       yield* bus.publish(SessionEvent.Compaction.Failed, input)
       return { status: "failed" as const, error: input.error }
@@ -402,13 +404,14 @@ export const layer = Layer.effect(
             inputID: input.inputID,
           })
     // Manual controls settle through the inbox; only automatic work needs a durable interruption record.
-    const interrupted = (input: ExecuteInput) =>
+    const interrupted = (input: ExecuteInput, usage?: SessionUsage.Recorded) =>
       input.reason === "auto"
         ? failed({
             sessionID: input.context.session.id,
             reason: input.reason,
             inputID: input.inputID,
             error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
+            ...usage,
           }).pipe(Effect.asVoid)
         : Effect.void
     const compactionRequest = (
@@ -504,11 +507,12 @@ export const layer = Layer.effect(
               )
             }),
           )
-          if (result.usage)
+          const usage = result.usage ? SessionUsage.record(result.usage, context.model.cost) : undefined
+          if (usage)
             yield* bus.publish(SessionEvent.UsageRecorded, {
               sessionID: context.session.id,
               source: "compaction" as const,
-              ...SessionUsage.record(result.usage, context.model.cost),
+              ...usage,
             })
           yield* bus.publish(SessionEvent.Compaction.Ended, {
             sessionID: context.session.id,
@@ -517,6 +521,7 @@ export const layer = Layer.effect(
             text: "",
             recent: "",
             providerContext: SessionProviderContext.encode(provenance, result.replacement),
+            ...usage,
           })
           return { status: "completed" as const }
         }),
@@ -644,7 +649,7 @@ export const layer = Layer.effect(
               failure = toSessionError(error)
             }),
           ),
-          Effect.onInterrupt(() => recordUsage.pipe(Effect.andThen(interrupted(input)))),
+          Effect.onInterrupt(() => recordUsage.pipe(Effect.andThen(interrupted(input, usage)))),
         )
         if (failure || hasSummarySection(chunks.join(""))) break
       }
@@ -662,6 +667,7 @@ export const layer = Layer.effect(
           reason: input.reason,
           error,
           inputID: input.inputID,
+          ...usage,
         })
       }
       yield* bus.publish(SessionEvent.Compaction.Ended, {
@@ -671,6 +677,7 @@ export const layer = Layer.effect(
         providerState,
         text: summary,
         recent: history.recent,
+        ...usage,
       })
       return { status: "completed" as const }
     })

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -415,6 +415,8 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               summary: event.data.text,
               providerContext: event.data.providerContext,
               recent: event.data.recent,
+              cost: event.data.cost,
+              tokens: event.data.tokens,
             })
             return
           }
@@ -430,6 +432,8 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               summary: event.data.text,
               providerContext: event.data.providerContext,
               recent: event.data.recent,
+              cost: event.data.cost,
+              tokens: event.data.tokens,
               time: { created },
             }),
           )
@@ -444,6 +448,8 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             metadata: current?.metadata ?? event.metadata,
             reason: event.data.reason,
             error: event.data.error,
+            cost: event.data.cost,
+            tokens: event.data.tokens,
             time: current?.time ?? { created },
           })
           if (current?.status === "running") return yield* adapter.updateCompaction(failed)

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -401,8 +401,16 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(JSON.stringify(requests[0]?.messages)).toContain("Use Effect services and generators.")
     expect(JSON.stringify(requests[0]?.messages)).toContain("User shell pwd completed: /project")
     expect(JSON.stringify(requests[0]?.messages)).not.toContain("display-only-output")
+    // The compaction message carries its own request usage so clients can show what compacting cost.
     expect(yield* store.context(sessionID)).toMatchObject([
-      { type: "compaction", reason: "manual", summary: "## Objective\n- manual summary", recent: "" },
+      {
+        type: "compaction",
+        reason: "manual",
+        summary: "## Objective\n- manual summary",
+        recent: "",
+        cost: 0.0000233,
+        tokens: { input: 10, output: 4, reasoning: 2, cache: { read: 3, write: 2 } },
+      },
     ])
     expect(yield* store.get(sessionID)).toMatchObject({
       cost: 0.0000233,

--- a/packages/core/test/session-native-compaction.test.ts
+++ b/packages/core/test/session-native-compaction.test.ts
@@ -240,6 +240,8 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
       return yield* Effect.die("Missing native checkpoint")
     expect(last.summary).toBe("")
     expect(last.recent).toBe("")
+    // Provider compaction has no summary, so the request usage is the only visible cost of the operation.
+    expect(last.tokens).toMatchObject({ input: 20, output: 4 })
     return last.providerContext
   })
   return {

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -590,6 +590,8 @@ export namespace Compaction {
       providerContext: SessionMessage.CompactionCompleted.fields.providerContext,
       text: Schema.String,
       recent: Schema.String,
+      // Repeats the internal `session.usage.recorded` figures: that event never reaches clients, and it
+      // stays the accounting source for session totals and stats.
       cost: SessionMessage.CompactionCompleted.fields.cost,
       tokens: SessionMessage.CompactionCompleted.fields.tokens,
     },

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -590,6 +590,8 @@ export namespace Compaction {
       providerContext: SessionMessage.CompactionCompleted.fields.providerContext,
       text: Schema.String,
       recent: Schema.String,
+      cost: SessionMessage.CompactionCompleted.fields.cost,
+      tokens: SessionMessage.CompactionCompleted.fields.tokens,
     },
   })
   export type Ended = typeof Ended.Type
@@ -602,6 +604,8 @@ export namespace Compaction {
       reason: Started.data.fields.reason,
       error: SessionError.Error,
       inputID: SessionMessage.ID.pipe(optional),
+      cost: SessionMessage.CompactionFailed.fields.cost,
+      tokens: SessionMessage.CompactionFailed.fields.tokens,
     },
   })
   export type Failed = typeof Failed.Type

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -235,10 +235,10 @@ export const Assistant = Schema.Struct({
   }),
 }).annotate({ identifier: "Session.Message.Assistant" })
 
-const CompactionBase = {
-  type: Schema.tag("compaction"),
-  ...Base,
-  /** Usage of the compaction request itself, not the size of the resulting context. */
+const CompactionBase = { type: Schema.tag("compaction"), ...Base }
+
+/** Usage of the compaction request itself, not the size of the resulting context. */
+const CompactionUsage = {
   cost: Money.USD.pipe(optional),
   tokens: TokenUsage.Info.pipe(optional),
 }
@@ -262,6 +262,7 @@ export const CompactionCompleted = Schema.Struct({
   summary: Schema.String,
   recent: Schema.String,
   providerContext: SessionProviderContext.Info.pipe(optional),
+  ...CompactionUsage,
 }).annotate({ identifier: "Session.Message.Compaction.Completed" })
 
 export interface CompactionFailed extends Schema.Schema.Type<typeof CompactionFailed> {}
@@ -270,6 +271,7 @@ export const CompactionFailed = Schema.Struct({
   status: Schema.tag("failed"),
   reason: Schema.Literals(["auto", "manual"]),
   error: SessionError.Error,
+  ...CompactionUsage,
 }).annotate({ identifier: "Session.Message.Compaction.Failed" })
 
 export const Compaction = Schema.Union([CompactionRunning, CompactionCompleted, CompactionFailed]).pipe(

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -235,7 +235,13 @@ export const Assistant = Schema.Struct({
   }),
 }).annotate({ identifier: "Session.Message.Assistant" })
 
-const CompactionBase = { type: Schema.tag("compaction"), ...Base }
+const CompactionBase = {
+  type: Schema.tag("compaction"),
+  ...Base,
+  /** Usage of the compaction request itself, not the size of the resulting context. */
+  cost: Money.USD.pipe(optional),
+  tokens: TokenUsage.Info.pipe(optional),
+}
 
 export interface CompactionRunning extends Schema.Schema.Type<typeof CompactionRunning> {}
 export const CompactionRunning = Schema.Struct({

--- a/packages/session-ui/src/message/message-content.tsx
+++ b/packages/session-ui/src/message/message-content.tsx
@@ -389,8 +389,8 @@ export function SessionCompactionMessage(props: { message: SessionMessageCompact
   )
   // Usage of the compaction request itself; the resulting context size only shows on the next assistant step.
   const usage = () => {
+    if (props.message.status === "running" || !props.message.tokens) return ""
     const tokens = props.message.tokens
-    if (!tokens) return ""
     const input = tokens.input + tokens.cache.read + tokens.cache.write
     const output = tokens.output + tokens.reasoning
     if (input + output <= 0) return ""
@@ -399,17 +399,23 @@ export function SessionCompactionMessage(props: { message: SessionMessageCompact
       output: compact().format(output),
     })
   }
-  const label = () =>
-    i18n.t(
-      props.message.status === "completed" && props.message.providerContext
-        ? "ui.messagePart.providerCompaction"
-        : "ui.messagePart.compaction",
-    )
+  const label = createMemo(() =>
+    [
+      i18n.t(
+        props.message.status === "completed" && props.message.providerContext
+          ? "ui.messagePart.providerCompaction"
+          : "ui.messagePart.compaction",
+      ),
+      usage(),
+    ]
+      .filter(Boolean)
+      .join(" · "),
+  )
 
   return (
     <div data-component="session-compaction-message">
       <div class="py-2">
-        <TimelineSeparator label={usage() ? `${label()} · ${usage()}` : label()} />
+        <TimelineSeparator label={label()} />
       </div>
       <Show when={summary().trim()}>
         <div data-component="text-part" data-timeline-part-id={props.message.id}>

--- a/packages/session-ui/src/message/message-content.tsx
+++ b/packages/session-ui/src/message/message-content.tsx
@@ -384,17 +384,32 @@ export function SessionCompactionMessage(props: { message: SessionMessageCompact
     if (props.message.status !== "failed" || props.message.error.type === "aborted") return ""
     return props.error
   }
+  const compact = createMemo(
+    () => new Intl.NumberFormat(i18n.locale(), { notation: "compact", maximumFractionDigits: 1 }),
+  )
+  // Usage of the compaction request itself; the resulting context size only shows on the next assistant step.
+  const usage = () => {
+    const tokens = props.message.tokens
+    if (!tokens) return ""
+    const input = tokens.input + tokens.cache.read + tokens.cache.write
+    const output = tokens.output + tokens.reasoning
+    if (input + output <= 0) return ""
+    return i18n.t("ui.messagePart.compaction.usage", {
+      input: compact().format(input),
+      output: compact().format(output),
+    })
+  }
+  const label = () =>
+    i18n.t(
+      props.message.status === "completed" && props.message.providerContext
+        ? "ui.messagePart.providerCompaction"
+        : "ui.messagePart.compaction",
+    )
 
   return (
     <div data-component="session-compaction-message">
       <div class="py-2">
-        <TimelineSeparator
-          label={i18n.t(
-            props.message.status === "completed" && props.message.providerContext
-              ? "ui.messagePart.providerCompaction"
-              : "ui.messagePart.compaction",
-          )}
-        />
+        <TimelineSeparator label={usage() ? `${label()} · ${usage()}` : label()} />
       </div>
       <Show when={summary().trim()}>
         <div data-component="text-part" data-timeline-part-id={props.message.id}>

--- a/packages/session-ui/src/storybook/current-session-fixtures.ts
+++ b/packages/session-ui/src/storybook/current-session-fixtures.ts
@@ -998,6 +998,8 @@ export const compactionDocument = document([
     reason: "auto",
     summary: "The Session timeline now consumes current nested assistant content.",
     recent: "Add deterministic stories and verify Storybook.",
+    cost: 0.0142,
+    tokens: { input: 3_180, output: 412, reasoning: 96, cache: { read: 8_704, write: 0 } },
     time: { created: STORY_TIME + 63_000 },
   },
   assistant({

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2100,8 +2100,8 @@ function CompactionMessage(props: { message: Extract<SessionMessageInfo, { type:
   const color = () => (status() === "failed" && !cancelled() ? theme.text.feedback.error.default : theme.text.subdued)
   // Usage of the compaction request itself; the resulting context size only shows on the next assistant step.
   const usage = () => {
+    if (props.message.status === "running" || !props.message.tokens) return
     const tokens = props.message.tokens
-    if (!tokens) return
     const input = tokens.input + tokens.cache.read + tokens.cache.write
     const output = tokens.output + tokens.reasoning
     if (input + output <= 0) return
@@ -3851,12 +3851,7 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined
 }
 
-function formatSessionTranscript(
-  session: SessionInfo,
-  messages: SessionMessageInfo[],
-  thinking: boolean,
-  tools = true,
-) {
+function formatSessionTranscript(session: SessionInfo, messages: SessionMessageInfo[], thinking: boolean, tools = true) {
   const body = messages.flatMap((message) => {
     if (message.type === "user") return [`## User\n\n${message.text}`]
     if (message.type === "shell")

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2098,6 +2098,15 @@ function CompactionMessage(props: { message: Extract<SessionMessageInfo, { type:
     props.message.status === "failed" ? (cancelled() ? "" : props.message.error.message) : props.message.summary
   const content = createMemo(() => text().trim())
   const color = () => (status() === "failed" && !cancelled() ? theme.text.feedback.error.default : theme.text.subdued)
+  // Usage of the compaction request itself; the resulting context size only shows on the next assistant step.
+  const usage = () => {
+    const tokens = props.message.tokens
+    if (!tokens) return
+    const input = tokens.input + tokens.cache.read + tokens.cache.write
+    const output = tokens.output + tokens.reasoning
+    if (input + output <= 0) return
+    return `${Locale.number(input)} in · ${Locale.number(output)} out`
+  }
   return (
     <box>
       <box flexDirection="row" alignItems="center">
@@ -2120,6 +2129,9 @@ function CompactionMessage(props: { message: Extract<SessionMessageInfo, { type:
           </text>
           <Show when={cancelled()}>
             <text fg={color()}>· cancelled</text>
+          </Show>
+          <Show when={usage()}>
+            <text fg={color()}>· {usage()}</text>
           </Show>
         </box>
         <box border={["top"]} borderColor={color()} flexGrow={1} />
@@ -3839,7 +3851,12 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined
 }
 
-function formatSessionTranscript(session: SessionInfo, messages: SessionMessageInfo[], thinking: boolean, tools = true) {
+function formatSessionTranscript(
+  session: SessionInfo,
+  messages: SessionMessageInfo[],
+  thinking: boolean,
+  tools = true,
+) {
   const body = messages.flatMap((message) => {
     if (message.type === "user") return [`## User\n\n${message.text}`]
     if (message.type === "shell")

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -105,6 +105,7 @@ const source = {
   "ui.messagePart.questions.dismissed": "Questions dismissed",
   "ui.messagePart.compaction": "Session compacted",
   "ui.messagePart.providerCompaction": "Session compacted by provider",
+  "ui.messagePart.compaction.usage": "{{input}} in · {{output}} out",
   "ui.messagePart.context.details": "Details",
   "ui.messagePart.context.read.one": "{{count}} read",
   "ui.messagePart.context.read.other": "{{count}} reads",


### PR DESCRIPTION
## Summary
- Feedback on provider compaction: it is hard to tell how many tokens compacting took. The usage was recorded in session totals through the internal `session.usage.recorded` event, but nothing attached it to the compaction message, and that event never reaches clients.
- Carry `cost`/`tokens` on `Compaction.Ended` and `Compaction.Failed`, the same way `Step.Ended` carries a step's usage for the assistant message, and expose them on the completed and failed compaction messages. Applies to local summaries and provider checkpoints alike. `session.usage.recorded` is unchanged and remains the accounting source for session totals and stats; the event schema says so where the fields are repeated.
- TUI divider becomes `Provider compaction · 18.2K in · 263 out`; session-ui gets the same through a new `ui.messagePart.compaction.usage` key. The client fold also copies `providerContext` on `compaction.ended`, so the "Provider compaction" label now matches a reloaded session instead of appearing only after refetch.

The two numbers are the compaction request's usage, not the resulting context size — that only shows on the next assistant step, and the label comment says so.

## Validation
- `session-compaction.test.ts` and `session-native-compaction.test.ts` assert `cost`/`tokens` on the completed compaction message for local and provider paths; `solid-compaction.test.ts` asserts the live client fold including `providerContext`.
- Live: an isolated V2 server with provider compaction shows `auto` `tokens.input 18163 / output 263` and `manual` `2672 (+8704 cached) / 391` on the compaction rows.
- `bun run generate` in `packages/client`; typecheck clean for schema, core, client, tui, session-ui, ui. Tests: core 5,248 passed, client 160, tui 1,344, session-ui 180. (`packages/schema` `contract-hygiene` fails on `v2` already: `Schema.Any` in `integration.ts` since 297a3328c6.)
