### PR TITLE
fix(core): defer provider registry loading to plugin boot

### DIFF
--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -30,7 +30,6 @@ import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { AgentPlugin } from "./agent"
 import { CommandPlugin } from "./command"
 import { ModelsDevPlugin } from "./models-dev"
-import { ProviderPlugins } from "./provider"
 import { SkillPlugin } from "./skill"
 import { VariantPlugin } from "./variant"
 
@@ -62,6 +61,8 @@ export function define<R>(plugin: Plugin<R>) {
 
 const layer = Layer.effectDiscard(
   Effect.gen(function* () {
+    // Provider plugins import define from this module, so load their registry after module initialization.
+    const { ProviderPlugins } = yield* Effect.promise(() => import("./provider"))
     const catalog = yield* Catalog.Service
     const commands = yield* CommandV2.Service
     const plugin = yield* PluginV2.Service


### PR DESCRIPTION
## Summary
- Break the circular import between provider plugins, plugin/internal, and the provider registry by loading the registry during plugin boot.
- Fix standalone Bedrock tests failing with Cannot access AmazonBedrockPlugin before initialization.

## Verification
- bun test test/plugin/provider-amazon-bedrock.test.ts: 17 passed without a preload workaround
- bun test test/plugin: 227 passed across 40 files
- bun typecheck in packages/core: passed
- git diff --check: passed