### PR TITLE
docs(ecosystem): add TelegramCode

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [TelegramCode](https://github.com/olosegres/telegramcode)                                  | Telegram bot to control OpenCode from your phone, voice or text  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Related: #13372 (request for a Telegram bot to control OpenCode)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the Projects table on the ecosystem page for TelegramCode, a self-hosted Telegram bot that runs OpenCode on your own machine or VPS so you can drive it from your phone by voice or text, with one forum topic per project. Repo: https://github.com/olosegres/telegramcode

### How did you verify your code works?

Rendered the Markdown locally; the new row lines up with the existing Projects table and both links open. Only ecosystem.mdx changed.

### Screenshots / recordings

Docs only, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
