### PR TITLE
docs(ecosystem): add opencode-prune-images to plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-| [opencode-prune-images](https://github.com/Sugamsss/opencode-prune-images)                          | Auto-prune older images in context to prevent 413 and too-many-images errors with natural recall   |
+| [opencode-prune-images](https://github.com/Sugamsss/opencode-prune-images)                          | Manage active image context within count and payload budgets with natural recall                  |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-prune-images](https://github.com/Sugamsss/opencode-prune-images)                          | Auto-prune older images in context to prevent 413 and too-many-images errors with natural recall   |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #48095

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-prune-images` to the community plugins table in
`packages/web/src/content/docs/ecosystem.mdx`.

During long agent runs, especially visual QA loops with Playwright or Chrome
DevTools, chats can collect many screenshots. The plugin changes only the
outgoing context before provider dispatch. It keeps the newest images within a
count budget (7 by default) and a cumulative estimated wire Base64 budget (16
MiB by default). Older images become compact text cards with the path, nearby
context, and best-effort recall guidance. During compaction, recognized images
are converted to cards so raw image data is not passed to the compaction
context. Persisted SQLite history is not rewritten.

Repository:
https://github.com/Sugamsss/opencode-prune-images

The plugin reduces payload pressure but cannot guarantee that every provider or
gateway will accept every request. Provider limits and the rest of the request
still apply. The repository is source-only and is not currently published to
npm.

### How did you verify your code works?

Verified that the markdown table format matches the existing entries in
`ecosystem.mdx`. The plugin repository has 17 passing tests and a passing strict
TypeScript check. The tests cover image count and payload budgets, nested tool
results, V1 tool attachment pruning, rolling cache behavior, compaction,
malformed input, duplicate cards, and plugin hook registration.

### Screenshots / recordings

_N/A (documentation addition)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes

