### PR TITLE
feat(cli): add auth account switching and targeted logout

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -123,11 +123,29 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
           },
         }),
         Spec.make("logout", {
-          description: "log out from a configured provider",
+          description: "log out of a saved account",
           params: {
             ...ServerParams,
             target: Argument.string("target").pipe(
               Argument.withDescription("Integration ID or name"),
+              Argument.optional,
+            ),
+            credential: Argument.string("credential").pipe(
+              Argument.withDescription("Credential ID or label (opens an account picker when omitted)"),
+              Argument.optional,
+            ),
+          },
+        }),
+        Spec.make("switch", {
+          description: "switch the active account for an integration",
+          params: {
+            ...ServerParams,
+            target: Argument.string("target").pipe(
+              Argument.withDescription("Integration ID or name"),
+              Argument.optional,
+            ),
+            credential: Argument.string("credential").pipe(
+              Argument.withDescription("Credential ID or label (opens an account picker when omitted)"),
               Argument.optional,
             ),
           },

--- a/packages/cli/src/commands/handlers/auth/account.ts
+++ b/packages/cli/src/commands/handlers/auth/account.ts
@@ -1,0 +1,74 @@
+import { autocomplete } from "@clack/prompts"
+import { Effect } from "effect"
+import type { IntegrationInfo } from "@opencode/client"
+import { prompt } from "../../../ui/prompt"
+import { resolveIntegration } from "./shared"
+
+export const chooseIntegration = Effect.fn("cli.auth.account.integration")(function* (
+  integrations: IntegrationInfo[],
+  target?: string,
+) {
+  if (target) return yield* resolveIntegration(integrations, target)
+  const configured = integrations.filter((integration) =>
+    integration.connections.some((connection) => connection.type === "credential"),
+  )
+  if (configured.length === 0) return yield* Effect.fail(new Error("No stored credentials found"))
+  const id = yield* prompt<string>(() =>
+    autocomplete({
+      message: "Select integration",
+      maxItems: 8,
+      options: configured.map((integration) => ({
+        value: integration.id,
+        label: integration.name,
+        hint: integration.connections
+          .filter((connection) => connection.type === "credential")
+          .map((connection) => connection.label)
+          .join(", "),
+      })),
+    }),
+  )
+  return yield* resolveIntegration(configured, id)
+})
+
+export const chooseCredential = Effect.fn("cli.auth.account.credential")(function* (
+  integration: IntegrationInfo,
+  action: "log out" | "switch to",
+  target?: string,
+) {
+  const credentials = integration.connections.filter((connection) => connection.type === "credential")
+  if (credentials.length === 0) {
+    const environment = integration.connections
+      .filter((connection) => connection.type === "env")
+      .map((connection) => connection.name)
+    if (environment.length && action === "log out") {
+      yield* Effect.fail(
+        new Error(
+          `${integration.name} is authenticated through ${environment.join(", ")}; unset the environment variable to disconnect`,
+        ),
+      )
+    }
+    yield* Effect.fail(new Error(`No stored credentials for ${integration.name}`))
+  }
+  if (target) {
+    const byID = credentials.find((credential) => credential.id === target)
+    if (byID) return byID.id
+    const matches = credentials.filter((credential) => credential.label.toLowerCase() === target.toLowerCase())
+    if (matches.length === 1) return matches[0].id
+    if (matches.length > 1)
+      return yield* Effect.fail(
+        new Error(`Credential label "${target}" is ambiguous. Use an ID: ${matches.map((item) => item.id).join(", ")}`),
+      )
+    return yield* Effect.fail(new Error(`Credential not found for ${integration.name}: ${target}`))
+  }
+  return yield* prompt<string>(() =>
+    autocomplete({
+      message: `Select ${integration.name} account to ${action}`,
+      maxItems: 8,
+      options: credentials.map((credential, index) => ({
+        value: credential.id,
+        label: index === 0 ? `${credential.label} (active)` : credential.label,
+        hint: credential.id,
+      })),
+    }),
+  )
+})

--- a/packages/cli/src/commands/handlers/auth/switch.ts
+++ b/packages/cli/src/commands/handlers/auth/switch.ts
@@ -7,9 +7,9 @@ import { createClient, loadIntegrations, location, request } from "./shared"
 import { chooseCredential, chooseIntegration } from "./account"
 
 export default Runtime.handler(
-  Commands.commands.auth.commands.logout,
-  Effect.fn("cli.auth.logout")((input) =>
-    logout({
+  Commands.commands.auth.commands.switch,
+  Effect.fn("cli.auth.switch")((input) =>
+    switchAccount({
       target: Option.getOrUndefined(input.target),
       credential: Option.getOrUndefined(input.credential),
       server: Option.getOrUndefined(input.server),
@@ -18,7 +18,7 @@ export default Runtime.handler(
   ),
 )
 
-const logout = Effect.fn("cli.auth.logout.run")(function* (input: {
+const switchAccount = Effect.fn("cli.auth.switch.run")(function* (input: {
   target?: string
   credential?: string
   server?: string
@@ -28,16 +28,16 @@ const logout = Effect.fn("cli.auth.logout.run")(function* (input: {
     yield* requireInteractive("Pass an integration ID or name when running without an interactive terminal")
   if (!input.credential)
     yield* requireInteractive("Pass a credential ID or label when running without an interactive terminal")
-  intro("Log out of an account")
+  intro("Switch account")
   const client = yield* createClient({ server: input.server, standalone: input.standalone })
   const integrations = yield* loadIntegrations(client)
   const integration = yield* chooseIntegration(integrations, input.target)
-  const credentialID = yield* chooseCredential(integration, "log out", input.credential)
+  const credentialID = yield* chooseCredential(integration, "switch to", input.credential)
   const progress = spinner()
-  progress.start("Removing credential...")
-  yield* request((signal) => client.credential.remove({ credentialID, location }, { signal })).pipe(
-    Effect.tap(() => Effect.sync(() => progress.stop(`Removed account from ${integration.name}`))),
-    Effect.tapCause(() => Effect.sync(() => progress.stop("Failed to remove credential", 1))),
+  progress.start("Switching account...")
+  yield* request((signal) => client.credential.activate({ credentialID, location }, { signal })).pipe(
+    Effect.tap(() => Effect.sync(() => progress.stop(`Switched account for ${integration.name}`))),
+    Effect.tapCause(() => Effect.sync(() => progress.stop("Failed to switch account", 1))),
   )
   outro("Done")
 })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ const Handlers = Runtime.handlers(Commands, {
     list: () => import("./commands/handlers/auth/list"),
     login: () => import("./commands/handlers/auth/login"),
     logout: () => import("./commands/handlers/auth/logout"),
+    switch: () => import("./commands/handlers/auth/switch"),
   },
   debug: {
     agents: () => import("./commands/handlers/debug/agents"),


### PR DESCRIPTION
### Issue for this PR

Requested CLI account-management improvement; no linked issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `auth switch [target] [credential]` and makes `auth logout [target] [credential]` remove one saved account. Both commands prompt for omitted integration/account arguments, mark the active account, and accept credential IDs or unambiguous labels. Noninteractive use requires both arguments.

### How did you verify your code works?

- CLI and pre-push workspace typechecks passed.
- 17 temporary checks passed for direct selection, activation/removal, ambiguous labels, missing arguments, and help output; temporary tests were removed as requested.
- Terminal smoke checks covered both pickers, active-account markers, successful requests, and Ctrl-C cancellation against a local fixture server.
- Existing `test/auth.test.ts`: 7 passed, 2 failed because they still expect the old logout help text and noninteractive logout without a credential. Test changes were not retained per the temporary-checks-only request. These expectations still need updating.

### Screenshots / recordings

Picker screenshots were captured and inspected locally at `/tmp/opencode/auth-switch-picker.png` and `/tmp/opencode/auth-logout-picker.png`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR