### PR TITLE
docs(ecosystem): add AllaiGate model router

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-| [cortiq-opencode-router](https://github.com/infosave2007/cortiq-opencode-router) | Select configured models for user messages using Cortiq task and complexity classification |
+| [cortiq-opencode-router](https://github.com/infosave2007/cortiq-opencode-router) | Automatically select inexpensive models for simple tasks and stronger models for complex work, with your own rules and AllaiGate |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [cortiq-opencode-router](https://github.com/infosave2007/cortiq-opencode-router) | Select configured models for user messages using Cortiq task and complexity classification |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #48164

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `cortiq-opencode-router` to the ecosystem Plugins table. The plugin uses [AllaiGate](https://api.allaigate.com/) to assess task type and complexity, then applies the user's rules to select an already configured model.

### How did you verify your code works?

Reviewed the one-row Markdown diff and checked the public repository and npm links. The plugin's own [live validation](https://github.com/infosave2007/cortiq-opencode-router/blob/main/docs/live-verification.md) covers model selection and a completed tool cycle with OpenCode 1.18.30.

### Screenshots / recordings

Not applicable; this adds a documentation table entry.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
