### PR TITLE
fix(session-ui): simplify file search styling

### DIFF
--- a/packages/session-ui/src/v2/components/session-review-v2.css
+++ b/packages/session-ui/src/v2/components/session-review-v2.css
@@ -105,6 +105,14 @@
   max-width: 100%;
   min-width: 0;
   margin-top: 3px;
+  background: transparent;
+  box-shadow: none;
+}
+
+[data-component="session-review-v2-sidebar-root"]
+  [data-slot="session-review-v2-sidebar-filter"]
+  [data-component="text-input-v2"]:where(:hover, :focus-within):not([data-disabled], [data-invalid]) {
+  background: var(--v2-overlay-simple-overlay-hover);
 }
 
 [data-component="session-review-v2-sidebar-root"] [data-slot="session-review-v2-sidebar-tree"] {


### PR DESCRIPTION
- Match the file-tree search field to the browser address field in #48061.
- Remove the default gradient and shadow, leaving the field transparent at rest.
- Show a background on hover and focus, with the existing focus border while editing.