### PR TITLE
refactor(cli): move import and export under session

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -268,28 +268,6 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
         json: Flag.boolean("json").pipe(Flag.withDescription("Output statistics as JSON"), Flag.withDefault(false)),
       },
     }),
-    Spec.make("export", {
-      description: "Export session data as JSON",
-      params: {
-        ...ServerParams,
-        session: Argument.string("session").pipe(Argument.withDescription("Session ID to export"), Argument.optional),
-        sanitize: Flag.boolean("sanitize").pipe(
-          Flag.withDescription("Redact sensitive transcript and file data"),
-          Flag.withDefault(false),
-        ),
-      },
-    }),
-    Spec.make("import", {
-      description: "Import session data from a JSON file or URL",
-      params: {
-        ...ServerParams,
-        file: Argument.string("file").pipe(Argument.withDescription("JSON file or URL to import")),
-        directory: Flag.string("directory").pipe(
-          Flag.withDescription("Directory in which to import the session"),
-          Flag.optional,
-        ),
-      },
-    }),
     Spec.make("mini", {
       description: "Start the minimal interactive interface",
       params: {
@@ -392,6 +370,31 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
           params: {
             ...ServerParams,
             sessionID: Argument.string("sessionID").pipe(Argument.withDescription("Session ID to delete")),
+          },
+        }),
+        Spec.make("export", {
+          description: "Export session data as JSON",
+          params: {
+            ...ServerParams,
+            session: Argument.string("session").pipe(
+              Argument.withDescription("Session ID to export"),
+              Argument.optional,
+            ),
+            sanitize: Flag.boolean("sanitize").pipe(
+              Flag.withDescription("Redact sensitive transcript and file data"),
+              Flag.withDefault(false),
+            ),
+          },
+        }),
+        Spec.make("import", {
+          description: "Import session data from a JSON file or URL",
+          params: {
+            ...ServerParams,
+            file: Argument.string("file").pipe(Argument.withDescription("JSON file or URL to import")),
+            directory: Flag.string("directory").pipe(
+              Flag.withDescription("Directory in which to import the session"),
+              Flag.optional,
+            ),
           },
         }),
       ],

--- a/packages/cli/src/commands/handlers/session/export.ts
+++ b/packages/cli/src/commands/handlers/session/export.ts
@@ -3,14 +3,14 @@ import { OpenCode } from "@opencode/client"
 import { Service } from "@opencode/client/effect/service"
 import { Effect, Option } from "effect"
 import { EOL } from "node:os"
