### PR TITLE
fix(server): reject malformed message cursors

### DIFF
--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -491,6 +491,15 @@ describe("session HttpApi", () => {
           (yield* json<{ data: SessionMessage.Message[] }>(nextMessagePage)).data.map((message) => message.id),
         ).toEqual([firstMessage.id])
 
+        const malformedMessageCursor = yield* request(`/api/session/${session.id}/message?cursor=${messageCursor}!`, {
+          headers,
+        })
+        expect(malformedMessageCursor.status).toBe(400)
+        expect(yield* responseJson(malformedMessageCursor)).toMatchObject({
+          _tag: "InvalidCursorError",
+          message: "Invalid cursor",
+        })
+
         const legacyMessageCursor = Buffer.from(
           JSON.stringify({ id: secondMessage.id, time: 1, order: "desc", direction: "next" }),
         ).toString("base64url")

--- a/packages/server/src/handlers/message.ts
+++ b/packages/server/src/handlers/message.ts
@@ -1,6 +1,6 @@
 import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionV2 } from "@opencode-ai/core/session"
-import { Effect, Schema } from "effect"
+import { Effect, Encoding, Result, Schema } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
 import { InvalidCursorError, SessionNotFoundError, UnknownError } from "@opencode-ai/protocol/errors"
@@ -20,7 +20,9 @@ const cursor = {
     return Buffer.from(JSON.stringify({ id: message.id, order, direction })).toString("base64url")
   },
   decode(input: string) {
-    return decodeCursor(JSON.parse(Buffer.from(input, "base64url").toString("utf8")))
+    const decoded = Encoding.decodeBase64UrlString(input)
+    if (Result.isFailure(decoded)) throw decoded.failure
+    return decodeCursor(JSON.parse(decoded.success))
   },
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #48034

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Message pagination used Node's permissive Base64URL decoder, which ignored invalid characters. This uses Effect's strict decoder before the existing cursor schema validation, matching session pagination. Malformed cursors now reach the existing `InvalidCursorError` response path.

### How did you verify your code works?

- `bun test test/server/httpapi-session.test.ts -t "returns v2 public request errors for cursor and workspace query failures"`
- `bun test --timeout 10000 test/server/httpapi-session.test.ts`
- `bun typecheck`
- `bunx prettier --check packages/server/src/handlers/message.ts packages/opencode/test/server/httpapi-session.test.ts`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR