### PR TITLE
fix(core): drop gpt-5.4 models from the Codex allowlist

### DIFF
--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -20,7 +20,8 @@ const pollingSafetyMargin = 3000
 const codexBaseURL = "https://chatgpt.com/backend-api/codex"
 const browserMethodID = Integration.MethodID.make("chatgpt-browser")
 const headlessMethodID = Integration.MethodID.make("chatgpt-headless")
-const codexAllowed = new Set(["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"])
+// Codex rejects gpt-5.4 and gpt-5.4-mini for ChatGPT accounts since September 2026.
+const codexAllowed = new Set(["gpt-5.5", "gpt-5.3-codex-spark"])
 const codexDisallowed = new Set(["gpt-5.5-pro", "gpt-5.6"])
 
 type Pkce = {

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -20,7 +20,7 @@ const pollingSafetyMargin = 3000
 const codexBaseURL = "https://chatgpt.com/backend-api/codex"
 const browserMethodID = Integration.MethodID.make("chatgpt-browser")
 const headlessMethodID = Integration.MethodID.make("chatgpt-headless")
-// Codex rejects gpt-5.4 and gpt-5.4-mini for ChatGPT accounts since September 2026.
+// ChatGPT accounts lost gpt-5.4 and gpt-5.4-mini in Codex on 2026-08-31 (replacements: gpt-5.6-terra, gpt-5.6-luna).
 const codexAllowed = new Set(["gpt-5.5", "gpt-5.3-codex-spark"])
 const codexDisallowed = new Set(["gpt-5.5-pro", "gpt-5.6"])
 

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -164,11 +164,7 @@ describe("OpenAIPlugin", () => {
       expect(eligible.enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5-pro"))).enabled).toBe(false)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.4-pro"))).enabled).toBe(false)
-      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.4"))).limit).toEqual({
-        context: 400_000,
-        input: 272_000,
-        output: 64_000,
-      })
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.4"))).enabled).toBe(false)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.6"))).enabled).toBe(false)
       const gpt56 = required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.6-sol")))
       expect(gpt56.enabled).toBe(true)


### PR DESCRIPTION
## Summary
OpenAI retired GPT-5.4 and GPT-5.4 mini for ChatGPT accounts in Codex on August 31, 2026 ([Using Codex with your ChatGPT plan](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan), "What happens to GPT-5.4 and GPT-5.4 mini in Codex?"). The recommended replacements are GPT-5.6 Terra and GPT-5.6 Luna; the OpenAI API and Codex with an API key are unaffected.

The backend now enforces it: both the streaming endpoint and the WebSocket answer `invalid_request_error` "The 'gpt-5.4-mini' model is not supported when using Codex with a ChatGPT account." (`gpt-5.4` observed rejected on 2026-09-08, `gpt-5.4-mini` on 2026-09-09; `gpt-5.5` and `gpt-5.3-codex-spark` still work). `codexAllowed` still listed both, so ChatGPT users saw models that fail on first use.

Remove them from the allowlist. The replacements already pass the existing `5.5+` version rule.

## Validation
- `provider-openai.test.ts` now expects `gpt-5.4` disabled under a ChatGPT credential.
- Verified live against the Codex endpoint with a ChatGPT credential (HTTP and WebSocket).