-import { Commands } from "../commands"
-import { Runtime } from "../../framework/runtime"
-import { ServerConnection } from "../../services/server-connection"
-import { errorMessage } from "../../util/error"
+import { Commands } from "../../commands"
+import { Runtime } from "../../../framework/runtime"
+import { ServerConnection } from "../../../services/server-connection"
+import { errorMessage } from "../../../util/error"
 
 export default Runtime.handler(
-  Commands.commands.export,
-  Effect.fn("cli.export")((input) =>
+  Commands.commands.session.commands.export,
+  Effect.fn("cli.session.export")((input) =>
     Effect.gen(function* () {
       const requested = Option.getOrUndefined(input.session)
       if (!requested && !process.stdin.isTTY) {

--- a/packages/cli/src/commands/handlers/session/import.ts
+++ b/packages/cli/src/commands/handlers/session/import.ts
@@ -5,13 +5,13 @@ import { SessionTransfer } from "@opencode/schema/session-transfer"
 import { Effect, Option, Schema } from "effect"
 import { EOL } from "node:os"
 import path from "node:path"
-import { Commands } from "../commands"
-import { Runtime } from "../../framework/runtime"
-import { ServerConnection } from "../../services/server-connection"
+import { Commands } from "../../commands"
+import { Runtime } from "../../../framework/runtime"
+import { ServerConnection } from "../../../services/server-connection"
 
 export default Runtime.handler(
-  Commands.commands.import,
-  Effect.fn("cli.import")(function* (input) {
+  Commands.commands.session.commands.import,
+  Effect.fn("cli.session.import")(function* (input) {
     const text = yield* Effect.tryPromise({
       try: () =>
         input.file.startsWith("http://") || input.file.startsWith("https://")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,14 +51,14 @@ const Handlers = Runtime.handlers(Commands, {
   },
   models: () => import("./commands/handlers/models"),
   stats: () => import("./commands/handlers/stats"),
-  export: () => import("./commands/handlers/export"),
-  import: () => import("./commands/handlers/import"),
   mini: () => import("./commands/handlers/mini"),
   run: () => import("./commands/handlers/run"),
   pair: () => import("./commands/handlers/pair"),
   session: {
     list: () => import("./commands/handlers/session/list"),
     delete: () => import("./commands/handlers/session/delete"),
+    export: () => import("./commands/handlers/session/export"),
+    import: () => import("./commands/handlers/session/import"),
   },
   service: {
     start: () => import("./commands/handlers/service/start"),

--- a/packages/cli/test/import-export.test.ts
+++ b/packages/cli/test/import-export.test.ts
@@ -71,13 +71,14 @@ test("export is raw by default and supports explicit sanitization", async () => 
   })
 
   try {
-    const [stdout, , exitCode] = await run(["export", info.id, "--server", server.url.toString()])
+    const [stdout, , exitCode] = await run(["session", "export", info.id, "--server", server.url.toString()])
     const exported = JSON.parse(stdout)
 
     expect(exitCode).toBe(0)
     expect(exported).toEqual(transfer)
 
     const [sanitized, , sanitizedExitCode] = await run([
+      "session",
       "export",
       info.id,
       "--sanitize",
@@ -110,7 +111,7 @@ test("export requires a session outside an interactive terminal", async () => {
   })
 
   try {
-    const [stdout, stderr, exitCode] = await run(["export", "--server", server.url.toString()])
+    const [stdout, stderr, exitCode] = await run(["session", "export", "--server", server.url.toString()])
 
     expect(exitCode).toBe(1)
     expect(stdout).toBe("")
@@ -138,7 +139,7 @@ test("export reports a missing session without a stack trace", async () => {
   })
 
   try {
-    const [stdout, stderr, exitCode] = await run(["export", sessionID, "--server", server.url.toString()])
+    const [stdout, stderr, exitCode] = await run(["session", "export", sessionID, "--server", server.url.toString()])
 
     expect(exitCode).toBe(1)
     expect(stdout).toBe("")
@@ -173,7 +174,15 @@ test("import validates a file and sends it to the resolved location", async () =
   })
 
   try {
-    const [stdout, , exitCode] = await run(["import", file, "--directory", root, "--server", server.url.toString()])
+    const [stdout, , exitCode] = await run([
+      "session",
+      "import",
+      file,
+      "--directory",
+      root,
+      "--server",
+      server.url.toString(),
+    ])
 
     expect(exitCode).toBe(0)
     expect(stdout).toBe(`Imported session: ${info.id}${os.EOL}`)
@@ -205,7 +214,7 @@ test("import reports an existing session without a stack trace", async () => {
   })
 
   try {
-    const [stdout, stderr, exitCode] = await run(["import", file, "--server", server.url.toString()])
+    const [stdout, stderr, exitCode] = await run(["session", "import", file, "--server", server.url.toString()])
 
     expect(exitCode).toBe(0)
     expect(stdout).toBe("")


### PR DESCRIPTION
### Issue for this PR

Requested CLI organization cleanup; no linked issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves the top-level `import` and `export` commands to `session import` and `session export`. Relocates their handlers and updates existing test invocations. Arguments and flags are preserved.

### How did you verify your code works?

- All 5 import/export tests passed.
- CLI and pre-push workspace typechecks passed.
- Checked root, session, export, and import help output.
- Formatting and `git diff --check` passed.

### Screenshots / recordings

Not applicable; CLI command grouping change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR