### PR TITLE
fix(worktree): resolve configured paths relative to project

### DIFF
--- a/packages/core/src/config/plugin/worktree.ts
+++ b/packages/core/src/config/plugin/worktree.ts
@@ -26,7 +26,7 @@ export const Plugin = define({
           directory: AbsolutePath.make(
             directory.startsWith("~/")
               ? path.join(global.home, directory.slice(2))
-              : path.resolve(entry.path ? path.dirname(entry.path) : location.directory, directory),
+              : path.resolve(location.project.canonical, directory),
           ),
         })
       }

--- a/packages/core/test/worktree.test.ts
+++ b/packages/core/test/worktree.test.ts
@@ -315,6 +315,15 @@ describe("Worktree", () => {
       const bus = yield* Bus.Service
       const context = yield* Layer.build(worktreeLayer(selected.directory, selected.id, database, bus, root.path))
       const worktrees = Context.get(context, Worktree.Service)
+      const config = yield* Config.Test
+      yield* config.setEntries([
+        new Document({
+          type: "document",
+          path: abs(path.join(root.path, "global/opencode.json")),
+          info: new Info({ worktree: { directory: ".lane/trees" } }),
+        }),
+      ])
+      yield* ConfigWorktreePlugin.Plugin.effect(host()).pipe(Effect.provide(context))
       yield* projects.update({
         projectID: initial.id,
         commands: {
@@ -326,11 +335,11 @@ describe("Worktree", () => {
       const created = yield* worktrees.create({
         strategy: gitWorktree,
         from: selected.canonical,
-        directory: abs(path.join(root.path, "worktrees")),
         name: "selected-clone",
       })
 
       expect(selected.id).toBe(initial.id)
+      expect(created.directory).toBe(abs(path.join(clone, ".lane/trees/selected-clone")))
       expect((yield* projects.list()).find((project) => project.id === initial.id)?.canonical).toBe(main)
       expect(yield* Effect.promise(() => $`git rev-parse HEAD`.cwd(created.directory).text())).toBe(
         yield* Effect.promise(() => $`git rev-parse HEAD`.cwd(clone).text()),
@@ -911,7 +920,7 @@ describe("Worktree", () => {
         }),
       )
       const first = yield* worktrees.create({ name: "one" })
-      expect(first.directory).toBe(abs(path.join(input.root.path, "nested/copies/one")))
+      expect(first.directory).toBe(abs(path.join(input.root.path, "copies/one")))
       expect(yield* stored(input.projectID)).toContainEqual({ directory: first.directory, strategy: "custom" })
       yield* config.setEntries(documents.slice(0, 1))
       yield* bus.publish(Event.Updated, {})
@@ -925,6 +934,50 @@ describe("Worktree", () => {
       expect(third.directory).toBe(abs(path.join(input.root.path, "worktree", input.projectID.slice(0, 6), "three")))
     }),
   )
+  ;["relative", "absolute", "home"].forEach((mode) => {
+    it.live(`resolves ${mode} global directory config from a linked checkout's subdirectory`, () =>
+      Effect.gen(function* () {
+        const input = yield* setup()
+        const config = yield* Config.Test
+        const projects = yield* Project.Service
+        const global = yield* Global.Service
+        const worktrees = yield* Worktree.Service
+        const linked = abs(path.join(input.root.path, "linked"))
+        const nested = abs(path.join(linked, "src"))
+        const home = abs(path.join(input.root.path, "home"))
+        yield* Effect.promise(async () => {
+          await $`git worktree add ${linked} -b linked`.cwd(input.sourceDirectory).quiet()
+          await fs.mkdir(nested)
+        })
+        const project = yield* projects.resolve(nested)
+        const directory =
+          mode === "relative" ? ".lane/trees" : mode === "home" ? "~/copies" : path.join(home, "absolute")
+        yield* config.setEntries([
+          new Document({
+            type: "document",
+            path: abs(path.join(home, ".config/opencode/opencode.json")),
+            info: new Info({ worktree: { directory } }),
+          }),
+        ])
+        yield* ConfigWorktreePlugin.Plugin.effect(host()).pipe(
+          Effect.provideService(Location.Service, { directory: nested, project }),
+          Effect.provideService(Global.Service, { ...global, home }),
+        )
+
+        const created = yield* worktrees.create({ name: "task" })
+
+        expect(project.directory).toBe(linked)
+        expect(project.canonical).toBe(input.sourceDirectory)
+        expect(created.directory).toBe(
+          abs(
+            mode === "relative"
+              ? path.join(input.sourceDirectory, ".lane/trees/task")
+              : path.join(home, mode === "home" ? "copies/task" : "absolute/task"),
+          ),
+        )
+      }),
+    )
+  })
 
   it.effect("normalization retains worktree directory and rejects invalid configuration", () =>
     Effect.sync(() => {

--- a/packages/schema/src/config/worktree.ts
+++ b/packages/schema/src/config/worktree.ts
@@ -4,7 +4,7 @@ import { Schema } from "effect"
 
 export const Info = Schema.Struct({
   directory: Schema.Trim.pipe(Schema.check(Schema.isNonEmpty())).annotate({
-    description: "Parent directory for new worktrees, relative to the declaring config file when not absolute",
+    description: "Parent directory for new worktrees, relative to the project's primary checkout when not absolute",
   }),
 }).annotate({ identifier: "Config.Worktree" })
 export interface Info extends Schema.Schema.Type<typeof Info> {}

--- a/services/www/src/docs/content/config.mdx
+++ b/services/www/src/docs/content/config.mdx
@@ -473,7 +473,20 @@ Set the parent directory for new local worktrees. OpenCode appends the requested
 }
 ```
 
-Relative paths resolve against the config file that declares them; `~/` resolves against the user's home directory.
+Relative paths resolve against the project's primary checkout, including when called from a subdirectory or linked
+worktree. This applies to global and project configuration alike; absolute paths are used as-is, and `~/` resolves
+against the user's home directory.
+
+For example, this global configuration places new worktrees under each project's own `.lane/trees/` directory:
+
+```jsonc
+{
+  "worktree": {
+    "directory": ".lane/trees",
+  },
+}
+```
+
 Without this setting, creation uses the server's data directory under `worktree/<first-six-project-ID-characters>`.
 Configuration applies to the caller's location, not every clone sharing a project ID. Changing it does not move existing worktrees.
 


### PR DESCRIPTION
## Summary
- Resolve relative `worktree.directory` settings against the primary checkout of the operation’s local repository, rather than the declaring config file.
- Allow global configuration such as `"directory": ".lane/trees"` to apply independently to each repository, including calls from linked worktrees and subdirectories.
- Preserve absolute paths, `~/` expansion, config precedence/reload behavior, and the default data-directory destination.
- Update the schema description and configuration documentation.

## Behavior change
Existing relative settings in global, nested, or `.opencode/` config files now resolve from the project’s primary checkout. Project-root config paths resolve as before. Separate clones sharing a project ID use their own primary checkout.

## Validation
- `packages/core`: `bun test test/worktree.test.ts` — 35 passing tests
- `packages/core`: `bun typecheck`
- `packages/schema`: `bun typecheck`
- `services/www`: `bun typecheck`, `bun run check:generated`, `bun run build`
- Prettier and `git diff --check`

Regression coverage includes global relative/absolute/home paths from a linked checkout’s subdirectory, independent clones, config precedence, reload, and removal of configured defaults.