### PR TITLE
fix(core): name hosted provider opencode web search

### DIFF
--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -213,7 +213,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | Bus.Service | Scope
       if (!descriptor || !connection) return
       editor.add({
         id: descriptor.providerID,
-        name: "OpenCode",
+        name: "OpenCode Web Search",
         execute: (input) =>
           Effect.gen(function* () {
             const active = yield* ctx.integration.connection.active("opencode")

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -432,13 +432,13 @@ describe("OpencodePlugin", () => {
           yield* drain
           expect(state.requests).toBe(2)
           expect(rebuilds).toEqual({ catalog: initial.catalog + 1, websearch: initial.websearch + 1 })
-          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode" })
+          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode Web Search" })
 
           yield* TestClock.adjust("10 minutes")
           yield* drain
           expect(state.requests).toBe(3)
           expect(rebuilds).toEqual({ catalog: initial.catalog + 1, websearch: initial.websearch + 1 })
-          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode" })
+          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode Web Search" })
 
           state.advertised = false
           yield* TestClock.adjust("10 minutes")
@@ -526,9 +526,12 @@ describe("OpencodePlugin", () => {
           })
 
           yield* addPlugin()
-          expect(yield* websearch.providers()).toContainEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode" })
-          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode" })
-          expect(yield* websearch.query({ query: "effect code search" })).toEqual(
+          expect(yield* websearch.providers()).toContainEqual({
+            id: WebSearch.ID.make("opencode"),
+            name: "OpenCode Web Search",
+          })
+          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("opencode"), name: "OpenCode Web Search" })
+          expect(yield* websearch.query({ query: "effect web search" })).toEqual(
             new WebSearch.Response({
               providerID: WebSearch.ID.make("opencode"),
               results: [
@@ -553,7 +556,7 @@ describe("OpencodePlugin", () => {
               path: "/api/websearch",
               authorization: "Bearer secret",
               orgID: "org_test",
-              body: { query: "effect code search", providerID: "opencode" },
+              body: { query: "effect web search", providerID: "opencode" },
             },
           ])
 
@@ -657,7 +660,10 @@ describe("OpencodePlugin", () => {
             ),
           )
 
-          expect(yield* websearch.default()).toEqual({ id: WebSearch.ID.make("managed-search"), name: "OpenCode" })
+          expect(yield* websearch.default()).toEqual({
+            id: WebSearch.ID.make("managed-search"),
+            name: "OpenCode Web Search",
+          })
           expect(yield* websearch.query({ query: "default Console" })).toEqual(
             new WebSearch.Response({ providerID: WebSearch.ID.make("managed-search"), results: [] }),
           )


### PR DESCRIPTION
Rename the hosted search provider to **OpenCode Web Search** and update its display-name coverage. Provider IDs, Console endpoint derivation, authentication, and client request/response handling are unchanged. The paired Console PR broadens the supplier to general web search.

Follow-up to #47293, paired with the Web Search rename in https://github.com/anomalyco/opencode-console/pull/2023.

Validation: 61 focused core tests, all 35 repository typecheck tasks, Prettier, oxlint (no errors; two existing warnings), and Effect ast-grep checks pass.

