### PR TITLE
fix(mcp): reuse OAuth client registration

### DIFF
--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -185,11 +185,8 @@ export class McpOAuthPendingProvider extends McpOAuthProvider {
   private pendingTokens?: OAuthTokens
 
   override async clientInformation(): Promise<OAuthClientInformation | undefined> {
-    if (!this.config.clientId) return this.pendingClientInfo
-    return {
-      client_id: this.config.clientId,
-      client_secret: this.config.clientSecret,
-    }
+    if (this.pendingClientInfo && !this.config.clientId) return this.pendingClientInfo
+    return super.clientInformation()
   }
 
   override async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
@@ -197,7 +194,7 @@ export class McpOAuthPendingProvider extends McpOAuthProvider {
   }
 
   override async tokens(): Promise<OAuthTokens | undefined> {
-    return this.pendingTokens
+    return this.pendingTokens ?? super.tokens()
   }
 
   override async saveTokens(tokens: OAuthTokens): Promise<void> {
@@ -211,6 +208,9 @@ export class McpOAuthPendingProvider extends McpOAuthProvider {
 
   async commit(): Promise<void> {
     if (!this.pendingTokens) return
+    const existing = !this.config.clientId
+      ? await Effect.runPromise(this.auth.getForUrl(this.mcpName, this.serverUrl))
+      : undefined
     await Effect.runPromise(
       this.auth.set(
         this.mcpName,
@@ -229,7 +229,7 @@ export class McpOAuthPendingProvider extends McpOAuthProvider {
                   clientIdIssuedAt: this.pendingClientInfo.client_id_issued_at,
                   clientSecretExpiresAt: this.pendingClientInfo.client_secret_expires_at,
                 }
-              : undefined,
+              : existing?.clientInfo,
         },
         this.serverUrl,
       ),

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -37,6 +37,7 @@ function serveOAuthMcp(options: OAuthMcpOptions = {}) {
         enableJsonResponse: true,
       })
       let listToolsCalls = 0
+      let registerCalls = 0
       let requiresAuth = true
 
       if (capabilities === "tools") {
@@ -87,6 +88,7 @@ function serveOAuthMcp(options: OAuthMcpOptions = {}) {
             })
           }
           if (url.pathname === "/register") {
+            registerCalls++
             const metadata = (await request.json()) as Record<string, unknown>
             return Response.json({ ...metadata, client_id: "replacement-client" }, { status: 201 })
           }
@@ -121,6 +123,7 @@ function serveOAuthMcp(options: OAuthMcpOptions = {}) {
           requiresAuth = false
         },
         listToolsCalls: () => listToolsCalls,
+        registerCalls: () => registerCalls,
         close: async () => {
           await http.stop(true)
           await protocol.close()
@@ -184,7 +187,7 @@ mcpTest.instance("state() returns existing state when one is saved", () =>
   }),
 )
 
-mcpTest.instance("pending provider does not expose or overwrite existing credentials before commit", () =>
+mcpTest.instance("pending provider reuses existing credentials before commit", () =>
   Effect.gen(function* () {
     const auth = yield* McpAuth.Service
     const name = "test-pending-credentials"
@@ -194,10 +197,54 @@ mcpTest.instance("pending provider does not expose or overwrite existing credent
     yield* auth.updateClientInfo(name, { clientId: "old-client" }, url)
     yield* auth.updateTokens(name, { accessToken: "old-token" }, url)
 
-    expect(yield* Effect.promise(() => provider.clientInformation())).toBeUndefined()
-    expect(yield* Effect.promise(() => provider.tokens())).toBeUndefined()
+    expect(yield* Effect.promise(() => provider.clientInformation())).toMatchObject({ client_id: "old-client" })
+    expect(yield* Effect.promise(() => provider.tokens())).toMatchObject({ access_token: "old-token" })
     expect((yield* auth.get(name))?.tokens?.accessToken).toBe("old-token")
     expect((yield* auth.get(name))?.clientInfo?.clientId).toBe("old-client")
+  }),
+)
+
+mcpTest.instance("pending provider keeps client registration when committing refreshed tokens", () =>
+  Effect.gen(function* () {
+    const auth = yield* McpAuth.Service
+    const name = "test-pending-refresh"
+    const url = "https://example.com/mcp"
+    const provider = new McpOAuthPendingProvider(name, url, {}, { onRedirect: async () => {} }, auth)
+
+    yield* auth.updateClientInfo(name, { clientId: "old-client", clientSecret: "old-secret" }, url)
+    yield* Effect.promise(() =>
+      provider.saveTokens({
+        access_token: "new-token",
+        refresh_token: "new-refresh",
+        token_type: "Bearer",
+      }),
+    )
+    yield* Effect.promise(() => provider.commit())
+
+    const entry = yield* auth.get(name)
+    expect(entry?.tokens?.accessToken).toBe("new-token")
+    expect(entry?.tokens?.refreshToken).toBe("new-refresh")
+    expect(entry?.clientInfo).toMatchObject({ clientId: "old-client", clientSecret: "old-secret" })
+    expect(entry?.serverUrl).toBe(url)
+  }),
+)
+
+mcpTest.instance("startAuth reuses stored dynamic client registration", () =>
+  Effect.gen(function* () {
+    yield* stopOAuthCallback
+    const server = yield* serveOAuthMcp()
+    const mcp = yield* MCP.Service
+    const auth = yield* McpAuth.Service
+    const name = "test-stored-client-reuse"
+
+    yield* auth.updateClientInfo(name, { clientId: "stored-client" }, server.url)
+    yield* mcp.add(name, remote(server.url))
+
+    const result = yield* mcp.startAuth(name)
+    const authorizationUrl = new URL(result.authorizationUrl)
+    expect(authorizationUrl.pathname).toBe("/authorize")
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("stored-client")
+    expect(server.registerCalls()).toBe(0)
   }),
 )
 
@@ -226,7 +273,7 @@ mcpTest.instance("failed reauthentication preserves existing credentials", () =>
   }),
 )
 
-mcpTest.instance("successful reauthentication commits replacement credentials", () =>
+mcpTest.instance("successful reauthentication commits replacement tokens", () =>
   Effect.gen(function* () {
     yield* stopOAuthCallback
     const server = yield* serveOAuthMcp()
@@ -243,7 +290,7 @@ mcpTest.instance("successful reauthentication commits replacement credentials", 
     expect((yield* mcp.finishAuth(name, "valid-code")).status).toBe("connected")
     const entry = yield* auth.get(name)
     expect(entry?.tokens?.accessToken).toBe("replacement-token")
-    expect(entry?.clientInfo?.clientId).toBe("replacement-client")
+    expect(entry?.clientInfo?.clientId).toBe("old-client")
     expect(entry?.serverUrl).toBe(server.url)
   }),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #44700

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reuses the stored OAuth client registration and tokens when an authentication flow resumes through the pending provider. It also preserves the stored client registration when committing refreshed tokens.

### How did you verify your code works?

- \`bun test test/mcp/oauth-auto-connect.test.ts\` (11 passed)
- \`bunx prettier --check src/mcp/oauth-provider.ts test/mcp/oauth-auto-connect.test.ts\`

### Screenshots / recordings

Not applicable; this is a backend authentication fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR