### PR TITLE
docs: add Remote for OpenCode to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Remote for OpenCode](https://github.com/tjameswilliams/remote-for-opencode)               | Native iPhone remote for OpenCode on your Mac, no network config |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

None, this is a docs listing request per the note on the Ecosystem page.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the Projects table on the Ecosystem page for [Remote for OpenCode](https://github.com/tjameswilliams/remote-for-opencode), a native iPhone app plus Mac menu bar companion for driving `opencode serve` from your phone. Devices pair through the user's own iCloud account and talk directly (Bonjour on the LAN, hole-punched UDP elsewhere), end-to-end encrypted, with no relay server and no Tailscale or port forwarding to set up. The Mac side ships via Homebrew cask and the iPhone app is on the App Store. It is free and source-available (PolyForm Noncommercial).

Placed at the end of the Projects table, next to the other mobile and remote clients (portal, CodeNomad).

### How did you verify your code works?

Ran prettier 3.6.2 with the repo's settings on `ecosystem.mdx`; the diff is a single aligned table row.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnpVEMaMSSAx6nVvazsayP
