### PR TITLE
fix(app): constrain worktree dropdown spacing

### DIFF
--- a/packages/app/src/new-session/workspace/selector.tsx
+++ b/packages/app/src/new-session/workspace/selector.tsx
@@ -89,7 +89,7 @@ export function PromptWorkspaceSelector(props: {
         contentClass={props.onboarding ? "max-w-[280px]" : undefined}
         class="min-w-0"
       >
-        <Menu placement="bottom" gutter={4} onOpenChange={onOpenChange}>
+        <Menu placement="bottom" gutter={4} overflowPadding={24} onOpenChange={onOpenChange}>
           <Menu.Trigger
             aria-description={language.t("session.new.workspace.trigger.tooltip")}
             class="flex h-6 min-w-0 max-w-[203px] items-center gap-1.5 rounded-sm px-1.5 hover:bg-v2-overlay-simple-overlay-hover focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:outline-none data-[expanded]:bg-v2-overlay-simple-overlay-pressed data-[expanded]:text-v2-text-text-muted"
@@ -148,7 +148,7 @@ export function PromptWorkspaceSelector(props: {
                 <Menu.Sub
                   gutter={0}
                   overlap
-                  overflowPadding={8}
+                  overflowPadding={24}
                   onOpenChange={(open) => {
                     if (!open) {
                       focusSearch = false
@@ -177,7 +177,7 @@ export function PromptWorkspaceSelector(props: {
                     </span>
                   </Menu.SubTrigger>
                   <Menu.Portal>
-                    <Menu.SubContent class="max-h-[224px] w-[200px] overflow-y-auto">
+                    <Menu.SubContent class="max-h-[66.667dvh] w-[200px] overflow-y-auto !pb-0 [&>[data-component=menu-v2-item]:last-child]:mb-0.5 [@media(max-height:600px)]:max-h-[calc(100dvh-48px)]">
                       <Show when={props.workspaces.length >= 10}>
                         <div class="flex h-7 items-center gap-2 rounded-sm ps-3 pe-2 text-v2-icon-icon-muted">
                           <Icon name="magnifying-glass" size="small" class="shrink-0" />

--- a/packages/app/src/session/timeline/session-workspace-menu.tsx
+++ b/packages/app/src/session/timeline/session-workspace-menu.tsx
@@ -80,6 +80,7 @@ export function SessionWorkspaceMenu(props: {
     <Menu
       placement={props.placement ?? "bottom-end"}
       gutter={props.gutter ?? 4}
+      overflowPadding={24}
       modal={false}
       onOpenChange={onOpenChange}
     >
@@ -101,13 +102,13 @@ export function SessionWorkspaceMenu(props: {
               {language.t("workspace.new")}
             </Menu.Item>
             <Show when={workspaces().length > 0}>
-              <Menu.Sub gutter={0} overlap overflowPadding={8}>
+              <Menu.Sub gutter={0} overlap overflowPadding={24}>
                 <Menu.SubTrigger>
                   <Icon name="outline-worktree" />
                   {language.t("session.new.workspace.existing").replace(/(…|\.{3})$/, "")}
                 </Menu.SubTrigger>
                 <Menu.Portal>
-                  <Menu.SubContent class="max-h-[calc(100dvh-16px)] w-[200px] overflow-y-auto">
+                  <Menu.SubContent class="max-h-[66.667dvh] w-[200px] overflow-y-auto !pb-0 [&>[data-component=menu-v2-item]:last-child]:mb-0.5 [@media(max-height:600px)]:max-h-[calc(100dvh-48px)]">
                     <For each={workspaces()}>
                       {(workspace) => (
                         <Menu.Item disabled={!!store.selected || blocked()} onSelect={() => void move(workspace)}>


### PR DESCRIPTION
- Keep new-session and move-session worktree menus at least 24 px from the viewport edges.
- Cap lists at roughly two-thirds of the window height; at 600 px or shorter, use the available height minus 48 px.
- Put the 2 px bottom spacing on the last item so it scrolls with the list and matches the side inset.

### Production benchmark

- Warm session-tab switch with review closed; one sample per revision, so timings are indicative.

| Metric | Before (`v2` baseline) | After |
| --- | ---: | ---: |
| First correct content | 31.2 ms | 24.7 ms |
| Stable content | 76.5 ms | 71.4 ms |
| Blank samples | 0 | 0 |