### PR TITLE
feat(session): expose metadata in V2 API and mark run origin

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -81,6 +81,7 @@ type CreateInput = {
   agent?: AgentV2.ID
   model?: ModelV2.Ref
   location: Location.Ref
+  metadata?: Record<string, unknown>
 }
 
 type CompactInput = {
@@ -227,6 +228,7 @@ const layer = Layer.effect(
           workspaceID: input.location.workspaceID ? WorkspaceV2.ID.make(input.location.workspaceID) : undefined,
           title: `New session - ${new Date(now).toISOString()}`,
           agent: input.agent,
+          metadata: input.metadata,
           model: input.model
             ? {
                 id: ModelV2.ID.make(input.model.id),

--- a/packages/core/src/session/info.ts
+++ b/packages/core/src/session/info.ts
@@ -41,6 +41,7 @@ export function fromRow(row: typeof SessionTable.$inferSelect): SessionSchema.In
     }),
     subpath: row.path ? RelativePath.make(row.path) : undefined,
     revert: row.revert ? { ...row.revert, messageID: SessionMessage.ID.make(row.revert.messageID) } : undefined,
+    metadata: row.metadata ?? undefined,
     time: {
       created: DateTime.makeUnsafe(row.time_created),
       updated: DateTime.makeUnsafe(row.time_updated),

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -519,6 +519,7 @@ export const RunCommand = effectCmd({
         const result = await sdk.session.create({
           title: name,
           permission: [...rules],
+          metadata: { origin: "run" },
         })
         const id = result.data?.id
         if (!id) {
@@ -562,6 +563,7 @@ export const RunCommand = effectCmd({
               }
             : undefined,
           permission: [...rules],
+          metadata: { origin: "run" },
         })
         const id = result.data?.id
         if (!id) {

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -132,6 +132,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           agent: Agent.ID.pipe(Schema.optional),
           model: Model.Ref.pipe(Schema.optional),
           location: Location.Ref.pipe(Schema.optional),
+          metadata: Schema.Record(Schema.String, Schema.Unknown).pipe(Schema.optional),
         }),
         success: Schema.Struct({ data: Session.Info }),
       }).annotateMerge(

--- a/packages/schema/src/session.ts
+++ b/packages/schema/src/session.ts
@@ -41,6 +41,7 @@ export const Info = Schema.Struct({
   location: Location.Ref,
   subpath: RelativePath.pipe(optional),
   revert: Revert.State.pipe(optional),
+  metadata: Schema.Record(Schema.String, Schema.Unknown).pipe(optional),
 }).annotate({ identifier: "SessionV2.Info" })
 
 export const ListAnchor = Schema.Struct({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -5477,6 +5477,9 @@ export class Session3 extends HeyApiClient {
       agent?: string
       model?: ModelRef
       location?: LocationRef
+      metadata?: {
+        [key: string]: unknown
+      }
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5489,6 +5492,7 @@ export class Session3 extends HeyApiClient {
             { in: "body", key: "agent" },
             { in: "body", key: "model" },
             { in: "body", key: "location" },
+            { in: "body", key: "metadata" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3930,6 +3930,9 @@ export type SessionV2Info = {
   location: LocationRef
   subpath?: string
   revert?: RevertState
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type PromptInputFileAttachment = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10172,6 +10172,10 @@
                   },
                   "location": {
                     "$ref": "#/components/schemas/LocationRef"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": true
                   }
                 },
                 "additionalProperties": false
@@ -27323,6 +27327,10 @@
           },
           "revert": {
             "$ref": "#/components/schemas/RevertState"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
           }
         },
         "required": ["id", "projectID", "cost", "tokens", "time", "title", "location"],

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -73,6 +73,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
               agent: ctx.payload.agent,
               model: ctx.payload.model,
               location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
+              metadata: ctx.payload.metadata,
             }),
           }
         }),


### PR DESCRIPTION
## Summary

Closes #40384.

The V2 session table already has a free-form `metadata` JSON column, but nothing in the V2 read or write path touches it. This PR exposes the field end-to-end so that programmatic clients can write metadata at session-creation time and read it back from V2 session APIs.

## Changes

- **`packages/schema/src/session.ts`** — add `metadata` field to `SessionV2.Info` schema
- **`packages/core/src/session/info.ts`** — `fromRow` maps `row.metadata` into the session info object
- **`packages/core/src/session.ts`** — `CreateInput` accepts `metadata`; creation path forwards it to `SessionV1.SessionInfo`
- **`packages/protocol/src/groups/session.ts`** — `session.create` V2 payload schema accepts `metadata`
- **`packages/server/src/handlers/session.ts`** — V2 handler passes `ctx.payload.metadata` through to the service
- **`packages/opencode/src/cli/cmd/run.ts`** — both `sdk.session.create` calls in `opencode run` set `metadata: { origin: "run" }` so run-sessions become attributable
- **`packages/sdk/openapi.json`** — `SessionV2Info` and `v2.session.create` requestBody schemas include `metadata`
- **`packages/sdk/js/src/v2/gen/{sdk,types}.gen.ts`** — regenerated SDK surfaces the field on `Session3.create` and `SessionV2Info`

## Test plan

- [x] Schema diff review — `metadata` is optional / free-form JSON, no breaking change to existing clients
- [x] Local type-check via generated SDK (`sdk.gen.ts` / `types.gen.ts` regenerated from updated `openapi.json`)
- [ ] Full `bun install && bun run build` — not run locally (no bun on this machine); recommend CI verification

## Notes

- Total: 9 files, +23 lines. Single-field pass-through, no behavioural change for clients that don't send `metadata`.
- The `origin: "run"` marker in `run.ts` is the concrete use case from #40384 — programmatic sessions started via `opencode run` are now distinguishable in the session store.