### PR TITLE
fix(app): detect session-not-found across legacy error shapes

### DIFF
--- a/packages/app/src/utils/server-errors.ts
+++ b/packages/app/src/utils/server-errors.ts
@@ -53,14 +53,31 @@ export function sessionNotFoundError(sessionID: string) {
 }
 
 export function isLocalSessionNotFoundError(error: unknown, sessionID: string) {
-  return error instanceof Error && error.message === sessionNotFoundMessage(sessionID)
+  if (error instanceof Error && error.message === sessionNotFoundMessage(sessionID)) return true
+  if (typeof error === "string" && error.includes(sessionNotFoundMessage(sessionID))) return true
+  return false
 }
 
 export function isSessionNotFoundError(error: unknown, sessionID: string) {
+  if (isLocalSessionNotFoundError(error, sessionID)) return true
   const unwrapped = unwrapNamedError(error)
   if (typeof unwrapped !== "object" || unwrapped === null) return false
   const value = unwrapped as Record<string, unknown>
-  return value._tag === "SessionNotFoundError" && value.sessionID === sessionID
+  if (value._tag === "SessionNotFoundError" && value.sessionID === sessionID) return true
+  if (
+    value.name === "NotFoundError" &&
+    typeof value.data === "object" &&
+    value.data !== null &&
+    (value.data as Record<string, unknown>).message === sessionNotFoundMessage(sessionID)
+  )
+    return true
+  if (
+    "message" in value &&
+    typeof value.message === "string" &&
+    value.message.includes(sessionNotFoundMessage(sessionID))
+  )
+    return true
+  return false
 }
 
 function isConfigInvalidErrorLike(error: unknown): error is ConfigInvalidError {


### PR DESCRIPTION
### Issue for this PR

Closes #48012

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`isSessionNotFoundError` and `isLocalSessionNotFoundError` now also recognise
session-not-found errors that arrive through other serialisation shapes, not just
the exact V1 tagged form:

- string errors whose text contains the not-found message;
- objects with `name: "NotFoundError"` whose `data.message` equals the message;
- any serialised object whose `message` includes the not-found text.

The existing exact-shape checks (`Error.message ===`, `_tag === "SessionNotFoundError"`)
are preserved, so current behaviour is unchanged where it already worked.

### How did you verify your code works?

- `bun typecheck` in `packages/app`: clean.
- The change is a pure widening of the two predicate functions; no call-site
  changes. (A focused test for the new shapes can be added if the maintainer
  wants one; none is included to keep the diff minimal.)

### Screenshots / recordings

N/A — not a UI change.

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...detect-session-errors

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR