### PR TITLE
fix(core): report malformed glob patterns

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -87,7 +87,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/v2
 const failure = (message: string, cause?: unknown) => new Error({ message, cause })
 
 const isInvalidPattern = (stderr: string) =>
-  stderr.includes("regex parse error") || stderr.includes("error parsing regex")
+  stderr.includes("regex parse error") || stderr.includes("error parsing regex") || stderr.includes("error parsing glob")
 
 const layer = Layer.effect(
   Service,
@@ -156,6 +156,7 @@ const layer = Layer.effect(
         run<string>({
           cwd: input.cwd,
           limit: input.limit,
+          pattern: input.pattern,
           signal: input.signal,
           args: [
             "--no-config",

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { RelativePath } from "@opencode-ai/core/schema"
@@ -78,6 +78,26 @@ describe("Ripgrep", () => {
           })
 
           expect(matches[0]?.text).toBe(`needle${"x".repeat(1_993)}...`)
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("rejects malformed glob patterns", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const ripgrep = yield* Ripgrep.Service
+          const globExit = yield* ripgrep.glob({ cwd: tmp.path, pattern: "[", limit: 10 }).pipe(Effect.exit)
+          expect(Exit.isFailure(globExit)).toBe(true)
+          if (Exit.isFailure(globExit)) expect(String(Cause.squash(globExit.cause))).toContain("error parsing glob")
+
+          const grepExit = yield* ripgrep
+            .grep({ cwd: tmp.path, pattern: "needle", include: "[", limit: 10 })
+            .pipe(Effect.exit)
+          expect(Exit.isFailure(grepExit)).toBe(true)
+          if (Exit.isFailure(grepExit)) expect(String(Cause.squash(grepExit.cause))).toContain("error parsing glob")
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),


### PR DESCRIPTION
### Issue for this PR

Fixes #47474

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The ripgrep adapter already turns invalid regex patterns into an error, but it does not classify ripgrep's `error parsing glob` stderr. As a result, malformed glob patterns can be reported as successful empty results.

This passes the glob pattern through the shared classifier, recognizes the glob parse error, and adds regression coverage for the built-in glob tool and grep include patterns. Valid empty searches and existing regex error handling are unchanged.

### How did you verify your code works?

- `git diff --check`
- `cd packages/core && bun test test/ripgrep.test.ts`
- `cd packages/core && bun typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR