### PR TITLE
fix(worktree): accept the strategy's returned directory

### DIFF
--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -254,8 +254,6 @@ const layer = Layer.effect(
         })
         .pipe(Effect.mapError((error) => operationError(selected.id, "create", error)))
       const result = { directory: yield* canonical(fs, created.directory) }
-      if (result.directory !== (yield* canonical(fs, worktreeDirectory)))
-        return yield* new InvalidDirectoryError({ directory: result.directory })
       yield* changed(
         yield* ops.create({
           directory: result.directory,

--- a/packages/plugin/src/worktree.ts
+++ b/packages/plugin/src/worktree.ts
@@ -1,5 +1,6 @@
 export interface WorktreeCreateInput {
   readonly sourceDirectory: string
+  /** Suggested destination after naming and collision handling. Strategies may return a different directory. */
   readonly directory: string
   /** Starting ref, not the name of a new branch. Reject unsupported refs rather than ignoring them. */
   readonly branch?: string
@@ -11,6 +12,7 @@ export interface WorktreeRemoveInput {
 }
 
 export interface WorktreeResult {
+  /** Actual directory created by the strategy, used for inventory and startup commands. */
   readonly directory: string
 }
 

--- a/services/www/src/docs/content/build/plugins/index.mdx
+++ b/services/www/src/docs/content/build/plugins/index.mdx
@@ -1025,8 +1025,12 @@ force confirmation without depending on Core or Git errors.
 
 #### Reference
 
-Implementations receive the final destination after naming and collision handling. Return that directory from `create`;
-`list` must report only directories the strategy owns, plus any repository roots. Core owns inventory and startup commands.
+Implementations receive a suggested destination after naming and collision handling. Return the actual directory from
+`create`; it may differ when a backend requires its own layout. OpenCode resolves the returned path and uses it for
+inventory, startup commands, and the API result. The returned directory must exist.
+
+Strategies choosing another destination handle naming collisions there. OpenCode still creates the suggested parent
+directory before calling the strategy. `list` must report only directories the strategy owns, plus any repository roots.
 
 ```ts
 interface WorktreeDefinition {


### PR DESCRIPTION
## Summary
Treat the directory returned by a worktree strategy as authoritative. Backends such as Lane require a fixed layout (`<primary-checkout>/.lane/trees`) and cannot always create at OpenCode’s suggested destination.

- Remove the equality check between the suggested and actual directory.
- Continue requiring the returned directory to exist and resolve successfully.
- Use the existing returned-directory handling for inventory, startup commands, and the API response.
- Keep parent-directory creation and collision checks at the suggested destination. Strategies choosing another location handle collisions there.
- Document the contract in the shared plugin types and plugin guide.

## Validation
- Worktree and Promise-adapter tests passed.
- Core and plugin type checks passed.
- Website type check, generated-file check, and build passed.
- Prettier and `git diff --check` passed.

No test changes included, as requested.