### PR TITLE
feat(opencode): add server.openBrowser config option

### DIFF
--- a/packages/core/src/v1/config/server.ts
+++ b/packages/core/src/v1/config/server.ts
@@ -12,6 +12,9 @@ export const Server = Schema.Struct({
   mdnsDomain: Schema.optional(Schema.String).annotate({
     description: "Custom domain name for mDNS service (default: opencode.local)",
   }),
+  openBrowser: Schema.optional(Schema.Boolean).annotate({
+    description: "Open the web interface in a browser automatically when running `opencode web` (default: true)",
+  }),
   cors: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional domains to allow for CORS",
   }),

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -72,11 +72,11 @@ export const WebCommand = effectCmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl).catch(() => {})
+      if (opts.openBrowser) open(localhostUrl).catch(() => {})
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      if (opts.openBrowser) open(displayUrl).catch(() => {})
     }
 
     yield* Effect.never

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -76,5 +76,7 @@ export function resolveNetworkOptionsNoConfig(args: NetworkOptions, config?: Con
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 
-  return { hostname, port, mdns, mdnsDomain, cors }
+  const openBrowser = config?.server?.openBrowser ?? true
+
+  return { hostname, port, mdns, mdnsDomain, cors, openBrowser }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1651,6 +1651,7 @@ export type ServerConfig = {
   hostname?: string
   mdns?: boolean
   mdnsDomain?: string
+  openBrowser?: boolean
   cors?: Array<string>
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -20551,6 +20551,9 @@
           "mdnsDomain": {
             "type": "string"
           },
+          "openBrowser": {
+            "type": "boolean"
+          },
           "cors": {
             "type": "array",
             "items": {

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -309,6 +309,7 @@ You can configure server settings for the `opencode serve` and `opencode web` co
     "hostname": "0.0.0.0",
     "mdns": true,
     "mdnsDomain": "myproject.local",
+    "openBrowser": false,
     "cors": ["http://localhost:5173"]
   }
 }
@@ -320,6 +321,7 @@ Available options:
 - `hostname` - Hostname to listen on. When `mdns` is enabled and no hostname is set, defaults to `0.0.0.0`.
 - `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your OpenCode server.
 - `mdnsDomain` - Custom domain name for mDNS service. Defaults to `opencode.local`. Useful for running multiple instances on the same network.
+- `openBrowser` - Automatically open the web interface in a browser when running `opencode web`. Defaults to `true`. Set to `false` to only print the URL (useful in containers, WSL, or background services).
 - `cors` - Additional origins to allow for CORS when using the HTTP server from a browser-based client. Values must be full origins (scheme + host + optional port), eg `https://app.example.com`.
 
 [Learn more about the server here](/docs/server).


### PR DESCRIPTION
### Issue for this PR

Part of #43636, #14520, #13419, #31815 (config half; CLI flag is covered by #41167)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `server.openBrowser` config option so `opencode web` can be started without automatically launching a browser tab, e.g. for systemd/WSL startup, containers, or headless hosts:

```json
{
  "server": {
    "openBrowser": false
  }
}
```

- New optional boolean in the `Server` config schema (`packages/core/src/v1/config/server.ts`), defaulting to `true` so existing behavior is unchanged.
- Resolved alongside the other server options in `resolveNetworkOptionsNoConfig` and used to gate both browser-launch paths in `opencode web`; the server URL is still printed so it can be opened manually.
- This composes with the `--open`/`--no-open` flag from #41167: once that lands, an explicit flag should win over the config value using the existing `hasBooleanArg` precedence pattern (same as `--mdns`).
- Regenerated `packages/sdk/openapi.json` and the legacy SDK types; documented the option in `config.mdx`.

Browser selection / `$BROWSER` support from #14520 is intentionally out of scope.

### How did you verify your code works?

- `bun typecheck` passes in `packages/core` and `packages/opencode`.
- `bun test test/config/config.test.ts` (108 pass) and `bun test test/cli/help/help-snapshots.test.ts` (34 snapshots) pass.
- Regenerated artifacts contain only the expected one-field additions to `ServerConfig`.

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
