### PR TITLE
fix(app): restore selected review pane tab per session

### DIFF
--- a/packages/app/e2e/regression/review-state-persistence.spec.ts
+++ b/packages/app/e2e/regression/review-state-persistence.spec.ts
@@ -39,6 +39,51 @@ test("restores review mode and selected file per session", async ({ page }) => {
   await expectSelectedFile(page, "gamma.ts")
 })
 
+for (const tab of ["Context", "Open file", "README.md"]) {
+  test(`restores the selected ${tab} pane tab after switching sessions and reloading`, async ({ page }) => {
+    await setup(page)
+    await page.goto(sessionHref(sessionA))
+    await expectSessionTitle(page, titleA)
+    await page.getByRole("button", { name: "Toggle review" }).click()
+
+    const panel = page.locator("#review-panel")
+    if (tab === "Context") await page.getByRole("button", { name: "View context usage" }).click()
+    if (tab !== "Context") await panel.getByRole("button", { name: "Open file" }).click()
+    if (tab === "README.md") await panel.getByRole("button", { name: "README.md" }).click()
+    await expect(panel.getByRole("tab", { name: tab, selected: true })).toBeVisible()
+
+    await switchSession(page, titleB)
+    await page.getByRole("button", { name: "Toggle review" }).click()
+    await expect(panel.locator("#session-side-panel-review-tab")).toHaveAttribute("aria-selected", "true")
+
+    await switchSession(page, titleA)
+    await expect(panel.getByRole("tab", { name: tab, selected: true })).toBeVisible()
+
+    await page.reload()
+    await expectSessionTitle(page, titleA)
+    await expect(panel.getByRole("tab", { name: tab, selected: true })).toBeVisible()
+
+    const selected = panel.getByRole("tab", { name: tab })
+    const review = panel.locator("#session-side-panel-review-tab")
+    await selected.press("Home")
+    await expect(review).toHaveAttribute("aria-selected", "true")
+    await review.press("End")
+    await expect(selected).toHaveAttribute("aria-selected", "true")
+    await review.click()
+    await expect(review).toHaveAttribute("aria-selected", "true")
+    await selected.click()
+    await expect(selected).toHaveAttribute("aria-selected", "true")
+
+    await switchSession(page, titleB)
+    await expect(review).toHaveAttribute("aria-selected", "true")
+    await switchSession(page, titleA)
+    await expect(selected).toHaveAttribute("aria-selected", "true")
+    await selected.press("Control+w")
+    await expect(selected).toHaveCount(0)
+    await expect(review).toHaveAttribute("aria-selected", "true")
+  })
+}
+
 async function selectFile(page: Page, file: string) {
   await page.getByRole("button", { name: file }).click()
   await expectSelectedFile(page, file)
@@ -76,6 +121,10 @@ async function setup(page: Page) {
       default: { providerID: "opencode", modelID: "test" },
     },
     sessions: [session(sessionA, titleA, 1700000000000), session(sessionB, titleB, 1700000001000)],
+    fileList: () => [
+      { name: "README.md", path: "README.md", absolute: `${directory}/README.md`, type: "file", ignored: false },
+    ],
+    fileContent: (path) => ({ type: "text", content: `contents:${path}` }),
     pageMessages: () => ({ items: [] }),
   })
   await page.route(/\/api\/vcs(?:\?.*)?$/, (route) =>

--- a/packages/app/src/runtime/platform/browser-pane.ts
+++ b/packages/app/src/runtime/platform/browser-pane.ts
@@ -1,7 +1,12 @@
 import type { Browser } from "@opencode/plugin-browser/rpc"
 
 export type BrowserPaneEndpoint = Readonly<{ url: string; username?: string; password?: string }>
-export type BrowserPaneTarget = Readonly<{ sessionID: string; endpoint: BrowserPaneEndpoint; restore?: Browser.State }>
+export type BrowserPaneTarget = Readonly<{
+  serverKey: string
+  sessionID: string
+  endpoint: BrowserPaneEndpoint
+  restore?: Browser.State
+}>
 export type BrowserPaneLayout = {
   tabID: Browser.TabID
   visible: boolean

--- a/packages/app/src/session/browser/attachments.ts
+++ b/packages/app/src/session/browser/attachments.ts
@@ -95,7 +95,11 @@ export const { use: useBrowserAttachments, provider: BrowserAttachmentsProvider 
         const connection = createBrowserConnection({
           pane,
           // Resolve the current port at every wake, including after sidecar replacement.
-          target: () => ({ sessionID, endpoint: { ...server.conn.http, url: server.ctx.sdk.url } }),
+          target: () => ({
+            serverKey: server.key,
+            sessionID,
+            endpoint: { ...server.conn.http, url: server.ctx.sdk.url },
+          }),
           focus: (tabID) => focus.get(id)?.forEach((listener) => listener(tabID)),
           change: (state) => {
             if (state.error === "browser.pane.unsupported") {

--- a/packages/app/src/session/browser/connection.test.ts
+++ b/packages/app/src/session/browser/connection.test.ts
@@ -29,7 +29,7 @@ function fixture() {
   }[] = []
   const endpoint = { url: "http://localhost:4096" }
   const connection = createBrowserConnection({
-    target: () => ({ sessionID: "ses_browser", endpoint: { ...endpoint } }),
+    target: () => ({ serverKey: "browser-test", sessionID: "ses_browser", endpoint: { ...endpoint } }),
     change: (state) => states.push(state),
     focus: () => {},
     pane: {
@@ -66,7 +66,12 @@ test("suspension retains tabs and reconnects once on demand using the current en
     app.connection.wake()
     app.connection.wake()
     expect(app.calls).toHaveLength(2)
-    expect(app.calls[1].target).toEqual({ sessionID: "ses_browser", endpoint: app.endpoint, restore: browser })
+    expect(app.calls[1].target).toEqual({
+      serverKey: "browser-test",
+      sessionID: "ses_browser",
+      endpoint: app.endpoint,
+      restore: browser,
+    })
     expect(app.states.at(-1)?.suspended).toBe(false)
     app.calls[0].emit({ type: "state", state: null, error: "browser.pane.registration.closed" })
     expect(app.states.at(-1)?.registration).toBeDefined()

--- a/packages/app/src/session/files/session-side-panel.tsx
+++ b/packages/app/src/session/files/session-side-panel.tsx
@@ -1,5 +1,6 @@
 import { For, Match, Show, Switch, createEffect, createMemo, onCleanup, type JSX } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
+import { createEventListener } from "@solid-primitives/event-listener"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
 import { isSortable } from "@dnd-kit/solid/sortable"
 import { Accessibility, AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
@@ -191,6 +192,7 @@ export function SessionSidePanel(props: {
 
   let fileFilter: HTMLInputElement | undefined
   let tabList: HTMLDivElement | undefined
+  let selectionEvent: Event | undefined
   const temporaryTab = tabs().preview
   const previewTab = (value: string) => {
     const next = normalizeTab(value)
@@ -299,11 +301,24 @@ export function SessionSidePanel(props: {
                       tabs().move(source.id.toString(), source.index)
                     }}
                   >
-                    <Tabs value={activeTab()} onChange={activateTab}>
+                    <Tabs
+                      value={activeTab()}
+                      onChange={(value) => {
+                        // Kobalte selects the first tab while session triggers register.
+                        // Persist input events only; createSessionTabs owns fallback selection.
+                        if (selectionEvent && selectionEvent.eventPhase !== Event.NONE) activateTab(value)
+                      }}
+                    >
                       <div class="session-review-v2-tabs-bar sticky top-0 shrink-0 flex items-center">
                         <Tabs.List
                           ref={(el: HTMLDivElement) => {
                             tabList = el
+                            createEventListener(
+                              el,
+                              ["pointerdown", "click", "keydown"],
+                              (event) => (selectionEvent = event),
+                              { capture: true },
+                            )
                             const stop = createFileTabListSync({ el, contextOpen })
                             onCleanup(stop)
                           }}

--- a/packages/desktop/src/main/browser-pane.ts
+++ b/packages/desktop/src/main/browser-pane.ts
@@ -13,6 +13,8 @@ import { createBrowserNetwork, type BrowserNetwork } from "./browser/network"
 import { destinationOrigin } from "./browser/policy"
 import { emitIpcEvent } from "./ipc-events"
 import { SidecarCredentials } from "./service/sidecar-credentials"
+import { createBrowserRestoreStore } from "./browser/restore"
+import type { StateStore } from "./storage/state"
 
 type Entry = {
   bindingID: string
@@ -28,10 +30,12 @@ type Entry = {
   partition: string
   lastState?: string
   network?: BrowserNetwork
+  storageKey: string
 }
 
-export function createBrowserPane() {
+export function createBrowserPane(storage: StateStore) {
   const entries = new Map<string, Entry>()
+  const restore = createBrowserRestoreStore(storage)
   // Keep long-lived RPC requests off Chromium's shared HTTP connection pool.
   const runtime = ManagedRuntime.make(NodeHttpClient.layerNodeHttp)
   let disposed = false
@@ -42,6 +46,16 @@ export function createBrowserPane() {
       if (entries.has(bindingID)) throw new Error("browser.pane.owner.invalid")
       if (win.isDestroyed() || win.webContents.isDestroyed()) throw new Error("browser.pane.owner.unavailable")
       const sessionID = SessionID.make(target.sessionID)
+      const storageKey = `${target.serverKey}\n${sessionID}`
+      const saved = restore.load(storageKey)
+      const previous = target.restore ?? {
+        tabs: saved.tabs.map((tab) => ({
+          ...tab,
+          title: "",
+          generation: 0,
+        })),
+        focusedTabID: saved.focusedTabID,
+      }
       const entry: Entry = {
         bindingID,
         win,
@@ -50,7 +64,7 @@ export function createBrowserPane() {
         requests: new Map(),
         pages: new Map(),
         tabs: new Map(
-          target.restore?.tabs.map((tab) => [
+          previous.tabs.map((tab) => [
             tab.id,
             {
               ...tab,
@@ -61,8 +75,9 @@ export function createBrowserPane() {
             },
           ]),
         ),
-        focusedTabID: target.restore?.focusedTabID ?? null,
+        focusedTabID: previous.focusedTabID,
         partition: `opencode-browser-${crypto.randomUUID()}`,
+        storageKey,
       }
       // "unsupported" means the server has no browser plugin; the renderer stops retrying.
       let reason: "browser.pane.unsupported" | "browser.pane.replaced" | "browser.pane.suspended" | undefined
@@ -260,7 +275,9 @@ export function createBrowserPane() {
       await execute(entry, { action: command, files: [] }, new AbortController().signal)
     },
     async close(win: BrowserWindow, bindingID: string) {
-      close(owned(win, bindingID))
+      const entry = owned(win, bindingID)
+      restore.remove(entry.storageKey)
+      close(entry)
     },
     async dispose() {
       disposed = true
@@ -323,6 +340,16 @@ export function createBrowserPane() {
       state: inventory(entry),
       ...(error === undefined ? {} : { error }),
     }
+    // Teardown publishes an empty inventory to the renderer, but the saved URLs survive app exit.
+    if (entry.report)
+      restore.save(entry.storageKey, {
+        tabs: event.state.tabs.map((tab) => ({
+          id: tab.id,
+          // A restored page can publish before Chromium assigns its URL.
+          url: tab.url || entry.tabs.get(tab.id)?.url || "about:blank",
+        })),
+        focusedTabID: entry.focusedTabID,
+      })
     const next = JSON.stringify(event)
     if (entry.lastState === next) return
     entry.lastState = next

--- a/packages/desktop/src/main/browser/restore.test.ts
+++ b/packages/desktop/src/main/browser/restore.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { Browser } from "@opencode/plugin-browser/rpc"
+import { mkdtemp, rm } from "node:fs/promises"
+import path from "node:path"
+import { tmpdir } from "node:os"
+import { openDatabase } from "../storage/database"
+import { createStateStore } from "../storage/state"
+import { createBrowserRestoreStore } from "./restore"
+
+test("persists browser tab URLs and focus across a database reopen", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "opencode-browser-restore-"))
+  const filename = path.join(directory, "state.sqlite")
+  const first = openDatabase(filename)
+  const storage = createStateStore(first.db)
+  const restore = createBrowserRestoreStore(storage)
+  const key = "local\nses_restore"
+  const tab = {
+    id: Browser.TabID.make("tab_00000000-0000-0000-0000-000000000001"),
+    url: "https://example.com/docs",
+    title: "Transient title",
+    loading: false,
+    canGoBack: true,
+    canGoForward: false,
+    generation: 5,
+  }
+  restore.save(key, { tabs: [tab], focusedTabID: tab.id })
+  storage.close()
+  first.close()
+
+  const second = openDatabase(filename)
+  const reopenedStorage = createStateStore(second.db)
+  const reopened = createBrowserRestoreStore(reopenedStorage)
+  try {
+    expect(reopened.load(key)).toEqual({ tabs: [{ id: tab.id, url: tab.url }], focusedTabID: tab.id })
+    expect(reopened.load("remote\nses_restore")).toEqual({ tabs: [], focusedTabID: null })
+    reopened.save(key, { tabs: [], focusedTabID: null })
+    expect(reopened.load(key)).toEqual({ tabs: [], focusedTabID: null })
+    reopened.remove(key)
+    expect(reopenedStorage.get("opencode.browser.dat", key)).toBeNull()
+  } finally {
+    reopenedStorage.close()
+    second.close()
+    // Bun's SQLite shim can retain WAL handles on Windows after close.
+    await rm(directory, { recursive: true, force: true }).catch(() => undefined)
+  }
+})
+
+test("ignores malformed browser restoration metadata", () => {
+  const database = openDatabase(":memory:")
+  const storage = createStateStore(database.db)
+  try {
+    storage.set("opencode.browser.dat", "local\nses_restore", '{"tabs":[{"id":"invalid","url":12}]}')
+    expect(createBrowserRestoreStore(storage).load("local\nses_restore")).toEqual({ tabs: [], focusedTabID: null })
+  } finally {
+    storage.close()
+    database.close()
+  }
+})

--- a/packages/desktop/src/main/browser/restore.ts
+++ b/packages/desktop/src/main/browser/restore.ts
@@ -1,0 +1,31 @@
+import { Browser } from "@opencode/plugin-browser/rpc"
+import { Option, Schema } from "effect"
+import type { StateStore } from "../storage/state"
+
+const Stored = Schema.fromJsonString(
+  Schema.Struct({
+    tabs: Schema.Array(Schema.Struct({ id: Browser.TabID, url: Browser.Tab.fields.url })),
+    focusedTabID: Schema.NullOr(Browser.TabID),
+  }),
+)
+const decode = Schema.decodeUnknownOption(Stored)
+const encode = Schema.encodeSync(Stored)
+const namespace = "opencode.browser.dat"
+
+export function createBrowserRestoreStore(storage: StateStore) {
+  return {
+    load(key: string) {
+      return Option.getOrElse(decode(storage.get(namespace, key)), () => ({ tabs: [], focusedTabID: null }))
+    },
+    save(key: string, state: typeof Stored.Type) {
+      const value = encode({
+        tabs: state.tabs.map((tab) => ({ id: tab.id, url: tab.url })),
+        focusedTabID: state.focusedTabID,
+      })
+      if (storage.get(namespace, key) !== value) storage.set(namespace, key, value)
+    },
+    remove(key: string) {
+      storage.delete(namespace, key)
+    },
+  }
+}

--- a/packages/desktop/src/main/ipc-handlers/events.ts
+++ b/packages/desktop/src/main/ipc-handlers/events.ts
@@ -6,13 +6,15 @@ import { ipcEventStream } from "../ipc-events"
 import { IpcPortHandoff } from "../ipc-transport"
 import { Shutdown } from "../lifecycle/shutdown"
 import { isRendererUrl } from "../windows/protocol"
+import { DesktopStorage } from "../storage"
 import { sender } from "./context"
 
 export const eventHandlers = EventRpcs.toLayer(
   Effect.gen(function* () {
     const handoff = yield* IpcPortHandoff
     const shutdown = yield* Shutdown.Service
-    const browser = createBrowserPane()
+    const storage = yield* DesktopStorage.Service
+    const browser = createBrowserPane(storage.state)
     const stop = Effect.promise(() => browser.dispose())
     const remove = yield* shutdown.add(stop)
     yield* Effect.addFinalizer(() => Effect.sync(remove).pipe(Effect.andThen(stop)))

--- a/packages/desktop/src/shared/ipc-rpc/browser.ts
+++ b/packages/desktop/src/shared/ipc-rpc/browser.ts
@@ -10,6 +10,7 @@ const endpoint = Schema.Struct({
   password: Schema.optionalKey(text(4_096)),
 })
 const target = Schema.Struct({
+  serverKey: text(16_384),
   sessionID: text(256).check(Schema.isStartsWith("ses")),
   endpoint,
   restore: Schema.optionalKey(Browser.State),

--- a/packages/desktop/test/browser/idle.ts
+++ b/packages/desktop/test/browser/idle.ts
@@ -12,6 +12,8 @@ import { bindIpcEvents, ipcEventStream } from "../../src/main/ipc-events"
 import { createBrowserConnection, type BrowserConnectionState } from "../../../app/src/session/browser/connection"
 import type { BrowserPaneEvent } from "../../../app/src/runtime/platform/browser-pane"
 import { Smoke } from "./contract"
+import { openDatabase } from "../../src/main/storage/database"
+import { createStateStore } from "../../src/main/storage/state"
 
 async function main() {
   app.setPath("userData", path.join(process.env.SMOKE_ROOT!, "electron-data"))
@@ -36,7 +38,9 @@ async function main() {
   const client = OpenCode.make({ baseUrl: endpoint.url, headers })
   const location = { directory: process.env.SMOKE_SERVER_FILES! }
   const session = await client.session.create({ title: "Idle browser", location })
-  const pane = createBrowserPane()
+  const database = openDatabase(":memory:")
+  const storage = createStateStore(database.db)
+  const pane = createBrowserPane(storage)
   const win = new BrowserWindow({ show: false, width: 1100, height: 800, webPreferences: { sandbox: true } })
   await win.loadURL("about:blank")
   win.showInactive()
@@ -53,7 +57,7 @@ async function main() {
   )
   const states: BrowserConnectionState[] = []
   const connection = createBrowserConnection({
-    target: () => ({ sessionID: session.id, endpoint }),
+    target: () => ({ serverKey: "browser-idle", sessionID: session.id, endpoint }),
     change: (state) => states.push(state),
     focus: () => {},
     pane: {
@@ -117,15 +121,13 @@ async function main() {
       )
     assert(!result.error, result.output)
     assert(result.output.includes("Browser connection restored"))
-    const background = await client
-      .rpc(Smoke)
-      .execute(
-        {
-          sessionID: session.id,
-          code: `return await tools.browser.snapshot({tabID: ${JSON.stringify(saved.tabs[1].id)}})`,
-        },
-        { location },
-      )
+    const background = await client.rpc(Smoke).execute(
+      {
+        sessionID: session.id,
+        code: `return await tools.browser.snapshot({tabID: ${JSON.stringify(saved.tabs[1].id)}})`,
+      },
+      { location },
+    )
     assert(!background.error, background.output)
     assert.equal(loads.get("/second"), 2, "an agent can load an inactive restored tab without user focus")
     if (process.env.SMOKE_EVIDENCE) {
@@ -139,6 +141,8 @@ async function main() {
   } finally {
     connection.dispose()
     await pane.dispose()
+    storage.close()
+    database.close()
     await Effect.runPromise(Fiber.interrupt(events))
     await Effect.runPromise(unbind)
     win.destroy()

--- a/packages/desktop/test/browser/native.ts
+++ b/packages/desktop/test/browser/native.ts
@@ -11,6 +11,8 @@ import { createBrowserPane } from "../../src/main/browser-pane"
 import { bindIpcEvents, ipcEventStream } from "../../src/main/ipc-events"
 import { Smoke } from "./contract"
 import { verifyTargets } from "./targets"
+import { openDatabase } from "../../src/main/storage/database"
+import { createStateStore } from "../../src/main/storage/state"
 
 type Output<Name extends Browser.Method> = Schema.Schema.Type<Extract<Browser.Operation, { name: Name }>["output"]>
 
@@ -126,7 +128,10 @@ async function main() {
   const location = { directory: process.env.SMOKE_SERVER_FILES! }
   const rpc = client.rpc(Smoke)
   const session = await client.session.create({ title: "Browser suite", location })
-  const pane = createBrowserPane()
+  const database = openDatabase(path.join(root, "browser.sqlite"))
+  const storage = createStateStore(database.db)
+  const pane = createBrowserPane(storage)
+  let restored: ReturnType<typeof createBrowserPane> | undefined
   const win = new BrowserWindow({ show: false, width: 1100, height: 800, webPreferences: { sandbox: true } })
   const readyToShow = once(win, "ready-to-show")
   await win.loadURL("about:blank")
@@ -138,6 +143,7 @@ async function main() {
   )
   const ipcErrors: string[] = []
   const replaced: string[] = []
+  const focusEvents: string[] = []
   const inventories = new Map<string, Browser.State | null>()
   const unbind = await Effect.runPromise(bindIpcEvents(win.webContents.id))
   const events = Effect.runFork(
@@ -150,6 +156,7 @@ async function main() {
             inventories.set(event.bindingID, event.event.state)
             return
           }
+          focusEvents.push(event.event.tabID)
           if (!inventories.get(event.bindingID)?.tabs.some((tab) => tab.id === event.event.tabID))
             ipcErrors.push("Focus arrived before its tab inventory")
           pane.layout(win, event.bindingID, {
@@ -188,6 +195,7 @@ async function main() {
   try {
     await verifyTargets(win, fixture)
     await pane.register(win, "suite", {
+      serverKey: "browser-suite",
       sessionID: session.id,
       endpoint: { url: process.env.SMOKE_URL!, password: process.env.SMOKE_PASSWORD },
     })
@@ -547,15 +555,54 @@ async function main() {
     )
     assert.deepEqual(ipcErrors, [])
     await pane.register(win, "replacement", {
+      serverKey: "browser-suite",
       sessionID: session.id,
       endpoint: { url: process.env.SMOKE_URL!, password: process.env.SMOKE_PASSWORD },
     })
     await until(async () => replaced.includes("suite"))
+    await until(async () => {
+      const state = await call("tabs.list", {})
+      return state.tabs.length === 2 && state.tabs.every((tab) => !tab.loading && tab.url !== "about:blank")
+    })
+    const saved = await call("tabs.list", {})
+    assert.equal(saved.tabs.length, 2)
+    await call("evaluate", { tabID, script: "window.restoreOnlyInMemory = true; null" })
+    await pane.dispose()
+    storage.flush()
+    restored = createBrowserPane(storage)
+    const focusCount = focusEvents.length
+    await restored.register(win, "restored", {
+      serverKey: "browser-suite",
+      sessionID: session.id,
+      endpoint: { url: process.env.SMOKE_URL!, password: process.env.SMOKE_PASSWORD },
+    })
+    await until(async () => {
+      const state = await call("tabs.list", {})
+      return (
+        state.tabs.length === saved.tabs.length && state.tabs.every((tab) => !tab.loading && tab.url !== "about:blank")
+      )
+    })
+    const reopened = await call("tabs.list", {})
+    assert.deepEqual(
+      reopened.tabs.map((tab) => ({ id: tab.id, url: tab.url })),
+      saved.tabs.map((tab) => ({ id: tab.id, url: tab.url })),
+    )
+    assert.equal(reopened.focusedTabID, saved.focusedTabID)
+    await Promise.all(
+      saved.tabs.map(async (tab) => {
+        assert.equal((await call("evaluate", { tabID: tab.id, script: "location.href" })).value, tab.url)
+      }),
+    )
+    assert.equal((await call("evaluate", { tabID, script: "typeof window.restoreOnlyInMemory" })).value, "undefined")
+    assert.equal(focusEvents.length, focusCount, "Restoring URLs must not select Browser over the saved pane tab")
     console.log(
       `PASS ${visited.size} browser operations over physical authenticated HTTP, including file bytes in both directions`,
     )
   } finally {
+    await restored?.dispose()
     await pane.dispose()
+    storage.close()
+    database.close()
     await Effect.runPromise(Fiber.interrupt(events))
     await Effect.runPromise(unbind)
     win.destroy()


### PR DESCRIPTION
- Restore each session's selected review-pane tab when switching sessions or reopening Desktop: Context, Browser, Files Changed, Open file, or an open file.
- Keep Kobalte's temporary first-tab selection from overwriting the saved selection while tab triggers register.
- Store Browser tab IDs, URLs, and focus in Desktop's existing SQLite storage. Reuse the idle-restore path to load a URL when its tab is displayed or used by the agent.

| Before: Context resets to Files Changed | After: Context is restored |
| --- | --- |
| ![Context resets after switching sessions](https://github.com/user-attachments/assets/d90b8207-0bc3-42b3-95c8-741c95c6ce5b) | ![Context stays selected after switching sessions](https://github.com/user-attachments/assets/a40a5508-1169-4570-9112-70d91a946a89) |

### Session-switch timing investigation

Frozen production Chromium builds: baseline `c1f4beaf40`, candidate `6d9a656ee2`. Eight serial samples per scenario and revision, in two-sample blocks ordered A/B/B/A/A/B/B/A; 400 messages per session, identical routed fixtures, tracing and service workers disabled. Each cell is median / p95 in milliseconds, measured from sampled DOM readiness.

These snapshots precede the upstream idle-suspend integration; they are diagnostic results, not a benchmark of the rebased HEAD.

| Scenario | First correct: before | First correct: after | Stable: before | Stable: after |
| --- | ---: | ---: | ---: | ---: |
| Cold, review closed | 358.8 / 482.9 | 373.3 / 494.4 | 403.9 / 508.4 | 402.6 / 535.3 |
| Cold, review open | 431.7 / 624.9 | 391.4 / 561.9 | 502.2 / 714.5 | 452.2 / 650.2 |
| Warm, review closed | 115.1 / 136.0 | 137.7 / 188.5 | 232.4 / 281.8 | 276.5 / 368.8 |
| Warm, review open | 255.1 / 284.0 | 237.3 / 296.4 | 381.8 / 453.1 | 380.3 / 498.0 |
| Warm, review resized | 264.5 / 341.4 | 265.9 / 365.9 | 412.6 / 515.7 | 401.8 / 531.2 |

- The broad slowdown in the initial three-sample comparison did not repeat consistently. Warm/review-closed remains higher by 22.6 ms to first correct content and 44.1 ms to stable content; the cause is not isolated, so this is not a claim of performance equivalence.
