### PR TITLE
fix(session-ui): emphasize mentions and soften at prefixes

### DIFF
--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -8,6 +8,8 @@
 }
 
 [data-component="user-message"] {
+  --user-message-mention-prefix-color: var(--v2-blue-500);
+
   font-family: var(--font-family-sans);
   font-size: var(--font-size-base);
   font-style: normal;
@@ -144,16 +146,16 @@
     padding: 8px 12px;
     border-radius: 10px;
 
-    [data-highlight="file"] {
-      color: var(--syntax-property);
+    [data-highlight="file"],
+    [data-highlight="agent"] {
+      color: inherit;
+      font-weight: 600;
       direction: ltr;
       unicode-bidi: isolate;
     }
 
-    [data-highlight="agent"] {
-      color: var(--syntax-type);
-      direction: ltr;
-      unicode-bidi: isolate;
+    [data-slot="user-message-mention-prefix"] {
+      color: var(--user-message-mention-prefix-color);
     }
 
     max-width: 100%;
@@ -1448,18 +1450,26 @@
 }
 
 :root body [data-workspace-session] [data-component="user-message"] [data-slot="user-message-text"] {
+  --user-message-mention-prefix-color: var(--v2-blue-300);
+
   background: var(--v2-background-bg-accent);
   color: var(--v2-text-text-contrast);
 }
 
-:root[data-color-scheme="light"] body [data-local-session] [data-component="user-message"]
+:root[data-color-scheme="light"]
+  body
+  [data-local-session]
+  [data-component="user-message"]
   [data-slot="user-message-text"] {
   background: var(--v2-blue-100);
   color: var(--v2-blue-700);
   border-radius: 8px;
 }
 
-:root[data-color-scheme="dark"] body [data-local-session] [data-component="user-message"]
+:root[data-color-scheme="dark"]
+  body
+  [data-local-session]
+  [data-component="user-message"]
   [data-slot="user-message-text"] {
   background: var(--v2-blue-1200);
   color: var(--v2-blue-300);

--- a/packages/session-ui/src/message/message-content.tsx
+++ b/packages/session-ui/src/message/message-content.tsx
@@ -372,7 +372,18 @@ function CurrentHighlightedText(props: {
     if (last < props.text.length) result.push({ text: props.text.slice(last) })
     return result
   })
-  return <For each={segments()}>{(segment) => <span data-highlight={segment.type}>{segment.text}</span>}</For>
+  return (
+    <For each={segments()}>
+      {(segment) => (
+        <span data-highlight={segment.type}>
+          <Show when={segment.type && segment.text.startsWith("@")} fallback={segment.text}>
+            <span data-slot="user-message-mention-prefix">@</span>
+            {segment.text.slice(1)}
+          </Show>
+        </span>
+      )}
+    </For>
+  )
 }
 
 type HighlightSegment = { text: string; type?: "file" | "agent" }


### PR DESCRIPTION
### Issue for this PR

Design update requested in review; no linked issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Use semibold (600) for file and agent mentions, inheriting the user bubble's text colour. Give only the leading `@` a softer blue: blue-500 in local sessions and blue-300 in worktree sessions. The symbol uses the same weight as the mention name.

No chip background, padding, or shadow. Mention text and copy behaviour are preserved.

### How did you verify your code works?

- Repository pre-push typechecks passed (35 tasks, Bun 1.4.2).
- Prettier and `git diff --check` passed.
- Browser checks covered both mention types, light/dark, local/worktree, and LTR/RTL; verified weight 600 on both the name and `@`.
- `session-message-projection.spec.ts`: 3 passed on the serial run, including the attachment/mention test. The interruption story fails with `textVisible(...).get(...) is not a function` in `timeline/projection.ts:114`, outside the changed files.

### Screenshots / recordings

Each comparison includes an agent mention (`@explore`) and a file mention (`@src/a.ts`). Before restores the `v2` mention markup/styles on the same production message fixture; After uses the new renderer.

#### Local session · Light mode

![Before and after — local light, agent and file mentions](https://raw.githubusercontent.com/anomalyco/opencode/aa0dfdeb0bb8c1a5ef941a22b513997dd75e6f44/local-light.png)

#### Local session · Dark mode

![Before and after — local dark, agent and file mentions](https://raw.githubusercontent.com/anomalyco/opencode/aa0dfdeb0bb8c1a5ef941a22b513997dd75e6f44/local-dark.png)

#### Worktree session · Light mode

![Before and after — worktree light, agent and file mentions](https://raw.githubusercontent.com/anomalyco/opencode/aa0dfdeb0bb8c1a5ef941a22b513997dd75e6f44/workspace-light.png)

#### Worktree session · Dark mode

![Before and after — worktree dark, agent and file mentions](https://raw.githubusercontent.com/anomalyco/opencode/aa0dfdeb0bb8c1a5ef941a22b513997dd75e6f44/workspace-dark.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
