### PR TITLE
fix(app): smooth right panel transitions

### DIFF
--- a/packages/app/e2e/regression/review-toggle-position.spec.ts
+++ b/packages/app/e2e/regression/review-toggle-position.spec.ts
@@ -1,5 +1,5 @@
 import { base64Encode } from "@opencode/util/encode"
-import { expect, test, type Locator } from "@playwright/test"
+import { expect, test, type Locator, type Page } from "@playwright/test"
 import { mockOpenCodeServer } from "../utils/mock-server"
 import { expectSessionTitle } from "../utils/waits"
 
@@ -85,6 +85,38 @@ for (const width of [1000, 1440]) {
       await expect.poll(() => toggle.boundingBox()).toEqual(closed)
     })
 
+    test(`keeps moving header content out of the toggle area (${width}px, ${direction})`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 })
+      await page.goto(`/server/${base64Encode(server)}/session/${sessionID}`)
+      await expectSessionTitle(page, "Review toggle position")
+      await page.locator("html").evaluate((element, dir) => element.setAttribute("dir", dir), direction)
+
+      const toggle = page.getByRole("button", { name: "Toggle review", exact: true })
+      await expect(toggle).toHaveAttribute("aria-expanded", "false")
+      for (const opened of [true, false]) {
+        // Pause in the same task as the click so even the first painted state can be inspected.
+        await toggle.evaluate((element) => {
+          ;(element as HTMLButtonElement).click()
+          document
+            .getAnimations()
+            .filter((animation) => animation.timeline instanceof DocumentTimeline)
+            .forEach((animation) => animation.pause())
+        })
+        await expect(toggle).toHaveAttribute("aria-expanded", String(opened))
+        await expect(page.locator("#review-panel")).toHaveAttribute("aria-hidden", String(!opened))
+        for (const progress of [0.08, 0.16, 0.25, 0.5, 0.8, 0.96]) {
+          await expectHeaderClearOfToggle(page, toggle, progress)
+        }
+        await page.evaluate(() => {
+          document
+            .getAnimations()
+            .filter((animation) => animation.timeline instanceof DocumentTimeline)
+            .forEach((animation) => animation.finish())
+        })
+      }
+      await expect(page.locator("#review-panel")).toBeHidden()
+    })
+
     test(`keeps terminal controls clear of the review toggle (${width}px, ${direction})`, async ({ page }) => {
       await page.setViewportSize({ width, height: 900 })
       const ptys: { id: string; title: string }[] = []
@@ -166,8 +198,82 @@ for (const width of [1000, 1440]) {
       await expect(toggle).toBeFocused()
       await expect.poll(() => toggle.boundingBox()).toEqual(position)
       await expectTerminalControlsAligned(terminal, toggle)
+
+      // Closing the terminal clears the region's animation flag while retaining the review contents.
+      await page.keyboard.press("Control+Backquote")
+      await expect(terminal).toBeHidden()
+      await expect
+        .poll(() =>
+          page
+            .locator('[data-slot="session-chat-panel"]')
+            .evaluate((element) => element.getAnimations().every((animation) => animation.playState === "finished")),
+        )
+        .toBe(true)
+      await expect(page.locator('[data-slot="session-review-content"]')).toHaveCSS("opacity", "0")
+      await toggle.evaluate((element) => {
+        ;(element as HTMLButtonElement).click()
+        document
+          .getAnimations()
+          .filter((animation) => animation.timeline instanceof DocumentTimeline)
+          .forEach((animation) => animation.pause())
+      })
+      await expect(toggle).toHaveAttribute("aria-expanded", "true")
+      await expectHeaderClearOfToggle(page, toggle, 0.25)
     })
   }
+}
+
+async function expectHeaderClearOfToggle(page: Page, toggle: Locator, progress: number) {
+  const geometry = await page.locator('[data-slot="session-chat-panel"]').evaluate((chat, progress) => {
+    const row = chat.parentElement!
+    const animations = row
+      .getAnimations({ subtree: true })
+      .filter((animation) => animation.timeline instanceof DocumentTimeline)
+    const width = animations.find(
+      (animation) => animation instanceof CSSTransition && animation.transitionProperty === "width",
+    )!
+    animations.forEach((animation) => {
+      animation.pause()
+      animation.currentTime = Number(width.effect!.getTiming().duration) * progress
+    })
+    const chatBounds = chat.getBoundingClientRect()
+    const panelBounds = document.querySelector("#review-panel")!.getBoundingClientRect()
+    const summaryBounds = document
+      .querySelector('[data-session-title] button[aria-label="Session details"]')!
+      .getBoundingClientRect()
+    return {
+      row: row.getBoundingClientRect().width,
+      panelWidth: panelBounds.width,
+      timelineControlInset:
+        getComputedStyle(row).direction === "rtl"
+          ? summaryBounds.left - chatBounds.left
+          : chatBounds.right - summaryBounds.right,
+      gap:
+        getComputedStyle(row).direction === "rtl"
+          ? chatBounds.left - panelBounds.right
+          : panelBounds.left - chatBounds.right,
+      contentOpacity: Number(getComputedStyle(document.querySelector('[data-slot="session-review-content"]')!).opacity),
+      panels: chatBounds.width + panelBounds.width + parseFloat(getComputedStyle(row).columnGap),
+    }
+  }, progress)
+  expect(geometry.gap).toBeCloseTo(8, 1)
+  // Reserve the fixed toggle's 28px width, the 8px control gap, and the 12px header inset.
+  expect(geometry.timelineControlInset).toBeCloseTo(48, 1)
+  if (geometry.panelWidth > 0) expect(Math.abs(geometry.row - geometry.panels)).toBeLessThanOrEqual(1)
+  if (progress === 0.25) {
+    expect(geometry.contentOpacity).toBeGreaterThan(0)
+    expect(geometry.contentOpacity).toBeLessThan(1)
+  }
+
+  const clip = await toggle.boundingBox()
+  if (!clip) throw new Error("Review toggle bounds are unavailable")
+  // Header contents must make no difference to the pixels behind the fixed toggle.
+  expect(await page.screenshot({ clip })).toEqual(
+    await page.screenshot({
+      clip,
+      style: ".session-review-v2-tabs-bar { visibility: hidden !important; }",
+    }),
+  )
 }
 
 async function expectTerminalControlsAligned(terminal: Locator, toggle: Locator) {

--- a/packages/app/e2e/regression/session-panel-scrollbar.spec.ts
+++ b/packages/app/e2e/regression/session-panel-scrollbar.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test"
+import { setupTimeline } from "../performance/timeline-stability/fixture"
+
+for (const reducedMotion of [false, true]) {
+  test(`suppresses the scrollbar from toggle press until timeline interaction (reduced motion: ${reducedMotion})`, async ({
+    page,
+  }) => {
+    await setupTimeline(page, { seedHistory: true, reducedMotion })
+    const chat = page.locator('[data-slot="session-chat-panel"]')
+    const scroll = page.locator('[data-slot="session-timeline-scroll"]')
+    const viewport = scroll.locator(".scroll-view__viewport")
+    const thumb = scroll.locator('.scroll-view__thumb[data-orientation="vertical"]')
+    const toggle = page.getByRole("button", { name: "Toggle review", exact: true })
+    await expect(thumb).toHaveCount(1)
+    await scroll.hover()
+    await expect(thumb).toHaveAttribute("data-visible", "true")
+    await expect(thumb).toHaveCSS("visibility", "visible")
+
+    for (const opened of [true, false]) {
+      await toggle.hover()
+      await page.mouse.down()
+      await expect(thumb).toHaveCSS("visibility", "hidden")
+      await page.mouse.up()
+      await expect(toggle).toHaveAttribute("aria-expanded", String(opened))
+      await chat.evaluate(async (element) => {
+        await Promise.all(element.getAnimations().map((animation) => animation.finished))
+      })
+      await expect(chat).toHaveAttribute("data-width-animating", "false")
+      await expect(thumb).toHaveCSS("visibility", "hidden")
+      // Late scroll anchoring must not bring the thumb back after the panel has settled.
+      await viewport.evaluate(
+        (element) =>
+          new Promise<void>((resolve) => {
+            element.addEventListener("scroll", () => resolve(), { once: true })
+            element.scrollTop += element.scrollTop > 0 ? -1 : 1
+          }),
+      )
+      await expect(thumb).toHaveCSS("visibility", "hidden")
+      await scroll.hover()
+      await expect(thumb).toHaveAttribute("data-visible", "true")
+      await expect(thumb).toHaveCSS("visibility", "visible")
+    }
+  })
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -38,12 +38,65 @@
 }
 
 @layer components {
+  [data-slot="session-chat-panel"][data-scrollbar-hidden="true"]
+    [data-slot="session-timeline-scroll"]
+    > .scroll-view__thumb {
+    visibility: hidden;
+  }
+
   [data-slot="session-side-panel-presence"][data-opened="true"] {
-    animation: terminal-panel-presence-in 240ms cubic-bezier(0.22, 1, 0.36, 1);
+    animation: side-region-presence-in 240ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   [data-slot="session-side-panel-presence"][data-opened="false"] {
-    animation: terminal-panel-presence-out 240ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+    animation: side-region-presence-out 240ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+
+  #review-panel {
+    container-type: inline-size;
+  }
+
+  /* Like the composer toolbar, fade only clipped content without reserving layout space.
+     The fade contracts as overflow clears; the second mask preserves the header divider. */
+  #review-panel .session-review-v2-tabs-bar {
+    --session-review-header-fade: clamp(0px, calc(100% - 100cqi), 24px);
+    mask-image:
+      linear-gradient(
+        to right,
+        #000 calc(100cqi - 40px - var(--session-review-header-fade)),
+        transparent calc(100cqi - 40px)
+      ),
+      linear-gradient(to top, #000 1px, transparent 1px);
+
+    &:dir(rtl) {
+      mask-image:
+        linear-gradient(
+          to left,
+          #000 calc(100cqi - 40px - var(--session-review-header-fade)),
+          transparent calc(100cqi - 40px)
+        ),
+        linear-gradient(to top, #000 1px, transparent 1px);
+    }
+  }
+
+  /* The panel's width animation supplies the slide; only fade its fixed-width contents. */
+  [data-slot="session-side-region-presence"][data-opened] [data-slot="session-review-content"] {
+    transition: opacity 200ms ease-out 40ms;
+  }
+
+  /* Cached contents must stay transparent even after the presence animation finishes. */
+  #review-panel[aria-hidden="true"] > [data-slot="session-review-content"] {
+    opacity: 0;
+  }
+
+  [data-slot="session-side-region-presence"][data-opened="false"] [data-slot="session-review-content"] {
+    transition: opacity 160ms ease-out;
+  }
+
+  @starting-style {
+    [data-slot="session-side-region-presence"][data-opened="true"] [data-slot="session-review-content"] {
+      opacity: 0;
+    }
   }
 
   [data-slot="session-side-region-presence"][data-opened="true"] {
@@ -82,9 +135,14 @@
     [data-slot="terminal-panel-presence"],
     [data-slot="side-terminal-panel-presence"],
     [data-slot="session-side-panel-presence"],
+    [data-slot="session-review-content"],
     [data-slot="session-side-region-presence"],
     [data-component="terminal-panel"] {
       animation: none !important;
+    }
+
+    [data-slot="session-review-content"] {
+      transition: none !important;
     }
   }
 
@@ -125,13 +183,9 @@
     }
   }
 
+  /* Presence needs an animation lifetime, but the panel frame must never fade. */
   @keyframes side-region-presence-in {
-    from {
-      opacity: 0;
-    }
-    0.01% {
-      opacity: 0.999999;
-    }
+    from,
     to {
       opacity: 1;
     }
@@ -142,7 +196,7 @@
       opacity: 1;
     }
     to {
-      opacity: 0.999999;
+      opacity: 1;
       visibility: hidden;
     }
   }

--- a/packages/app/src/session/files/session-side-panel.tsx
+++ b/packages/app/src/session/files/session-side-panel.tsx
@@ -272,7 +272,11 @@ export function SessionSidePanel(props: {
         style={{ width: panelWidth() }}
       >
         <Show when={visible()}>
-          <div class="size-full flex">
+          <div
+            data-slot="session-review-content"
+            class="h-full flex shrink-0"
+            style={{ width: "var(--session-side-content-width, 100%)" }}
+          >
             <Show when={reviewVisible()}>
               <div class="relative min-w-0 h-full flex-1 overflow-hidden bg-v2-background-bg-base">
                 <div class="size-full min-w-0 h-full bg-v2-background-bg-base">
@@ -537,7 +541,7 @@ export function SessionSidePanel(props: {
                           onClick={(event) => event.stopPropagation()}
                         >
                           <OpenInAppButton directory={projectDirectory} />
-                          <Show when={reviewOpen()}>
+                          <Show when={reviewVisible()}>
                             <div class="size-7 shrink-0" aria-hidden />
                           </Show>
                         </div>

--- a/packages/app/src/session/header/session-header-actions.tsx
+++ b/packages/app/src/session/header/session-header-actions.tsx
@@ -55,6 +55,11 @@ export function SessionHeaderActions(props: { state: SessionHeaderActionsState }
             variant="ghost-muted"
             size="large"
             class="shrink-0"
+            style={{
+              // This fixed control sits above moving panel contents.
+              "--v2-overlay-simple-overlay-hover": "var(--v2-background-bg-layer-01)",
+              "--v2-overlay-simple-overlay-pressed": "var(--v2-background-bg-layer-02)",
+            }}
             state={props.state.reviewOpened ? "pressed" : undefined}
             onClick={props.state.onReviewToggle}
             aria-label={props.state.reviewLabel}

--- a/packages/app/src/session/header/session-header.tsx
+++ b/packages/app/src/session/header/session-header.tsx
@@ -2,7 +2,6 @@ import { Show } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { useLanguage } from "@/runtime/i18n/language"
 import { useSettings } from "@/settings/model"
-import { useSessionLayout } from "@/session/session-layout"
 import { StatusPopover } from "@/shell/status/status-popover"
 import { TitlebarRight } from "@/shell/titlebar/right-slot"
 import { Tooltip } from "@opencode/ui/tooltip"
@@ -10,7 +9,6 @@ import { Tooltip } from "@opencode/ui/tooltip"
 export function SessionHeader() {
   const language = useLanguage()
   const settings = useSettings()
-  const { view } = useSessionLayout()
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
@@ -23,7 +21,8 @@ export function SessionHeader() {
           </Tooltip>
         </Show>
       </TitlebarRight>
-      <Show when={isDesktop() && !view().reviewPanel.opened()}>
+      {/* Keep the fixed toggle's slot mounted throughout panel motion. */}
+      <Show when={isDesktop()}>
         <div class="size-7 shrink-0" aria-hidden />
       </Show>
     </>

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -61,6 +61,8 @@ export function SessionScreen(props: { session: SessionModel }) {
   const [store, setStore] = createStore({
     deferRender: false,
     bottomTerminalCached: false,
+    sideWidthMotion: false,
+    timelineScrollbarHidden: false,
     sideHeightMotion: false,
     sideRegionPresent: false,
     sideReviewPresent: false,
@@ -109,6 +111,16 @@ export function SessionScreen(props: { session: SessionModel }) {
     sideMotion().animateRegion ||
     sideMotion().animateTerminal ||
     bottomTerminalPresence.animate()
+  const trackSideWidthMotion = (event: TransitionEvent) => {
+    if (event.currentTarget !== event.target || event.propertyName !== "width") return
+    setStore("sideWidthMotion", event.type === "transitionrun")
+  }
+  const hideTimelineScrollbar = () => setStore("timelineScrollbarHidden", true)
+  const revealTimelineScrollbar = (event: Event) => {
+    if (!store.timelineScrollbarHidden || store.sideWidthMotion) return
+    if (!(event.target instanceof Element) || !event.target.closest('[data-slot="session-timeline-scroll"]')) return
+    setStore("timelineScrollbarHidden", false)
+  }
   createEffect(() => {
     if (sideTerminalVisible()) setStore("sideTerminalPresent", true)
     if (bottomTerminalVisible()) setStore("bottomTerminalCached", true)
@@ -296,6 +308,8 @@ export function SessionScreen(props: { session: SessionModel }) {
               class="absolute end-3 top-0 z-30 flex items-center"
               classList={{ "h-[51px]": sideTerminalVisible(), "h-12": !sideTerminalVisible() }}
               data-slot="session-review-toggle"
+              onPointerDown={hideTimelineScrollbar}
+              onClick={hideTimelineScrollbar}
             >
               <SessionReviewToggle />
             </div>
@@ -303,11 +317,20 @@ export function SessionScreen(props: { session: SessionModel }) {
           <div
             classList={{
               "@container relative z-10 min-w-0 shrink-0 flex flex-col min-h-0 h-full flex-1 md:flex-none transition-[width]": true,
-              "duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
+              "duration-[240ms] ease-[cubic-bezier(0.4,0,0.2,1)] will-change-[width] motion-reduce:transition-none":
                 !screen.size.active() && sidePresence.animate(),
               "transition-none": screen.size.active() || !sidePresence.animate(),
             }}
             data-slot="session-chat-panel"
+            data-width-animating={store.sideWidthMotion}
+            data-scrollbar-hidden={store.timelineScrollbarHidden || store.sideWidthMotion}
+            onPointerMove={revealTimelineScrollbar}
+            onPointerDown={revealTimelineScrollbar}
+            onWheel={revealTimelineScrollbar}
+            onKeyDown={revealTimelineScrollbar}
+            onTransitionRun={trackSideWidthMotion}
+            onTransitionEnd={trackSideWidthMotion}
+            onTransitionCancel={trackSideWidthMotion}
             style={{
               width: screen.panel.width(),
             }}
@@ -342,7 +365,7 @@ export function SessionScreen(props: { session: SessionModel }) {
               data-opened={sidePresence.animate() ? sidePresence.show() : undefined}
               onAnimationEnd={(event) => {
                 if (event.currentTarget !== event.target) return
-                if (event.animationName !== "terminal-panel-presence-in" || !sideVisible()) return
+                if (event.animationName !== "side-region-presence-in" || !sideVisible()) return
                 setStore("sideHeightMotion", true)
               }}
               classList={{
@@ -353,8 +376,8 @@ export function SessionScreen(props: { session: SessionModel }) {
             >
               <div
                 data-slot="session-side-panel-content"
-                class="absolute inset-y-0 start-0 h-full"
-                style={{ width: screen.side.contentWidth() }}
+                class="absolute inset-y-0 start-0 size-full"
+                style={{ "--session-side-content-width": screen.side.contentWidth() }}
               >
                 <div
                   data-slot="session-side-region"
@@ -363,7 +386,7 @@ export function SessionScreen(props: { session: SessionModel }) {
                     "will-change-[height]": !screen.size.active() && store.sideHeightMotion && paneAnimating(),
                     "transition-none": screen.size.active() || !store.sideHeightMotion || !paneAnimating(),
                   }}
-                  style={{ height: screen.side.region.height() }}
+                  style={{ height: sideVisible() ? screen.side.region.height() : "100%" }}
                 >
                   <Show when={store.sideRegionPresent}>
                     <div
@@ -383,7 +406,7 @@ export function SessionScreen(props: { session: SessionModel }) {
                     </div>
                   </Show>
                 </div>
-                <div class="absolute inset-x-0 bottom-0 flex flex-col">
+                <div class="absolute start-0 bottom-0 flex flex-col" style={{ width: screen.side.contentWidth() }}>
                   <div
                     data-slot="session-side-panel-gap"
                     classList={{

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -536,6 +536,7 @@ export function createTimelineVirtualizer(input: Input) {
           </button>
         </div>
         <ScrollView
+          data-slot="session-timeline-scroll"
           viewportRef={bindListRoot}
           onWheel={handleListWheel}
           onTouchStart={handleListTouchStart}


### PR DESCRIPTION
- Keep the panel frame opaque as it grows and shrinks, with fading content and a consistent 8px gap.
- Fade overflowing header content behind the fixed toggle without moving “Open in”; reserve space for timeline controls and use solid toggle states.
- Hide the timeline scrollbar on toggle press until the next timeline interaction.

### Opening transition

| Before | After |
| --- | --- |
| ![Before: panel opening](https://github.com/user-attachments/assets/980e9e9d-5032-4f05-9ad2-0abe47440144) | ![After: panel opening](https://github.com/user-attachments/assets/dec198b2-db88-4e5a-a6a2-2a153e6d1994) |