### PR TITLE
fix(opencode): merge session permissions in task descriptions

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -262,11 +262,9 @@ const layer = Layer.effect(
       return (yield* all()).map((tool) => tool.id)
     })
 
-    const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (agent: Agent.Info) {
+    const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (ruleset: PermissionV1.Ruleset) {
       const items = (yield* agents.list()).filter((item) => item.mode !== "primary")
-      const filtered = items.filter(
-        (item) => Permission.evaluate("task", item.name, agent.permission).action !== "deny",
-      )
+      const filtered = items.filter((item) => Permission.evaluate("task", item.name, ruleset).action !== "deny")
       const list = filtered.toSorted((a, b) => a.name.localeCompare(b.name))
       const description = list
         .map(
@@ -324,7 +322,9 @@ const layer = Layer.effect(
             id: tool.id,
             description: [
               output.description,
-              tool.id === TaskTool.id ? yield* describeTask(input.agent) : undefined,
+              tool.id === TaskTool.id
+                ? yield* describeTask(Permission.merge(input.agent.permission, input.permission ?? []))
+                : undefined,
               tool.id === "execute" ? codeModeDescription : undefined,
             ]
               .filter(Boolean)

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -21,6 +21,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { MCP } from "@/mcp"
 import type { Tool as MCPToolDef } from "@modelcontextprotocol/sdk/types.js"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 
 const configLayer = TestConfig.layer({
   directories: () => InstanceState.directory.pipe(Effect.map((dir) => [path.join(dir, ".opencode")])),
@@ -100,6 +101,74 @@ afterEach(async () => {
 })
 
 describe("tool.registry", () => {
+  const cases: {
+    name: string
+    permission?: PermissionV1.Ruleset
+    explore: boolean
+    general: boolean
+  }[] = [
+    { name: "omitted session permissions", explore: true, general: false },
+    { name: "empty session permissions", permission: [], explore: true, general: false },
+    {
+      name: "session deny overriding agent allow",
+      permission: [{ permission: "task", pattern: "explore", action: "deny" }],
+      explore: false,
+      general: false,
+    },
+    {
+      name: "session allow overriding agent deny",
+      permission: [{ permission: "task", pattern: "general", action: "allow" }],
+      explore: true,
+      general: true,
+    },
+    {
+      name: "session ask overriding agent deny",
+      permission: [{ permission: "task", pattern: "general", action: "ask" }],
+      explore: true,
+      general: true,
+    },
+    {
+      name: "ordered session wildcard and target rules",
+      permission: [
+        { permission: "task", pattern: "*", action: "deny" },
+        { permission: "task", pattern: "general", action: "allow" },
+      ],
+      explore: false,
+      general: true,
+    },
+  ]
+
+  for (const item of cases) {
+    it.instance(`task description respects ${item.name}`, () =>
+      Effect.gen(function* () {
+        const registry = yield* ToolRegistry.Service
+        const agents = yield* Agent.Service
+        const agent = {
+          ...(yield* agents.defaultInfo()),
+          permission: [
+            { permission: "task", pattern: "*", action: "deny" },
+            { permission: "task", pattern: "explore", action: "allow" },
+          ] satisfies PermissionV1.Ruleset,
+        }
+        const tools = yield* registry.tools({
+          providerID: ProviderV2.ID.opencode,
+          modelID: ModelV2.ID.make("test"),
+          agent,
+          permission: item.permission,
+        })
+        const task = tools.find((tool) => tool.id === "task")
+
+        expect(task).toBeDefined()
+        expect(task!.description.includes("\n- explore:")).toBe(item.explore)
+        expect(task!.description.includes("\n- general:")).toBe(item.general)
+        expect(agent.permission).toEqual([
+          { permission: "task", pattern: "*", action: "deny" },
+          { permission: "task", pattern: "explore", action: "allow" },
+        ])
+      }),
+    )
+  }
+
   it.instance("does not expose task_status", () =>
     Effect.gen(function* () {
       const registry = yield* ToolRegistry.Service


### PR DESCRIPTION
### Issue for this PR

Closes #48106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pass merged agent and session permissions to `describeTask`, so its available-agent list reflects session deny, allow, and ask overrides, matching execution-time evaluation.

This resubmits only the description permission merge from #41100, which was closed by automated cleanup. No changes to target visibility policy or execution checks.

### How did you verify your code works?

Using Bun 1.3.14 in `packages/opencode`:

- `bun test test/tool/registry.test.ts test/session/tools.test.ts test/permission-task.test.ts --timeout 30000` — 43 pass.
- `bun typecheck` — pass; the pre-push full-workspace typecheck also passed (30/30 tasks).
- Six regression cases cover omitted/empty session permissions, deny/allow/ask overrides, and wildcard rule ordering. The four override cases fail against the unmodified base and pass with the fix.
- Prettier and `git diff --check` pass.

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
