### PR TITLE
fix(codemode): support object helpers on arrays

### DIFF
--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -1,4 +1,4 @@
-import { type AstNode, InterpreterRuntimeError } from "../interpreter/model.js"
+import { type AstNode, InterpreterRuntimeError, isRecord } from "../interpreter/model.js"
 import { isBlockedMember } from "../tool-runtime.js"
 import { isSandboxValue, SandboxMap, SandboxURLSearchParams } from "../values.js"
 import { boundedData, coerceToString } from "./value.js"
@@ -7,13 +7,13 @@ export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "as
 
 export const invokeObjectMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   if (!objectStatics.has(name)) throw new InterpreterRuntimeError(`Object.${name} is not available in CodeMode.`, node)
-  const requireObject = (): Record<string, unknown> => {
+  const requireObject = (): Record<string, unknown> | Array<unknown> => {
     const value = boundedData(args[0], `Object.${name} input`)
     if (isSandboxValue(value)) return {}
-    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    if (!isRecord(value)) {
       throw new InterpreterRuntimeError(`Object.${name} expects a data object.`, node)
     }
-    return value as Record<string, unknown>
+    return value
   }
   const guardedSet = (out: Record<string, unknown>, key: string, item: unknown): void => {
     if (isBlockedMember(key)) throw new InterpreterRuntimeError(`Property '${key}' is not available in CodeMode.`, node)

--- a/packages/codemode/test/enumeration.test.ts
+++ b/packages/codemode/test/enumeration.test.ts
@@ -86,6 +86,14 @@ describe("Object.keys over arrays", () => {
     expect(await value(`return Object.keys({ a: 1, b: 2 })`)).toEqual(["a", "b"])
   })
 
+  test("Object.values and Object.entries enumerate arrays", async () => {
+    expect(await value(`return Object.values(["a", "b"])`)).toEqual(["a", "b"])
+    expect(await value(`return Object.entries(["a", "b"])`)).toEqual([
+      ["0", "a"],
+      ["1", "b"],
+    ])
+  })
+
   test("non-object inputs still fail clearly", async () => {
     const failure = await error(`return Object.keys("nope")`)
     expect(failure.message).toContain("Object.keys expects a data object or array")


### PR DESCRIPTION
### Issue for this PR

Closes #48097

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

CodeMode rejected arrays passed to `Object.values` and `Object.entries`, although `Object.keys` already supported them.

This allows arrays through the shared object-helper receiver check and adds regression coverage for both methods.

### How did you verify your code works?

- `bun test` — 264 tests passed
- `bun typecheck`
- Prettier check
- Oxlint — 0 warnings and 0 errors
- `git diff --check`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
