### PR TITLE
fix(core): trim compaction summary prompt

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -340,7 +340,7 @@ const findTailStart = (messages: readonly SessionMessage.Info[], keepTokens: num
   return previousSummary?.recent ? conversation[0].index : messages.length
 }
 
-export const buildPrompt = (update: boolean) => {
+export const buildPrompt = (update: boolean, legacy = false) => {
   const shared = [
     "Summarize only what the user and the assistant said and did. Leave out instructions and setup the assistant was given rather than told by the user: repository conventions, instruction files such as AGENTS.md, and environment details like the session ID. The next agent receives current versions of all of these separately.",
     SUMMARY_TEMPLATE,
@@ -351,6 +351,11 @@ export const buildPrompt = (update: boolean) => {
   if (update) {
     return [
       "Update the existing checkpoint in the conversation above into one consolidated summary.",
+      ...(legacy
+        ? [
+            "The existing checkpoint was written with an earlier format that recorded far more detail than this one asks for. Rewrite it at the level of detail described below rather than carrying its detail forward. Keep its requirements, decisions, and open questions; they came from earlier conversation with the user.",
+          ]
+        : []),
       "Newer history always takes precedence over the existing checkpoint. Preserve previous information unless newer history clearly contradicts, supersedes, resolves, or makes it stale. If something is no longer relevant to continuing the work, you may remove it.",
       "Incorporate newer requirements, decisions, progress, and context. Reconcile Work State and Next Move: move completed work out of Active, remove resolved blockers and answered questions, and preserve unresolved or pending work.",
       "Return only the updated Markdown sections. Do not reproduce the `<conversation-checkpoint>`, `<summary>`, or `<recent-context>` wrapper tags from the previous checkpoint.",
@@ -566,12 +571,14 @@ export const layer = Layer.effect(
             })
           : Effect.void,
       )
+      const previous = history.messages.findLast(
+        (message): message is SessionMessage.CompactionCompleted =>
+          message.type === "compaction" && message.status === "completed",
+      )
+      // Checkpoints from the earlier template used "## Additional Context" and ran far longer than this one asks for.
+      const legacy = previous !== undefined && !previous.summary.includes("## Important Context")
       const prepared = yield* compactionRequest(input, history.messages, [
-        Message.user(
-          buildPrompt(
-            history.messages.some((message) => message.type === "compaction" && message.status === "completed"),
-          ),
-        ),
+        Message.user(buildPrompt(previous !== undefined, legacy)),
       ])
       // Both requests share the retry allowance; rejected output never enters the reminder request.
       const transient = SessionRunnerRetry.transient(yield* SessionRunnerRetry.policy(context.session.id), {

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -83,6 +83,7 @@ const SUMMARY_RULES = `Rules:
 - Do not mention the summary process or that context was compacted.`
 
 const SUMMARY_HEADINGS = SUMMARY_TEMPLATE.split("\n").filter((line) => line.startsWith("##"))
+const LEGACY_HEADINGS = ["## Additional Context", "## Important Details"]
 
 export type Settings = {
   auto: boolean
@@ -575,8 +576,8 @@ export const layer = Layer.effect(
         (message): message is SessionMessage.CompactionCompleted =>
           message.type === "compaction" && message.status === "completed",
       )
-      // Checkpoints from the earlier template used "## Additional Context" and ran far longer than this one asks for.
-      const legacy = previous !== undefined && !previous.summary.includes("## Important Context")
+      // Checkpoints from earlier templates ran far longer than this one asks for; their catch-all headings identify them.
+      const legacy = LEGACY_HEADINGS.some((heading) => previous?.summary.includes(heading))
       const prepared = yield* compactionRequest(input, history.messages, [
         Message.user(buildPrompt(previous !== undefined, legacy)),
       ])

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -47,38 +47,39 @@ const SUMMARY_TEMPLATE = `You MUST use this format for your response (you may om
 - [one or two brief sentences describing what the user is trying to accomplish]
 
 ## Requirements
-- [constraints, preferences, requirements, and scope boundaries, or "(none)"]
+- [constraints, preferences, requirements, and scope boundaries stated by the user, or "(none)"]
 
 ## Decisions
 - [decisions already made and why, or "(none)"]
 
 ## Work State
+Break the objective into smaller goals and report which are completed, which are being worked on, and which are blocked.
 ### Completed
-- [finished work or changes made; otherwise "(none)"]
+- [goals that have been completed; otherwise "(none)"]
 
 ### Active
-- [current work, partial changes, or investigation state; otherwise "(none)"]
+- [goals currently being worked on; otherwise "(none)"]
 
 ### Blocked
-- [blockers, failing commands, or unknowns; otherwise "(none)"]
+- [anything blocking progress, and why; otherwise "(none)"]
 
 ## Next Move
 1. [ordered list of next actions, or "(none)"]
 
 ## Relevant Files
-List files and directories that are important to the conversation. Include paths outside the current working directory when relevant. If none are relevant, write "(none)".
-- \`[exact path]\`: [why it matters]
+List the files and directories, other than the current working directory, that another agent would need to open to continue this work. Include at most 15, most important first. Do not list every file that was read or changed. Include paths outside the current working directory when relevant. If none, write "(none)".
+- \`[file or directory path]\`: [brief reason it matters]
 
-## Additional Context
-- [facts or references needed to continue the work that are not captured above; omit this section if none]
+## Important Context
+- [facts the next agent cannot continue without and cannot easily find on its own; or "(none)"]
 </template>`
 
 const SUMMARY_RULES = `Rules:
-- Use terse bullets, not prose paragraphs.
-- Preserve exact file paths, symbols, commands, error strings, URLs, and identifiers when known.
+- Keep each section concise. Use terse, single-line bullets, not prose paragraphs or nested lists.
+- Prefer short references over detailed restatement. It is fine to leave out information the next agent can recover from the code, the files listed above, or the recent messages that follow this summary.
+- Preserve exact file paths, symbols, commands, error strings, URLs, and identifiers.
 - Carry forward only user questions or requests that remain unanswered or require further action. Do not repeat ones that newer history has answered or resolved. Preserve exact wording when carrying one forward.
 - Preserve consequential workflow state, including whether changes are uncommitted, committed, pushed, under review, or merged.
-- Do not include ambient environment metadata such as the session ID, current working directory, repository root, current branch, or worktree path. The next agent receives current environment information separately. Include these details only when they directly affect the task.
 - Do not mention the summary process or that context was compacted.`
 
 const SUMMARY_HEADINGS = SUMMARY_TEMPLATE.split("\n").filter((line) => line.startsWith("##"))
@@ -341,7 +342,7 @@ const findTailStart = (messages: readonly SessionMessage.Info[], keepTokens: num
 
 export const buildPrompt = (update: boolean) => {
   const shared = [
-    "Summarize only the history shown. More recent context may be retained and presented after this summary.",
+    "Summarize only what the user and the assistant said and did. Leave out instructions and setup the assistant was given rather than told by the user: repository conventions, instruction files such as AGENTS.md, and environment details like the session ID. The next agent receives current versions of all of these separately.",
     SUMMARY_TEMPLATE,
     SUMMARY_RULES,
     "Do not continue the task or call tools.",
@@ -350,7 +351,7 @@ export const buildPrompt = (update: boolean) => {
   if (update) {
     return [
       "Update the existing checkpoint in the conversation above into one consolidated summary.",
-      "Newer history always takes precedence over the existing checkpoint. Preserve previous information unless newer history clearly contradicts, supersedes, resolves, or makes it stale. When uncertain and there is no conflict, retain it under Additional Context.",
+      "Newer history always takes precedence over the existing checkpoint. Preserve previous information unless newer history clearly contradicts, supersedes, resolves, or makes it stale. If something is no longer relevant to continuing the work, you may remove it.",
       "Incorporate newer requirements, decisions, progress, and context. Reconcile Work State and Next Move: move completed work out of Active, remove resolved blockers and answered questions, and preserve unresolved or pending work.",
       "Return only the updated Markdown sections. Do not reproduce the `<conversation-checkpoint>`, `<summary>`, or `<recent-context>` wrapper tags from the previous checkpoint.",
       ...shared,

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -93,7 +93,8 @@ const it = testEffect(
 test("compaction prompt preserves detailed work state and relevant files", () => {
   const prompt = SessionCompaction.buildPrompt(false)
 
-  expect(prompt).toContain("## Work State\n### Completed")
+  expect(prompt).toContain("## Work State")
+  expect(prompt).toContain("### Completed")
   expect(prompt).toContain("### Active")
   expect(prompt).toContain("### Blocked")
   expect(prompt).toContain("## Relevant Files")
@@ -134,7 +135,7 @@ test("compaction prompt requires the checkpoint headings in order", () => {
     "### Blocked",
     "## Next Move",
     "## Relevant Files",
-    "## Additional Context",
+    "## Important Context",
   ])
 })
 

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -139,6 +139,13 @@ test("compaction prompt requires the checkpoint headings in order", () => {
   ])
 })
 
+test("compaction update prompt rewrites legacy checkpoints only when asked", () => {
+  const rewrite = "The existing checkpoint was written with an earlier format"
+  expect(SessionCompaction.buildPrompt(true, true)).toContain(rewrite)
+  expect(SessionCompaction.buildPrompt(true)).not.toContain(rewrite)
+  expect(SessionCompaction.buildPrompt(false, true)).not.toContain(rewrite)
+})
+
 test("compaction prompts prohibit task execution", () => {
   for (const update of [false, true])
     expect(SessionCompaction.buildPrompt(update)).toContain("Do not continue the task or call tools")

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2037,7 +2037,7 @@ describe("SessionRunnerLLM", () => {
       expect((yield* s.messages).some((message) => message.type === "compaction")).toBe(false)
       yield* active.finish
 
-      expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only the history shown")
+      expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only what the user and the assistant said and did")
       expect(s.requests).toHaveLength(3)
       expect(userTexts(s.requests[1])).not.toContain("STEER_A")
       expect(userTexts(s.requests[1])).not.toContain("STEER_B")
@@ -2076,7 +2076,7 @@ describe("SessionRunnerLLM", () => {
     yield* Fiber.join(run)
 
     expect(s.requests).toHaveLength(3)
-    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only the history shown")
+    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only what the user and the assistant said and did")
     expect(s.requests[1].messages.some((message) => message.role === "tool")).toBe(true)
     expect(userTexts(s.requests[2]).slice(-2)).toEqual(["STEER_A", "STEER_B"])
     expect(yield* s.inbox).toEqual([])
@@ -2099,7 +2099,7 @@ describe("SessionRunnerLLM", () => {
     yield* Deferred.succeed(release, undefined)
     yield* Fiber.join(run)
     expect(s.requests).toHaveLength(3)
-    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only the history shown")
+    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only what the user and the assistant said and did")
     expect(userTexts(s.requests[2]).slice(-2)).toEqual(["STEER_A", "STEER_B"])
     expect(yield* s.inbox).toEqual([])
   })
@@ -2119,7 +2119,7 @@ describe("SessionRunnerLLM", () => {
 
       expect(s.requests).toHaveLength(outcome === "cancelled" ? 2 : 3)
       if (outcome === "failed") {
-        expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only the history shown")
+        expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only what the user and the assistant said and did")
         expect((yield* s.messages).find((message) => message.id === compact.id)).toMatchObject({
           status: "failed",
           error: { type: "provider.error", message: "summary unavailable" },
@@ -2144,7 +2144,7 @@ describe("SessionRunnerLLM", () => {
     const summary = yield* s.llm.gate
     const compact = yield* s.session.compact({ sessionID })
     yield* summary.started
-    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only the history shown")
+    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only what the user and the assistant said and did")
     expect((yield* s.inbox).map((item) => item.id)).toEqual([first.id, second.id])
     yield* s.session.interrupt(sessionID)
     yield* s.session.wait(sessionID)
@@ -2184,7 +2184,7 @@ describe("SessionRunnerLLM", () => {
     yield* s.resume
     expect(s.requests).toHaveLength(3)
     expect(userTexts(s.requests[0])).toEqual(["STEER_A"])
-    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only the history shown")
+    expect(userTexts(s.requests[1]).at(-1)).toContain("Summarize only what the user and the assistant said and did")
     expect(userTexts(s.requests[2]).at(-1)).toBe("STEER_B")
     expect(
       (yield* recordedEventTypes(sessionID)).filter(


### PR DESCRIPTION
## Summary

Compaction summaries from GPT-family models were retaining nearly everything: every file touched, per-edit changelogs with commit hashes and test tallies, restated AGENTS.md conventions, and an Additional Context section that grew on every update. On long sessions this produced 30k-character summaries that took minutes to generate.

This trims the prompt without changing the compaction mechanism:

- Scope the summary to what the user and assistant said and did. Instructions, repository conventions, and environment details are delivered to the next agent separately and no longer need to be recorded.
- Cap Relevant Files at 15 entries, scoped to what the next agent must open to continue, excluding the current working directory.
- Frame Work State as goals that are completed, in progress, or blocked rather than a log of individual changes.
- Require single-line bullets and explicitly allow leaving out anything recoverable from the code, the listed files, or the retained recent messages.
- Rename Additional Context to Important Context and restrict it to facts the next agent cannot continue without and cannot easily find.
- Replace the update-path "when uncertain, retain" tiebreaker with permission to drop what is no longer relevant to continuing the work. The preserve-first sentence is unchanged.

## Measurement

Replayed five historical compactions against their exact original history with `gpt-6-astra#high`, old prompt vs new. Each row is one summary.

| session | path | summary size (old → new) | output tokens (old → new) | Relevant Files (old → new) | time (old → new) |
|---|---|---:|---:|---:|---:|
| 300k-token provider work, 4th compaction | update | 29.8k → **11.3k** chars | 7,505 → **2,945** | 44 → 15 | 114s → 49s |
| MCP adjustment work, 2nd compaction | update | 27.5k → **13.0k** chars | 6,392 → **2,844** | 43 → 15 | 98s → 45s |
| Provider plugin work, 1st compaction | create | 18.0k → **11.3k** chars | 4,499 → **2,570** | 25 → 15 | 70s → 43s |
| Provider coverage, 1st compaction | create | 14.5k → **7.1k** chars | 3,424 → **2,696** | 41 → 15 | 56s → 51s |
| Session hooks, 1st compaction | create | 13.5k → **8.7k** chars | 3,072 → **2,053** | 36 → 15 | 55s → 49s |

Averages: a summary went from ~20.7k chars / ~5,000 output tokens to ~10.3k chars / ~2,600 output tokens. Nested sub-bullets went from 87–182 per summary to 0. The update-path summaries, which previously grew on every compaction, are now the same size as first-time ones.

A reviewer pass over each old/new pair found no material loss: every open user request, PR/branch state, blocker, and decision is either in the new summary or in the retained tail. Dropped content was commit hashes, per-file test counts, research links for deferred work, and restated repository conventions.

## Test plan

- `bun test test/session-compaction.test.ts` and `bun typecheck` in `packages/core`
- Manual compaction on long GPT sessions