### PR TITLE
fix(plugin): normalize promise API inputs

### DIFF
--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -449,6 +449,28 @@ it.live("retains Promise plugin groups for later registrations and ignores a dis
   }),
 )
 
+it.effect("normalizes Promise plugin API inputs through JSON", () =>
+  Effect.gen(function* () {
+    const plugins = yield* Plugin.Service
+    const created: boolean[] = []
+    yield* plugins.activate([
+      {
+        ...fromPromise({
+          id: "promise-input",
+          async setup(ctx) {
+            await ctx.session.create({ title: "Promise session", agent: undefined })
+            created.push(true)
+          },
+        }),
+        revision: "1",
+      },
+    ])
+    yield* plugins.awaitActivation
+
+    expect(created).toEqual([true])
+  }),
+)
+
 it.effect("reloading a plugin replaces its command implementation", () =>
   Effect.gen(function* () {
     const plugins = yield* Plugin.Service

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -26,6 +26,7 @@ interface CompiledEndpoint {
 }
 
 const compiledEndpoints = new WeakMap<object, CompiledEndpoint>()
+const JsonInput = Schema.fromJsonString(Schema.Unknown)
 
 interface HostRpcCallContext {
   readonly error: (type: string, message: string, data?: unknown) => unknown
@@ -263,7 +264,11 @@ export function fromPromise(plugin: Plugin) {
           const compiled = compileEndpoint(endpoint)
           return ((input?: unknown) =>
             Effect.gen(function* () {
-              const decoded = yield* Effect.forEach(compiled.decode, (decode) => decode(input ?? {}))
+              // Match the generated Promise client, whose request body crosses JSON before endpoint decoding.
+              const normalized = yield* Schema.encodeUnknownEffect(JsonInput)(input ?? {}).pipe(
+                Effect.flatMap(Schema.decodeUnknownEffect(JsonInput)),
+              )
+              const decoded = yield* Effect.forEach(compiled.decode, (decode) => decode(normalized))
               const result = yield* method(Object.assign({}, ...decoded) as never)
               if (compiled.noContent) return undefined
               return yield* compiled.encode(result)


### PR DESCRIPTION
## Summary
- normalize Promise plugin API inputs through JSON before decoding endpoint schemas
- match the generated Promise client request boundary so optional `undefined` fields are omitted
- add an integration regression test for `session.create`

## Tests
- `bun test test/plugin.test.ts` (packages/core)
- `bun test` (packages/plugin, with canonical macOS TMPDIR)
- `bun typecheck` (packages/core)
- `bun typecheck` (packages/plugin)