### PR TITLE
fix(opencode): hoist Bedrock Astra tool-result images

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -148,7 +148,11 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
     if (model.api.npm === "@ai-sdk/anthropic") return true
     if (model.api.npm === "@ai-sdk/openai") return true
     if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true
-    if (model.api.npm === "@ai-sdk/amazon-bedrock") return attachment.mime.startsWith("image/")
+    if (model.api.npm === "@ai-sdk/amazon-bedrock") {
+      // Astra accepts images in user content, but rejects them inside Converse tool results.
+      if (/^(global\.|us\.)?openai\.gpt-6-astra$/.test(model.api.id)) return false
+      return attachment.mime.startsWith("image/")
+    }
     if (model.api.npm === "@ai-sdk/xai") return attachment.mime.startsWith("image/")
     if (model.api.npm === "@ai-sdk/google-vertex/anthropic") return true
     if (model.api.npm === "@ai-sdk/google") {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -494,6 +494,96 @@ describe("session.message-v2.toModelMessage", () => {
     })
   })
 
+  test.each([
+    ["openai.gpt-6-astra", "@ai-sdk/amazon-bedrock", true],
+    ["us.openai.gpt-6-astra", "@ai-sdk/amazon-bedrock", true],
+    ["global.openai.gpt-6-astra", "@ai-sdk/amazon-bedrock", true],
+    ["anthropic.claude-sonnet-4-6", "@ai-sdk/amazon-bedrock", false],
+    ["openai.gpt-6-astra", "@ai-sdk/amazon-bedrock/mantle", false],
+  ])("handles image tool results for %s via %s", async (id, npm, hoist) => {
+    const bedrockModel: Provider.Model = {
+      ...model,
+      id: ModelV2.ID.make("custom-alias"),
+      providerID: ProviderV2.ID.make("amazon-bedrock"),
+      api: { id, npm, url: "https://bedrock-runtime.us-east-2.amazonaws.com" },
+      capabilities: {
+        ...model.capabilities,
+        attachment: true,
+        input: { ...model.capabilities.input, image: true },
+      },
+    }
+    const userID = "m-user-bedrock-image"
+    const assistantID = "m-assistant-bedrock-image"
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [{ ...basePart(userID, "u1-bedrock-image"), type: "text", text: "read image" }],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-bedrock-image"),
+            type: "tool",
+            callID: "call-bedrock-image-1",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/tmp/example.png" },
+              output: "Image read successfully",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-bedrock-image-1"),
+                  type: "file",
+                  mime: "image/png",
+                  url: "data:image/png;base64,Zm9v",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, bedrockModel)
+    expect(result).toHaveLength(hoist ? 4 : 3)
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "call-bedrock-image-1", toolName: "read" }],
+    })
+    expect(result[2]).toMatchObject({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-bedrock-image-1",
+          toolName: "read",
+          output: hoist
+            ? { type: "text", value: "Image read successfully" }
+            : {
+                type: "content",
+                value: [
+                  { type: "text", text: "Image read successfully" },
+                  { type: "media", mediaType: "image/png", data: "Zm9v" },
+                ],
+              },
+        },
+      ],
+    })
+    if (hoist) {
+      expect(result[3]).toMatchObject({
+        role: "user",
+        content: [
+          { type: "text", text: "Attached media from tool result:" },
+          { type: "file", mediaType: "image/png", data: "data:image/png;base64,Zm9v" },
+        ],
+      })
+    }
+  })
+
   test("moves bedrock pdf tool-result media into a separate user message", async () => {
     const bedrockModel: Provider.Model = {
       ...model,


### PR DESCRIPTION
### Issue for this PR

Closes #48069

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bedrock Astra accepts user-level images but rejects images inside Converse `toolResult.content`, so reading a PNG breaks the next request.

Mark Astra's Converse API IDs as not supporting tool-result media, reusing the existing user-message hoisting logic. Match the API ID so custom model aliases work. Other Bedrock models and Mantle are unchanged.

### How did you verify your code works?

- `bun test test/session/message-v2.test.ts`: 44 pass. New cases cover unprefixed/US/global Astra IDs, custom aliases, Bedrock Claude, and Mantle. The three Astra cases failed before the fix.
- `bun typecheck` in `packages/opencode` and Prettier checks pass.
- Live test with `global.openai.gpt-6-astra` in `us-east-2`: stock 1.18.29 with `--pure` fails after `read`; patched source with `--pure` reads the same synthetic PNG and correctly identifies its red/blue halves. No workaround plugin was enabled.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
