### PR TITLE
fix(app): back off event stream reconnects after repeated failures

### DIFF
--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -262,6 +262,7 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
     started = true
     const active = ++generation
     const previous = run
+    let consecutiveErrors = 0
     const current = (async () => {
       if (previous) await previous
       // oxlint-disable-next-line no-unmodified-loop-condition -- `started` is set to false by stop() which also aborts; both flags are checked to allow graceful exit
@@ -279,6 +280,7 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
               : eventApi.event.subscribe({ signal: attempt.signal })
           let yielded = Date.now()
           for await (const event of events) {
+            consecutiveErrors = 0
             streamErrorLogged = false
             const legacy = "payload" in event
             if (legacy && event.payload.type === "sync") continue
@@ -291,6 +293,7 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
             await wait(0)
           }
         } catch (error) {
+          consecutiveErrors++
           if (!isStreamClosed(error, attempt?.signal) && !streamErrorLogged) {
             streamErrorLogged = true
             console.error("[global-sdk] event stream failed", {
@@ -305,7 +308,8 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
         }
 
         if (abort.signal.aborted || !started || generation !== active) return
-        await wait(RECONNECT_DELAY_MS)
+        const backoff = Math.min(5000, RECONNECT_DELAY_MS * Math.pow(1.5, Math.min(consecutiveErrors, 8)))
+        await wait(backoff)
       }
     })().finally(() => {
       if (run !== current) return


### PR DESCRIPTION
### Issue for this PR

Closes #48014

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The global event stream (`server-sdk.tsx`) reconnected after every failure with
the same fixed `RECONNECT_DELAY_MS` delay. This adds an exponential backoff:

- a `consecutiveErrors` counter resets on every successfully consumed event and
  increments on each catch;
- the reconnect wait becomes
  `min(5000, RECONNECT_DELAY_MS * 1.5 ** min(consecutiveErrors, 8))`,
  so repeated failures back off from 250 ms up to a 5 s cap, while a healthy
  stream keeps the fast cadence.

No other behaviour in the loop changes.

### How did you verify your code works?

- `bun typecheck` in `packages/app`: clean.
- The change is a 5-line delta restricted to the reconnect wait; the counter is
  scoped to the loop invocation and reset on any received event, so a recovered
  stream returns to the fast path immediately.

### Screenshots / recordings

N/A — not a UI change.

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...event-reconnect-backoff

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR