### PR TITLE
fix(core): map Bedrock OpenAI reasoning effort for inference-profile model IDs

### DIFF
--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -209,7 +209,7 @@ function mapBedrockRequest(input: MapInput): Pick<Mapping, "headers" | "body"> {
   const additional = isRecord(settings.additionalModelRequestFields) ? settings.additionalModelRequestFields : {}
   const reasoning = isRecord(settings.reasoningConfig) ? settings.reasoningConfig : undefined
   const anthropic = input.modelID.includes("anthropic")
-  const openai = input.modelID.startsWith("openai.")
+  const openai = input.modelID.includes("openai.")
   const effort = typeof reasoning?.maxReasoningEffort === "string" ? reasoning.maxReasoningEffort : undefined
   const type = typeof reasoning?.type === "string" ? reasoning.type : undefined
   const budget = typeof reasoning?.budgetTokens === "number" ? reasoning.budgetTokens : undefined

--- a/packages/core/test/aisdk-native.test.ts
+++ b/packages/core/test/aisdk-native.test.ts
@@ -251,10 +251,11 @@ describe("AISDKNative", () => {
       },
     })
 
-    expect(
-      map("@ai-sdk/amazon-bedrock", { reasoningConfig: { maxReasoningEffort: "high" } }, "openai.gpt-oss-120b-1:0")
-        ?.body,
-    ).toEqual({ additionalModelRequestFields: { reasoning_effort: "high" } })
+    for (const modelID of ["openai.gpt-oss-120b-1:0", "global.openai.gpt-5.6-sol", "us.openai.gpt-5.6-sol"]) {
+      expect(
+        map("@ai-sdk/amazon-bedrock", { reasoningConfig: { maxReasoningEffort: "high" } }, modelID)?.body,
+      ).toEqual({ additionalModelRequestFields: { reasoning_effort: "high" } })
+    }
   })
 
   test("maps Bedrock Mantle models to their supported native APIs", () => {


### PR DESCRIPTION
Bedrock Converse rejects OpenAI inference-profile models (e.g. `global.openai.gpt-5.6-sol`) with `Unknown parameter: 'reasoningConfig'` whenever a reasoning variant is selected.

Root cause: `mapBedrockRequest` detected OpenAI models with `startsWith("openai.")`, which misses `global.`/`us.`/`eu.` profile prefixes, so those models fell into the generic Nova-style `reasoningConfig` path instead of `reasoning_effort`. The Anthropic check on the adjacent line already used `includes()`; this aligns OpenAI detection the same way.

- `packages/core/src/aisdk-native.ts`: `startsWith("openai.")` -> `includes("openai.")`
- `packages/core/test/aisdk-native.test.ts`: cover `global.openai.gpt-5.6-sol` and `us.openai.gpt-5.6-sol` alongside the bare ID

Fixes the `GPT-5.6 Sol (Global)` Converse failure for all effort variants (`none`–`max`).