### PR TITLE
fix(app): reveal scrollbar in settings dialog panels

### DIFF
--- a/packages/app/e2e/regression/settings-padding.spec.ts
+++ b/packages/app/e2e/regression/settings-padding.spec.ts
@@ -39,6 +39,7 @@ for (const viewport of [
       await page.setViewportSize(viewport)
       const settings = page.getByTestId("settings-screen")
       const panel = settings.locator(":scope > .settings > .settings-panel:visible")
+      const scroller = panel.locator('[data-slot="settings-panel-scroll"] > [data-scrollable]')
       if (viewport.bottom) {
         const toggle = settings.locator('[data-action="settings-mobile-titlebar-bottom"]')
         await toggle.locator('[data-slot="switch-control"]').click()
@@ -74,7 +75,7 @@ for (const viewport of [
         await panel.hover()
         await page.mouse.wheel(0, 10000)
         await expect
-          .poll(() => panel.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
+          .poll(() => scroller.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
           .toBeLessThanOrEqual(1)
         await expect
           .poll(

--- a/packages/app/e2e/regression/settings-scroll.spec.ts
+++ b/packages/app/e2e/regression/settings-scroll.spec.ts
@@ -29,6 +29,7 @@ for (const viewport of [
 
     const settings = page.getByTestId("settings-screen")
     const panel = settings.getByRole("tabpanel")
+    const scroller = panel.locator('[data-slot="settings-panel-scroll"] > [data-scrollable]')
     const main = page.getByRole("main")
     const slider = settings.getByRole("slider", { name: "Timeline detail", exact: true })
     await expect(settings).toBeFocused()
@@ -41,7 +42,7 @@ for (const viewport of [
     await page.mouse.wheel(0, 10000)
     await panel.hover()
     await page.mouse.wheel(0, 10000)
-    await expect.poll(() => panel.evaluate((el) => el.scrollTop)).toBeGreaterThan(0)
+    await expect.poll(() => scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(0)
     await expect(main).toHaveJSProperty("scrollTop", 0)
     await expect(settings.getByRole("heading", { name: "Preferences", exact: true })).toBeInViewport()
 
@@ -60,7 +61,7 @@ for (const viewport of [
     await panel.hover()
     await page.mouse.wheel(0, 10000)
     await expect
-      .poll(() => panel.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
+      .poll(() => scroller.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop))
       .toBeLessThanOrEqual(1)
     await expect(main).toHaveJSProperty("scrollTop", 0)
     await expect.poll(() => main.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeLessThanOrEqual(1)

--- a/packages/app/src/providers/models/manage.tsx
+++ b/packages/app/src/providers/models/manage.tsx
@@ -100,7 +100,7 @@ export const DialogManageModels: Component = () => {
           </div>
         </div>
         <div data-slot="manage-models-scroll" class="relative min-h-0 flex-1">
-          <div class="settings-panel settings-models h-full px-4 pt-4 pb-4">
+          <div class="settings-panel settings-panel--scroll settings-models h-full px-4 pt-4 pb-4">
             <Show
               when={!list.grouped.loading}
               fallback={

--- a/packages/app/src/providers/models/select-dialog.tsx
+++ b/packages/app/src/providers/models/select-dialog.tsx
@@ -137,7 +137,10 @@ const ModelList: Component<{
         </div>
       </div>
       <div class="relative min-h-0 flex-1">
-        <div ref={(element) => (scrollRef = element)} class="settings-panel settings-models h-full px-4 pt-4 pb-4">
+        <div
+          ref={(element) => (scrollRef = element)}
+          class="settings-panel settings-panel--scroll settings-models h-full px-4 pt-4 pb-4"
+        >
           <Show
             when={models().length > 0}
             fallback={<div class="settings-models-status">{language.t("dialog.model.empty")}</div>}

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -97,6 +97,16 @@
   padding-inline: 24px;
 }
 
+/*
+ * .settings-about centers its content via align-items on the panel. The
+ * ScrollView viewport is a block box, so re-establish the centering there.
+ */
+.settings-about [data-slot="settings-panel-scroll"] > .scroll-view__viewport {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .settings-about-content {
   display: flex;
   flex-shrink: 0;

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -243,8 +243,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
-  scrollbar-width: none;
   user-select: none;
   container: settings-panel / inline-size;
 }
@@ -253,7 +251,23 @@
   user-select: text;
 }
 
-.settings-panel::-webkit-scrollbar {
+/*
+ * Panels that scroll themselves rather than delegating to a ScrollView child.
+ * The settings tabs wrap their content in ScrollView so a thumb reveals on
+ * hover, and must not also scroll here — otherwise the thumb tracks an inner
+ * viewport while the panel scrolls behind it.
+ *
+ * The two model dialogs have no ScrollView and rely on this element being the
+ * scroll container: Manage Models to drive its scroll-timeline top fade in
+ * index.css, and the model selector to scroll the active row into view. They
+ * keep the base class, so those selectors still match.
+ */
+.settings-panel--scroll {
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.settings-panel--scroll::-webkit-scrollbar {
   display: none;
 }
 

--- a/packages/app/src/settings/shell.tsx
+++ b/packages/app/src/settings/shell.tsx
@@ -4,6 +4,7 @@ import { Tabs } from "@opencode/ui/tabs"
 import { Icon } from "@opencode/ui/icon"
 import { Menu } from "@opencode/ui/menu"
 import { Button } from "@opencode/ui/button"
+import { ScrollView } from "@opencode/ui/scroll-view"
 import { useLanguage } from "@/runtime/i18n/language"
 import { SettingsGeneral } from "./general/general"
 import { SettingsAppearance } from "./appearance/appearance"
@@ -200,45 +201,66 @@ export const SettingsScreen: Component = () => {
         </Tabs.List>
 
         <Tabs.Content value="general" class="settings-panel">
-          <SettingsGeneral server={server()} />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsGeneral server={server()} />
+          </ScrollView>
         </Tabs.Content>
         <Tabs.Content value="appearance" class="settings-panel">
-          <SettingsAppearance />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsAppearance />
+          </ScrollView>
         </Tabs.Content>
         <Tabs.Content value="notifications" class="settings-panel">
-          <SettingsNotifications />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsNotifications />
+          </ScrollView>
         </Tabs.Content>
         <Tabs.Content value="shortcuts" class="settings-panel">
-          <SettingsKeybinds />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsKeybinds />
+          </ScrollView>
         </Tabs.Content>
         <Tabs.Content value="experimental" class="settings-panel">
-          <SettingsExperimental />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsExperimental />
+          </ScrollView>
         </Tabs.Content>
         <Tabs.Content value="servers" class="settings-panel">
-          <SettingsServers />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsServers />
+          </ScrollView>
         </Tabs.Content>
         <Tabs.Content value="projects" class="settings-panel">
-          <SettingsProjects />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsProjects />
+          </ScrollView>
         </Tabs.Content>
         <SettingsServerScope directory={directory()}>
           <Tabs.Content value="workspaces" class="settings-panel">
-            <SettingsWorkspaces
-              activeDirectory={directory()}
-              resetProjectFilter={() => state.worktreeFilterReset}
-            />
+            <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+              <SettingsWorkspaces activeDirectory={directory()} resetProjectFilter={() => state.worktreeFilterReset} />
+            </ScrollView>
           </Tabs.Content>
           <Tabs.Content value="providers" class="settings-panel">
-            <SettingsProviders directory={directory()} onBack={showProviders} />
+            <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+              <SettingsProviders directory={directory()} onBack={showProviders} />
+            </ScrollView>
           </Tabs.Content>
           <Tabs.Content value="models" class="settings-panel">
-            <SettingsModels />
+            <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+              <SettingsModels />
+            </ScrollView>
           </Tabs.Content>
           <Tabs.Content value="extensions" class="settings-panel">
-            <SettingsExtensions />
+            <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+              <SettingsExtensions />
+            </ScrollView>
           </Tabs.Content>
         </SettingsServerScope>
         <Tabs.Content value="about" class="settings-panel settings-about">
-          <SettingsAbout active={surface.tab() === "about"} />
+          <ScrollView data-slot="settings-panel-scroll" class="flex-1 min-h-0 w-full">
+            <SettingsAbout active={surface.tab() === "about"} />
+          </ScrollView>
         </Tabs.Content>
       </Tabs>
     </div>

--- a/packages/ui/src/components/scroll-view.tsx
+++ b/packages/ui/src/components/scroll-view.tsx
@@ -350,6 +350,9 @@ export function ScrollView(props: ScrollViewProps) {
   // We can also explicitly catch PageUp/Down if we want smooth scroll or specific behavior,
   // but native usually handles this perfectly. Let's explicitly ensure it behaves well.
   const onKeyDown = (e: KeyboardEvent) => {
+    // Defer to a descendant that already handled the key (e.g. an opening/open
+    // dropdown, listbox, or menu) — don't additionally scroll the viewport.
+    if (e.defaultPrevented) return
     // If user is focused on an input inside the scroll view, don't hijack keys
     if (document.activeElement && ["INPUT", "TEXTAREA", "SELECT"].includes(document.activeElement.tagName)) {
       return


### PR DESCRIPTION
### Issue for this PR

Closes #34108

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`.settings-panel` scrolls but hides its scrollbar entirely (`scrollbar-width: none` plus `::-webkit-scrollbar { display: none }`). So there is no hint that content continues below the fold — the Appearance / Color scheme setting is the one that caught me out — and no thumb to drag, which leaves keyboard users and mice without a scroll wheel with no way to get there.

This routes all 12 settings tabs through the shared `ScrollView`, which already provides the hover-reveal thumb used in 9 other places in `packages/app`. So settings ends up behaving like the rest of the app rather than getting a new pattern of its own.

Since the tabs no longer scroll themselves, `.settings-panel`'s own overflow rules would fight the ScrollView thumb — the thumb would track an inner viewport while the panel scrolled behind it. I moved those rules to a `.settings-panel--scroll` modifier instead of deleting them, because two other places still need that element to be the scroll container: Manage Models drives its `scroll-timeline` top fade off it in `index.css`, and the model select dialog scrolls the active row into view through its `scrollRef`. Both keep the base class, so those selectors still match.

Two smaller things included:

- `ScrollView` now ignores a key that a descendant already handled (`e.defaultPrevented`), so opening a focused dropdown with the arrow keys no longer also scrolls the panel behind it. The existing `isScrollKeyTarget` and `scrollKeyOwner` guards cover inputs and nested scrollers, but not this case.
- `.settings-about` centered its content with `align-items` on the panel itself, so that centering had to move to the ScrollView viewport, which is a block box.

This is the same fix as #46260, redone for `v2`. That PR targets `dev` and could not simply be retargeted: 11 of its 12 files do not exist here, since settings moved from `packages/app/src/components/settings-*.tsx` to `packages/app/src/settings/<feature>/`.

### How did you verify your code works?

`settings-scroll.spec.ts` and `settings-padding.spec.ts` both measured scroll metrics on the tabpanel, which is no longer the scroller, so I pointed them at the ScrollView viewport that now owns the scrolling. Both still assert that the panel scrolls and the surrounding screen does not. Between them they walk all 12 tabs at 5 viewports with top and bottom navigation, including the bottom-clearance check on every tab — 9/9 passing.

Also ran `bun typecheck` (35/35 packages) and `oxlint` (61 warnings before and after, so nothing new).

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
