### PR TITLE
docs(ecosystem): add opencode-fold-tools

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-fold-tools](https://github.com/ningzimu/opencode-fold-tools)                        | Expand tool outputs on click, with one row per call and native file diffs                       |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #48135

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-fold-tools](https://github.com/ningzimu/opencode-fold-tools) to the ecosystem plugins table. It keeps each TUI tool call on its own line and expands output on click while preserving native file diffs.

### How did you verify your code works?

Checked the one-row documentation diff and public repository/npm links. The plugin's install/update commands were tested; its 14 tests pass on Linux, macOS, and Windows. Interactive behavior was tested with OpenCode 1.18.27 in Otty; compatibility limits are documented in its README.

### Screenshots / recordings

No OpenCode UI changes. A [plugin demo GIF](https://raw.githubusercontent.com/ningzimu/opencode-fold-tools/main/assets/demo.gif) is available in the linked README.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
