### PR TITLE
fix(app): align skill slash defaults with TUI

### DIFF
--- a/packages/app/src/composer/model.ts
+++ b/packages/app/src/composer/model.ts
@@ -242,7 +242,7 @@ export function createComposerModel(adapter: ComposerAdapter, options?: { queue?
       })),
   ])
   const slashSkills = createMemo(() =>
-    skills().filter((skill) => skill.slash === true && !slashCommands().some((item) => item.trigger === skill.id)),
+    skills().filter((skill) => skill.slash !== false && !slashCommands().some((item) => item.trigger === skill.id)),
   )
   const commands = createMemo<ComposerSuggestion[]>(() => [
     ...slashCommands().map((item) => ({

--- a/packages/app/src/composer/submit.test.ts
+++ b/packages/app/src/composer/submit.test.ts
@@ -310,7 +310,7 @@ describe("Composer submission", () => {
     { text: "/show-me\nexplain caching", slash: true, expected: ["show-me"] },
     { text: "/show-me\texplain caching", slash: true, expected: ["show-me"] },
     { text: "/show-me", slash: false, expected: [] },
-    { text: "/show-me", slash: undefined, expected: [] },
+    { text: "/show-me", expected: ["show-me"] },
     { text: "/show-me-extra", slash: true, expected: [] },
     { text: "Explain /show-me", slash: true, expected: [] },
   ])("resolves raw slash skill input $text with slash=$slash", async ({ text, slash, expected }) => {

--- a/packages/app/src/composer/submit.ts
+++ b/packages/app/src/composer/submit.ts
@@ -298,7 +298,7 @@ export function withSlashSkill(prompt: Prompt, skills: ReturnType<ComposerSubmit
   const first = prompt[0]
   if (first?.type !== "text") return prompt
   const name = /^\/(\S+)(?:\s|$)/.exec(first.content)?.[1]
-  const skill = skills?.find((item) => item.slash === true && item.id === name)
+  const skill = skills?.find((item) => item.slash !== false && item.id === name)
   if (!skill || prompt.some((part) => part.type === "skill" && part.id === skill.id)) return prompt
   const content = `/${skill.id}`
   return [


### PR DESCRIPTION
### Issue for this PR

Closes #48022

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Include skills in desktop/web slash autocomplete and submission unless `slash: false`, matching the TUI. Update the existing test for omitted `slash` frontmatter.

### How did you verify your code works?

Tests updated.

### Screenshots / recordings

Simple change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR