### PR TITLE
fix(cli): support auto permissions when attaching

### DIFF
--- a/packages/opencode/src/cli/cmd/attach.ts
+++ b/packages/opencode/src/cli/cmd/attach.ts
@@ -32,6 +32,21 @@ export const AttachCommand = cmd({
         type: "boolean",
         describe: "fork the session when continuing (use with --continue or --session)",
       })
+      .option("auto", {
+        type: "boolean",
+        describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
+        default: false,
+      })
+      .option("yolo", {
+        type: "boolean",
+        hidden: true,
+        default: false,
+      })
+      .option("dangerously-skip-permissions", {
+        type: "boolean",
+        hidden: true,
+        default: false,
+      })
       .option("password", {
         alias: ["p"],
         type: "string",
@@ -88,6 +103,7 @@ export const AttachCommand = cmd({
         continue: args.continue,
         session: args.session,
         fork: args.fork,
+        auto: args.auto || args.yolo || args["dangerously-skip-permissions"],
         replay: noReplay ? false : undefined,
         replayLimit: args.replayLimit,
       })
@@ -139,6 +155,7 @@ export const AttachCommand = cmd({
           continue: args.continue,
           sessionID: args.session,
           fork: args.fork,
+          auto: args.auto || args.yolo || args["dangerously-skip-permissions"],
         },
         directory,
         headers,

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -974,6 +974,7 @@ type MiniCommandInput = {
   model?: string
   agent?: string
   prompt?: string
+  auto?: boolean
   replay?: boolean
   replayLimit?: number
   demo?: boolean
@@ -1007,7 +1008,7 @@ export async function runMini(input: MiniCommandInput) {
     replay: input.replay ?? true,
     "replay-limit": input.replayLimit,
     replayLimit: input.replayLimit,
-    auto: false,
+    auto: input.auto ?? false,
     yolo: false,
     "dangerously-skip-permissions": false,
     dangerouslySkipPermissions: false,

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -168,6 +168,7 @@ export const TuiThreadCommand = cmd({
         model: args.model,
         agent: args.agent,
         prompt: args.prompt,
+        auto: args.auto || args.yolo || args["dangerously-skip-permissions"],
         replay: noReplay ? false : undefined,
         replayLimit: args.replayLimit,
         demo: args.demo,

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -59,6 +59,8 @@ Options:
   -c, --continue      continue the last session                                            [boolean]
   -s, --session       session id to continue                                                [string]
       --fork          fork the session when continuing (use with --continue or --session)  [boolean]
+      --auto          auto-approve permissions that are not explicitly denied (dangerous!)
+                                                                          [boolean] [default: false]
   -p, --password      basic auth password (defaults to OPENCODE_SERVER_PASSWORD)            [string]
   -u, --username      basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')
                                                                                             [string]

--- a/packages/opencode/test/cli/tui/attach.test.ts
+++ b/packages/opencode/test/cli/tui/attach.test.ts
@@ -8,4 +8,17 @@ describe("tui attach", () => {
     expect(source).toMatch(/await import\(["']@\/plugin\/tui\/runtime["']\)/)
     expect(source).not.toContain('import("./app")')
   })
+
+  test("forwards automatic permission flags", async () => {
+    const source = await Bun.file(new URL("../../../src/cli/cmd/attach.ts", import.meta.url)).text()
+    const mini = await Bun.file(new URL("../../../src/cli/cmd/run.ts", import.meta.url)).text()
+
+    expect(source).toContain('.option("auto"')
+    expect(source).toContain('.option("yolo"')
+    expect(source).toContain('.option("dangerously-skip-permissions"')
+    expect(source.match(/auto: args\.auto \|\| args\.yolo \|\| args\["dangerously-skip-permissions"\]/g)).toHaveLength(
+      2,
+    )
+    expect(mini).toContain("auto: input.auto ?? false")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48142

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode attach` rejected the permission auto-approval flags supported by the regular TUI. This registers the same visible `--auto` flag and hidden compatibility aliases for attach, then forwards the selected mode through both the full and mini TUI paths.

### How did you verify your code works?

- `bun test test/cli/tui/attach.test.ts test/cli/tui/thread.test.ts`
- `bun test test/cli/help/help-snapshots.test.ts`
- `bun typecheck` in `packages/opencode`
- Pre-push `bun turbo typecheck` (30 packages)
- `bunx prettier --check` on changed TypeScript files

### Screenshots / recordings

Not applicable; this changes CLI startup behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR