### PR TITLE
fix(app): reorder and rename browser experiment

### DIFF
--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -1074,7 +1074,7 @@ export const dict = {
   "settings.general.row.uiFont.description": "Customise the font used throughout the interface",
   "settings.general.row.showFileTree.title": "File tree",
   "settings.general.row.showFileTree.description": "Show the file tree panel in sessions",
-  "settings.general.row.browserPane.title": "Browser pane",
+  "settings.general.row.browserPane.title": "Browser",
   "settings.general.row.browserPane.description": "Allow agents to open and control an in-app development browser.",
   "settings.general.row.showNavigation.title": "Navigation controls",
   "settings.general.row.showNavigation.description": "Show the back and forward buttons in the desktop title bar",

--- a/packages/app/src/settings/experimental/experimental.tsx
+++ b/packages/app/src/settings/experimental/experimental.tsx
@@ -31,22 +31,6 @@ export const SettingsExperimental: Component = () => {
       <div class="settings-tab-body">
         <div class="settings-section">
           <SettingsList>
-            <Show when={platform.browserPane}>
-              <SettingsRow
-                title={language.t("settings.general.row.browserPane.title")}
-                description={language.t("settings.general.row.browserPane.description")}
-              >
-                <div data-action="settings-experimental-browser">
-                  <Switch
-                    checked={settings.general.experimentalBrowser()}
-                    onChange={settings.general.setExperimentalBrowser}
-                    hideLabel
-                  >
-                    {language.t("settings.general.row.browserPane.title")}
-                  </Switch>
-                </div>
-              </SettingsRow>
-            </Show>
             <SettingsRow
               title={language.t("settings.appearance.row.tabs.title")}
               description={language.t("settings.appearance.row.tabs.description")}
@@ -65,6 +49,22 @@ export const SettingsExperimental: Component = () => {
                 onSelect={(option) => option && settings.appearance.setTabLayout(option)}
               />
             </SettingsRow>
+            <Show when={platform.browserPane}>
+              <SettingsRow
+                title={language.t("settings.general.row.browserPane.title")}
+                description={language.t("settings.general.row.browserPane.description")}
+              >
+                <div data-action="settings-experimental-browser">
+                  <Switch
+                    checked={settings.general.experimentalBrowser()}
+                    onChange={settings.general.setExperimentalBrowser}
+                    hideLabel
+                  >
+                    {language.t("settings.general.row.browserPane.title")}
+                  </Switch>
+                </div>
+              </SettingsRow>
+            </Show>
             <SettingsRow
               title={language.t("settings.appearance.row.projectName.title")}
               description={language.t("settings.appearance.row.projectName.description")}


### PR DESCRIPTION
- Move the browser toggle to the second option in desktop Settings → Experiments, after Tabs.
- Rename “Browser pane” to “Browser”.