### PR TITLE
feat(commands): add global menu commands for session and project management

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -21,6 +21,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
 import { Effect } from "effect"
 import { base64Encode } from "@opencode-ai/core/util/encode"
+import { useDirectoryPicker } from "@/components/directory-picker"
 import {
   type Component,
   createEffect,
@@ -46,7 +47,7 @@ import { ServerSyncProvider, useServerSync } from "@/context/server-sync"
 import { GlobalProvider, useGlobal } from "@/context/global"
 import { HighlightsProvider } from "@/context/highlights"
 import { LanguageProvider, type Locale, useLanguage } from "@/context/language"
-import { LayoutProvider } from "@/context/layout"
+import { LayoutProvider, useLayout } from "@/context/layout"
 import { ModelsProvider } from "@/context/models"
 import { NotificationProvider } from "@/context/notification"
 import { PermissionProvider } from "@/context/permission"
@@ -326,6 +327,10 @@ function DesktopCommands() {
   const command = useCommand()
   const language = useLanguage()
   const platform = usePlatform()
+  const navigate = useNavigate()
+  const server = useServer()
+  const settings = useSettings()
+  const pickDirectory = useDirectoryPicker()
 
   command.register("desktop", () => {
     const commands: CommandOption[] = []
@@ -339,6 +344,49 @@ function DesktopCommands() {
         },
       })
     }
+    // Global menu commands – available on every page including home
+    const conn = server.current
+    commands.push({
+      id: "session.new",
+      title: language.t("command.session.new"),
+      keybind: "mod+shift+s",
+      onSelect: () => {
+        if (settings.general.newLayoutDesigns()) {
+          command.trigger("tab.new")
+          return
+        }
+        if (conn) {
+          const projects = server.projects.list()
+          const dir = projects[0]?.worktree
+          if (dir) navigate(`/${base64Encode(dir)}/session`)
+        }
+      },
+    })
+    commands.push({
+      id: "project.open",
+      title: language.t("command.project.open"),
+      keybind: "mod+o",
+      onSelect: () => {
+        if (!conn) return
+        function resolve(result: string | string[] | null) {
+          if (Array.isArray(result)) {
+            for (const directory of result) {
+              server.projects.open(directory)
+            }
+            if (result[0]) navigate(`/${base64Encode(result[0])}/session`)
+          } else if (result) {
+            server.projects.open(result)
+            navigate(`/${base64Encode(result)}/session`)
+          }
+        }
+        pickDirectory({
+          server: conn,
+          title: language.t("command.project.open"),
+          multiple: true,
+          onSelect: resolve,
+        })
+      },
+    })
     return commands
   })
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds two app-wide commands so session and project actions are available from
every page (including home), not only from page-specific UI:

- **New Session** (`mod+shift+s`): when the *new layout designs* setting is
  enabled, triggers the existing `tab.new` flow; otherwise it navigates to a
  new session under the first known project's worktree, keeping the session
  routing consistent with existing links.
- **Open Project** (`mod+o`): opens the directory picker (native dialog on
  desktop) with multi-select support. Every selected directory is opened via
  `server.projects.open`, and the first selection is used to navigate to its
  encoded session route (`base64Encode(dir)`), matching how session URLs are
  already built elsewhere.

Both commands are registered through the existing command source in
`SharedProviders`, so they mount once for every route and surface in the
command palette with their keybindings. The session shortcut intentionally
branches on the `newLayoutDesigns` setting because the two layouts create
sessions through different flows (`tab.new` vs. route navigation).

### How did you verify your code works?

- Triggered both commands from the command palette and with the `mod+shift+s` /
  `mod+o` shortcuts on a desktop build.
- Verified New Session behaves correctly with the new layout design setting
  both enabled and disabled.

### Screenshots / recordings

<img width="1102" height="402" alt="image" src="https://github.com/user-attachments/assets/a085534c-0031-485f-bfae-61c47a2557ab" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR