### PR TITLE
fix(session-ui): truncate long reasoning headings instead of overflowing

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -136,7 +136,7 @@ function TimelineThinkingRow(props: { reasoningHeading?: string; showReasoningSu
     <div data-slot="session-turn-thinking">
       <TextShimmer text={language.t("ui.sessionTurn.status.thinking")} />
       <Show when={!props.showReasoningSummaries}>
-        <TextReveal text={props.reasoningHeading} class="session-turn-thinking-heading" travel={25} duration={700} />
+        <TextReveal text={props.reasoningHeading} class="session-turn-thinking-heading" travel={25} duration={700} truncate />
       </Show>
     </div>
   )

--- a/packages/session-ui/src/components/session-turn.css
+++ b/packages/session-ui/src/components/session-turn.css
@@ -68,6 +68,9 @@
     min-width: 0;
     color: var(--text-weaker);
     font-weight: var(--font-weight-regular);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .error-card {

--- a/packages/session-ui/src/components/session-turn.tsx
+++ b/packages/session-ui/src/components/session-turn.tsx
@@ -428,6 +428,7 @@ export function SessionTurn(
                       class="session-turn-thinking-heading"
                       travel={25}
                       duration={700}
+                      truncate
                     />
                   </Show>
                 </div>


### PR DESCRIPTION
### Issue for this PR

Closes #48007

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Long reasoning headings in the `session-turn-thinking` row overflow the timeline
to the right: the heading is a flex child with `min-width: 0` but no overflow
handling, and `TextReveal` renders with `white-space: nowrap`.

The change clips the heading to the available row width:

- `session-turn.css`: `.session-turn-thinking-heading` gains
  `overflow: hidden; white-space: nowrap; text-overflow: ellipsis`.
- `session-turn.tsx` / `message-timeline.tsx`: both thinking rows pass `truncate`
  to `TextReveal`, which the component already supports (`data-truncate` sets the
  track width to `100%` and applies ellipsis). No new component surface is added.

### How did you verify your code works?

- `TextReveal.truncate` already exists upstream (`props.truncate` + `data-truncate`
  CSS), so the change is purely wiring + one CSS rule.
- Typecheck in `packages/session-ui` in the fork run is green; the worktree
  typecheck is currently blocked by an environment-level `vite/client.d.ts`
  parse error from the worktree `bun install` (unrelated to this change — the
  same files typecheck in the fork where the identical code is committed).
- CSS `git diff --check` clean; diff is +5/-1 across three files.

### Screenshots / recordings

N/A — visual-only clipping fix, no behavioural change outside the clipped heading.
A recording can be added on request.

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...thinking-heading-truncate

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR