### PR TITLE
feat(app): add manual refresh for the session file tree

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -275,6 +275,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       tree: {
         list: tree.listDir,
         refresh: (input: string) => tree.listDir(input, { force: true }),
+        refreshAll: () => tree.refreshAll(),
         state: tree.dirState,
         children: tree.children,
         expand: tree.expandDir,

--- a/packages/app/src/context/file/tree-store.test.ts
+++ b/packages/app/src/context/file/tree-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { createFileTreeStore } from "./tree-store"
+import type { FileNode } from "@opencode-ai/sdk/v2"
+
+function node(path: string, type: FileNode["type"] = "file"): FileNode {
+  return { path, type, name: path.split("/").pop() ?? path, absolute: `/repo/${path}`, ignored: false }
+}
+
+function makeStore(listing: Record<string, FileNode[]>) {
+  const calls: string[] = []
+  const store = createFileTreeStore({
+    scope: () => "",
+    normalizeDir: (input) => input,
+    list: (dir) => {
+      calls.push(dir)
+      return Promise.resolve(listing[dir] ?? [])
+    },
+    onError: () => {},
+  })
+  return { store, calls }
+}
+
+describe("file tree store", () => {
+  test("lists a directory once and caches it", async () => {
+    const listing: Record<string, FileNode[]> = { "": [node("src", "directory")] }
+    const { store, calls } = makeStore(listing)
+
+    await store.listDir("")
+    await store.listDir("")
+
+    expect(calls).toEqual([""])
+    expect(store.children("")).toHaveLength(1)
+    expect(store.loadedDirs()).toEqual([""])
+  })
+
+  test("refreshAll force-reloads loaded directories and picks up new entries", async () => {
+    const listing: Record<string, FileNode[]> = {
+      "": [node("src", "directory")],
+      src: [node("src/a.ts")],
+    }
+    const { store, calls } = makeStore(listing)
+
+    await store.listDir("")
+    await store.listDir("src")
+    expect(store.children("src")).toHaveLength(1)
+
+    listing.src = [node("src/a.ts"), node("src/b.ts")]
+    await store.refreshAll()
+
+    expect(store.children("src")).toHaveLength(2)
+    expect(calls).toEqual(["", "src", "", "src"])
+  })
+
+  test("refreshAll skips directories that were never loaded", async () => {
+    const listing: Record<string, FileNode[]> = {
+      "": [node("src", "directory")],
+      src: [node("src/a.ts")],
+    }
+    const { store, calls } = makeStore(listing)
+
+    await store.listDir("")
+    await store.refreshAll()
+
+    expect(calls).toEqual(["", ""])
+    expect(store.children("src")).toEqual([])
+  })
+
+  test("refreshAll resolves when nothing is loaded", async () => {
+    const { store, calls } = makeStore({})
+    await store.refreshAll()
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -144,6 +144,15 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     setTree("dir", dir, "expanded", false)
   }
 
+  const loadedDirs = () => Object.keys(tree.dir).filter((key) => tree.dir[key]?.loaded)
+
+  // Force-reload every directory that has been listed at least once. Used by the
+  // manual tree refresh: the watcher only invalidates directories it knows about,
+  // so an external change can otherwise go unseen until a full page reload.
+  const refreshAll = async () => {
+    await Promise.all(loadedDirs().map((dir) => listDir(dir, { force: true })))
+  }
+
   const dirState = (input: string) => {
     const dir = options.normalizeDir(input)
     return tree.dir[dir]
@@ -165,6 +174,8 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     listDir,
     expandDir,
     collapseDir,
+    loadedDirs,
+    refreshAll,
     dirState,
     children,
     node: (path: string) => tree.node[path],

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -711,6 +711,7 @@ export const dict = {
   "session.review.noChanges": "ምንም ለውጦች የሉም",
   "session.review.noUncommittedChanges": "ገና ምንም ያልተደረጉ ለውጦች የሉም",
   "session.review.noBranchChanges": "ገና ምንም ቅርንጫፍ ምንም ለውጥ የለም",
+  "session.files.refresh": "አድስ",
   "session.files.selectToOpen": "ለመክፈት ፋይል ምረጥ",
   "session.files.all": "ሁሉም ፋይሎች",
   "session.files.empty": "ምንም ፋይሎች",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -706,6 +706,7 @@ export const dict = {
   "session.review.noBranchChanges": "لا توجد تغييرات في الفرع بعد",
   "session.review.noVcs": "لم يُكتشف نظام Git للتحكم في الإصدارات، لذا لن تُعرض التغييرات",
   "session.review.noSnapshot": "تم تعطيل تتبع اللقطات في التكوين، لذا فإن تغييرات الجلسة غير متوفرة",
+  "session.files.refresh": "تحديث",
   "session.files.selectToOpen": "اختر ملفًا لفتحه",
   "session.files.all": "كل الملفات",
   "session.files.empty": "لا توجد ملفات",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -734,6 +734,7 @@ export const dict = {
   "session.review.noChanges": "Dəyişiklik yoxdur",
   "session.review.noUncommittedChanges": "Hələ commit edilməmiş dəyişiklik yoxdur",
   "session.review.noBranchChanges": "Hələ branch dəyişikliyi yoxdur",
+  "session.files.refresh": "Yeniləyin",
   "session.files.selectToOpen": "Açmaq üçün fayl seçin",
   "session.files.all": "Bütün fayllar",
   "session.files.empty": "Fayl yoxdur",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -730,6 +730,7 @@ export const dict = {
   "session.review.noChanges": "Без промени",
   "session.review.noUncommittedChanges": "Все още няма незавършени промени",
   "session.review.noBranchChanges": "Все още няма промени в клона",
+  "session.files.refresh": "Опресняване",
   "session.files.selectToOpen": "Изберете файл за отваряне",
   "session.files.all": "Всички файлове",
   "session.files.empty": "Няма файлове",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -724,6 +724,7 @@ export const dict: Record<string, string> = {
   "session.review.noChanges": "কোনো পরিবর্তন নেই",
   "session.review.noUncommittedChanges": "এখনও কোন অপ্রতিরোধ্য পরিবর্তন",
   "session.review.noBranchChanges": "এখনো কোনো শাখা পরিবর্তন হয়নি",
+  "session.files.refresh": "রিফ্রেশ",
   "session.files.selectToOpen": "খুলতে একটি ফাইল নির্বাচন করুন",
   "session.files.all": "সমস্ত ফাইল",
   "session.files.empty": "কোনো ফাইল নেই",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -714,6 +714,7 @@ export const dict = {
   "session.review.noChanges": "Sem alterações",
   "session.review.noUncommittedChanges": "Ainda não há alterações sem commit",
   "session.review.noBranchChanges": "Ainda não há alterações na branch",
+  "session.files.refresh": "Atualizar",
   "session.files.selectToOpen": "Selecione um arquivo para abrir",
   "session.files.all": "Todos os arquivos",
   "session.files.empty": "Nenhum arquivo",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -768,6 +768,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "Još nema promjena koje nisu commitovane",
   "session.review.noBranchChanges": "Još nema promjena na grani",
 
+  "session.files.refresh": "Osvježi",
   "session.files.selectToOpen": "Odaberi datoteku za otvaranje",
   "session.files.all": "Sve datoteke",
   "session.files.empty": "Nema datoteka",

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -730,6 +730,7 @@ export const dict = {
   "session.review.noChanges": "Sense canvis",
   "session.review.noUncommittedChanges": "Encara no hi ha canvis no compromesos",
   "session.review.noBranchChanges": "Encara no hi ha canvis de branca",
+  "session.files.refresh": "Actualitza",
   "session.files.selectToOpen": "Seleccioneu un fitxer per obrir",
   "session.files.all": "Tots els fitxers",
   "session.files.empty": "No hi ha fitxers",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -724,6 +724,7 @@ export const dict = {
   "session.review.noChanges": "Žádné změny",
   "session.review.noUncommittedChanges": "Zatím žádné neprovedené změny",
   "session.review.noBranchChanges": "Zatím žádné změny ve větvi",
+  "session.files.refresh": "Obnovit",
   "session.files.selectToOpen": "Vyberte soubor, který chcete otevřít",
   "session.files.all": "Všechny soubory",
   "session.files.empty": "Žádné soubory",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -647,6 +647,7 @@ export const dict = {
   "session.review.noChanges": "Ingen ændringer",
   "session.review.noUncommittedChanges": "Ingen ændringer uden commit endnu",
   "session.review.noBranchChanges": "Ingen grenændringer endnu",
+  "session.files.refresh": "Opdater",
   "session.files.selectToOpen": "Vælg en fil at åbne",
   "session.files.all": "Alle filer",
   "session.files.empty": "Ingen filer",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -607,6 +607,7 @@ export const dict = {
   "session.review.noChanges": "Keine Änderungen",
   "session.review.noUncommittedChanges": "Noch keine nicht committeten Änderungen",
   "session.review.noBranchChanges": "Noch keine Branch-Änderungen",
+  "session.files.refresh": "Aktualisieren",
   "session.files.selectToOpen": "Datei zum Öffnen auswählen",
   "session.files.all": "Alle Dateien",
   "session.files.empty": "Keine Dateien",

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -736,6 +736,7 @@ export const dict = {
   "session.review.noChanges": "އެއްވެސް ބަދަލެއް ނާދެއެވެ",
   "session.review.noUncommittedChanges": "އަދި ކޮމިޓް ނުކުރާ ބަދަލެއް ނާދެއެވެ",
   "session.review.noBranchChanges": "އަދި އެއްވެސް ބްރާންޗަކަށް ބަދަލެއް ނާދެއެވެ",
+  "session.files.refresh": "ރިފްރެޝް ކޮށްލާށެވެ",
   "session.files.selectToOpen": "ހުޅުވަން ބޭނުންވާ ފައިލެއް ހޮވާށެވެ",
   "session.files.all": "ހުރިހާ ފައިލްއެކެވެ",
   "session.files.empty": "ފައިލްތަކެއް ނެތެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -737,6 +737,7 @@ export const dict: Record<string, string> = {
   "session.review.noChanges": "བསྒྱུར་བཅོས་མེད།",
   "session.review.noUncommittedChanges": "ཁས་ལེན་མ་འབད་བའི་བསྒྱུར་བཅོས་ཚུ་ད་ལྟོ་མེད།",
   "session.review.noBranchChanges": "ཡན་ལག་བསྒྱུར་བཅོས་ད་ལྟོ་མེད།",
+  "session.files.refresh": "གསརཔ་བཟོ།",
   "session.files.selectToOpen": "ཁ་ཕྱེ་ནི་ལུ་ཡིག་སྣོད་ཅིག་སེལ་འཐུ་འབད།",
   "session.files.all": "ཡིག་སྣོད་ཆ་མཉམ།",
   "session.files.empty": "ཡིག་སྣོད་ཚུ་མེད།",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -732,6 +732,7 @@ export const dict = {
   "session.review.noChanges": "Χωρίς αλλαγές",
   "session.review.noUncommittedChanges": "Δεν υπάρχουν ακόμη μη δεσμευμένες αλλαγές",
   "session.review.noBranchChanges": "Δεν υπάρχουν ακόμη αλλαγές κλάδου",
+  "session.files.refresh": "Ανανέωση",
   "session.files.selectToOpen": "Επιλέξτε ένα αρχείο για άνοιγμα",
   "session.files.all": "Όλα τα αρχεία",
   "session.files.empty": "Δεν υπάρχουν αρχεία",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -689,6 +689,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "No uncommitted changes yet",
   "session.review.noBranchChanges": "No branch changes yet",
 
+  "session.files.refresh": "Refresh",
   "session.files.selectToOpen": "Select a file to open",
   "session.files.all": "All files",
   "session.files.empty": "No files",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -771,6 +771,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "Aún no hay cambios sin confirmar",
   "session.review.noBranchChanges": "Aún no hay cambios en la rama",
 
+  "session.files.refresh": "Actualizar",
   "session.files.selectToOpen": "Selecciona un archivo para abrir",
   "session.files.all": "Todos los archivos",
   "session.files.empty": "Sin archivos",

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -720,6 +720,7 @@ export const dict = {
   "session.review.noChanges": "Muudatusi pole",
   "session.review.noUncommittedChanges": "Tehmata muudatusi pole veel tehtud",
   "session.review.noBranchChanges": "Filiaali muudatusi veel pole",
+  "session.files.refresh": "Värskenda",
   "session.files.selectToOpen": "Valige avamiseks fail",
   "session.files.all": "Kõik failid",
   "session.files.empty": "Faile pole",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -723,6 +723,7 @@ export const dict = {
   "session.review.noChanges": "بدون تغییر",
   "session.review.noUncommittedChanges": "هنوز هیچ تغییری انجام نشده است",
   "session.review.noBranchChanges": "هنوز شعبه ای تغییر نکرده است",
+  "session.files.refresh": "تازه کردن",
   "session.files.selectToOpen": "فایلی را برای باز کردن انتخاب کنید",
   "session.files.all": "همه فایل ها",
   "session.files.empty": "بدون فایل",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -622,6 +622,7 @@ export const dict = {
   "session.review.noChanges": "Ei muutoksia",
   "session.review.noUncommittedChanges": "Ei vielä sitomattomia muutoksia",
   "session.review.noBranchChanges": "Ei vielä haaran muutoksia",
+  "session.files.refresh": "Päivitä",
   "session.files.selectToOpen": "Valitse avattava tiedosto",
   "session.files.all": "Kaikki tiedostot",
   "session.files.empty": "Ei tiedostoja",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -724,6 +724,7 @@ export const dict = {
   "session.review.noChanges": "Ongar broytingar",
   "session.review.noUncommittedChanges": "Ongar óbundnar broytingar enn",
   "session.review.noBranchChanges": "Ongar greinarbroytingar enn",
+  "session.files.refresh": "Fríska upp",
   "session.files.selectToOpen": "Vel eina fílu at lata upp",
   "session.files.all": "Allar fílur",
   "session.files.empty": "Ongar fílur",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -724,6 +724,7 @@ export const dict = {
   "session.review.noVcs": "Aucun système de gestion de versions Git détecté ; modifications non affichées",
   "session.review.noSnapshot":
     "Le suivi des instantanés est désactivé dans la configuration, les modifications de session sont donc indisponibles",
+  "session.files.refresh": "Actualiser",
   "session.files.selectToOpen": "Sélectionnez un fichier à ouvrir",
   "session.files.all": "Tous les fichiers",
   "session.files.empty": "Aucun fichier",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -734,6 +734,7 @@ export const dict = {
   "session.review.noChanges": "कोई परिवर्तन नहीं",
   "session.review.noUncommittedChanges": "अभी तक कोई अप्रतिबद्ध परिवर्तन नहीं",
   "session.review.noBranchChanges": "अभी तक शाखा में कोई परिवर्तन नहीं",
+  "session.files.refresh": "रीफ़्रेश करें",
   "session.files.selectToOpen": "खोलने के लिए एक फ़ाइल का चयन करें",
   "session.files.all": "सभी फ़ाइलें",
   "session.files.empty": "कोई फ़ाइल नहीं",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -731,6 +731,7 @@ export const dict = {
   "session.review.noChanges": "Nema promjena",
   "session.review.noUncommittedChanges": "Još nema neizvršenih promjena",
   "session.review.noBranchChanges": "Još nema promjena grane",
+  "session.files.refresh": "Osvježiti",
   "session.files.selectToOpen": "Odaberite datoteku za otvaranje",
   "session.files.all": "Sve datoteke",
   "session.files.empty": "Nema datoteka",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -731,6 +731,7 @@ export const dict = {
   "session.review.noChanges": "Nincs változás",
   "session.review.noUncommittedChanges": "Még nincsenek végrehajtatlan változtatások",
   "session.review.noBranchChanges": "A fióktelep még nem változott",
+  "session.files.refresh": "Frissítés",
   "session.files.selectToOpen": "Válassza ki a megnyitandó fájlt",
   "session.files.all": "Minden fájl",
   "session.files.empty": "Nincsenek fájlok",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -729,6 +729,7 @@ export const dict = {
   "session.review.noChanges": "Ոչ փոփոխություններ",
   "session.review.noUncommittedChanges": "Դեռեւս չկատարված փոփոխություններ",
   "session.review.noBranchChanges": "Ճյուղի փոփոխություններ դեռ չկան",
+  "session.files.refresh": "Թարմացնել",
   "session.files.selectToOpen": "Ընտրեք ֆայլ բացելու համար",
   "session.files.all": "Բոլոր ֆայլերը",
   "session.files.empty": "Ֆայլեր չկան",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -790,6 +790,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "Belum ada perubahan yang belum dikomit",
   "session.review.noBranchChanges": "Belum ada perubahan cabang",
 
+  "session.files.refresh": "Muat ulang",
   "session.files.selectToOpen": "Pilih berkas untuk dibuka",
   "session.files.all": "Semua berkas",
   "session.files.empty": "Tidak ada berkas",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -727,6 +727,7 @@ export const dict = {
   "session.review.noChanges": "Engar breytingar",
   "session.review.noUncommittedChanges": "Engar óbundnar breytingar ennþá",
   "session.review.noBranchChanges": "Engar greinarbreytingar ennþá",
+  "session.files.refresh": "Endurnýja",
   "session.files.selectToOpen": "Veldu skrá til að opna",
   "session.files.all": "Allar skrár",
   "session.files.empty": "Engar skrár",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -640,6 +640,7 @@ export const dict = {
   "session.review.noChanges": "Nessuna modifica",
   "session.review.noUncommittedChanges": "Ancora nessuna modifica senza commit",
   "session.review.noBranchChanges": "Ancora nessuna modifica del branch",
+  "session.files.refresh": "Aggiorna",
   "session.files.selectToOpen": "Seleziona un file da aprire",
   "session.files.all": "Tutti i file",
   "session.files.empty": "Nessun file",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -709,6 +709,7 @@ export const dict = {
   "session.review.noChanges": "変更なし",
   "session.review.noUncommittedChanges": "コミットされていない変更はまだありません",
   "session.review.noBranchChanges": "ブランチの変更はまだありません",
+  "session.files.refresh": "更新",
   "session.files.selectToOpen": "開くファイルを選択",
   "session.files.all": "すべてのファイル",
   "session.files.empty": "ファイルなし",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -724,6 +724,7 @@ export const dict = {
   "session.review.noChanges": "ცვლილებები არ არის",
   "session.review.noUncommittedChanges": "შეუსრულებელი ცვლილებები ჯერ არ არის",
   "session.review.noBranchChanges": "ფილიალი ჯერ არ არის ცვლილებები",
+  "session.files.refresh": "განახლება",
   "session.files.selectToOpen": "აირჩიეთ ფაილი გასახსნელად",
   "session.files.all": "ყველა ფაილი",
   "session.files.empty": "ფაილები არ არის",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -721,6 +721,7 @@ export const dict = {
   "session.review.noChanges": "គ្មានការផ្លាស់ប្តូរទេ។",
   "session.review.noUncommittedChanges": "មិនទាន់មានការផ្លាស់ប្តូរដែលមិនទាន់បានកំណត់នៅឡើយ",
   "session.review.noBranchChanges": "មិនទាន់មានការផ្លាស់ប្តូរសាខានៅឡើយទេ",
+  "session.files.refresh": "ធ្វើឱ្យស្រស់",
   "session.files.selectToOpen": "ជ្រើសរើសឯកសារដើម្បីបើក",
   "session.files.all": "ឯកសារទាំងអស់។",
   "session.files.empty": "គ្មានឯកសារទេ។",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -485,6 +485,7 @@ export const dict = {
   "session.review.noVcs": "Git 버전 관리 시스템이 감지되지 않아 변경 사항이 표시되지 않습니다",
   "session.review.noSnapshot": "구성에서 스냅샷 추적이 비활성화되어 있어 세션 변경 사항을 사용할 수 없습니다",
   "session.review.noChanges": "변경 없음",
+  "session.files.refresh": "새로 고침",
   "session.files.selectToOpen": "열 파일을 선택하세요",
   "session.files.all": "모든 파일",
   "session.files.empty": "파일 없음",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -719,6 +719,7 @@ export const dict = {
   "session.review.noChanges": "ບໍ່ມີການປ່ຽນແປງ",
   "session.review.noUncommittedChanges": "ບໍ່ມີການປ່ຽນແປງທີ່ບໍ່ໄດ້ຕົກລົງເທື່ອ",
   "session.review.noBranchChanges": "ບໍ່ມີການປ່ຽນແປງສາຂາເທື່ອ",
+  "session.files.refresh": "ໂຫຼດຂໍ້ມູນຄືນໃໝ່",
   "session.files.selectToOpen": "ເລືອກໄຟລ໌ທີ່ຈະເປີດ",
   "session.files.all": "ໄຟລ໌ທັງໝົດ",
   "session.files.empty": "ບໍ່ມີໄຟລ໌",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -731,6 +731,7 @@ export const dict = {
   "session.review.noChanges": "Jokių pakeitimų",
   "session.review.noUncommittedChanges": "Dar nėra nepadarytų pakeitimų",
   "session.review.noBranchChanges": "Šakoje pakeitimų dar nėra",
+  "session.files.refresh": "Atnaujinti",
   "session.files.selectToOpen": "Pasirinkite failą, kurį norite atidaryti",
   "session.files.all": "Visi failai",
   "session.files.empty": "Failų nėra",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -726,6 +726,7 @@ export const dict = {
   "session.review.noChanges": "Nav izmaiņu",
   "session.review.noUncommittedChanges": "Vēl nav neapstiprinātu izmaiņu",
   "session.review.noBranchChanges": "Vēl nav zara izmaiņu",
+  "session.files.refresh": "Atsvaidzināt",
   "session.files.selectToOpen": "Izvēlies failu atvēršanai",
   "session.files.all": "Visi faili",
   "session.files.empty": "Nav failu",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -728,6 +728,7 @@ export const dict = {
   "session.review.noChanges": "Нема промени",
   "session.review.noUncommittedChanges": "Сè уште нема необврзани промени",
   "session.review.noBranchChanges": "Сè уште нема промени во гранката",
+  "session.files.refresh": "Освежи",
   "session.files.selectToOpen": "Изберете датотека за отворање",
   "session.files.all": "Сите датотеки",
   "session.files.empty": "Нема датотеки",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -730,6 +730,7 @@ export const dict = {
   "session.review.noChanges": "Өөрчлөлт байхгүй",
   "session.review.noUncommittedChanges": "Одоохондоо шийдэгдээгүй өөрчлөлт байхгүй байна",
   "session.review.noBranchChanges": "Одоогоор салбар өөрчлөлт ороогүй байна",
+  "session.files.refresh": "Сэргээх",
   "session.files.selectToOpen": "Нээх файлаа сонгоно уу",
   "session.files.all": "Бүх файлууд",
   "session.files.empty": "Файл байхгүй",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -722,6 +722,7 @@ export const dict = {
   "session.review.noChanges": "Tiada perubahan",
   "session.review.noUncommittedChanges": "Belum ada perubahan belum komited",
   "session.review.noBranchChanges": "Belum ada perubahan cawangan",
+  "session.files.refresh": "Segar semula",
   "session.files.selectToOpen": "Pilih fail untuk dibuka",
   "session.files.all": "Semua fail",
   "session.files.empty": "Tiada fail",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -732,6 +732,7 @@ export const dict = {
   "session.review.noChanges": "အပြောင်းအလဲမရှိပါ။",
   "session.review.noUncommittedChanges": "ကတိကဝတ်မပြုထားသော အပြောင်းအလဲများ မရှိသေးပါ။",
   "session.review.noBranchChanges": "ဌာနခွဲပြောင်းလဲမှုမရှိသေးပါ။",
+  "session.files.refresh": "ပြန်လည်စတင်ပါ။",
   "session.files.selectToOpen": "ဖွင့်ရန် ဖိုင်တစ်ခုကို ရွေးပါ။",
   "session.files.all": "ဖိုင်အားလုံး",
   "session.files.empty": "ဖိုင်မရှိပါ။",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -726,6 +726,7 @@ export const dict: Record<string, string> = {
   "session.review.noChanges": "कुनै परिवर्तन छैन",
   "session.review.noUncommittedChanges": "अहिलेसम्म कुनै पनि असीमित परिवर्तनहरू छैनन्",
   "session.review.noBranchChanges": "अझै शाखा परिवर्तन भएको छैन",
+  "session.files.refresh": "रिफ्रेस गर्नुहोस्",
   "session.files.selectToOpen": "खोल्नको लागि फाइल चयन गर्नुहोस्",
   "session.files.all": "सबै फाइलहरू",
   "session.files.empty": "कुनै फाइलहरू छैनन्",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -732,6 +732,7 @@ export const dict = {
   "session.review.noChanges": "Geen wijzigingen",
   "session.review.noUncommittedChanges": "Er zijn nog geen niet-gecommitteerde wijzigingen",
   "session.review.noBranchChanges": "Er zijn nog geen branchwijzigingen",
+  "session.files.refresh": "Vernieuwen",
   "session.files.selectToOpen": "Selecteer een bestand om te openen",
   "session.files.all": "Alle bestanden",
   "session.files.empty": "Geen bestanden",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -646,6 +646,7 @@ export const dict = {
     "Snapshot-sporing er deaktivert i konfigurasjonen, så sesjonsendringer er ikke tilgjengelige",
   "session.review.noChanges": "Ingen endringer",
 
+  "session.files.refresh": "Oppdater",
   "session.files.selectToOpen": "Velg en fil å åpne",
   "session.files.all": "Alle filer",
   "session.files.empty": "Ingen filer",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -733,6 +733,7 @@ export const dict = {
   "session.review.noChanges": "کوئی تبدیلی نئیں",
   "session.review.noUncommittedChanges": "ہلے کوئی ان کمٹڈ تبدیلی نئیں",
   "session.review.noBranchChanges": "ہلے تیکر کوئی برانچ نئیں بدلی",
+  "session.files.refresh": "تازہ کرو",
   "session.files.selectToOpen": "کھولن لئی کوئی فائل چنو",
   "session.files.all": "ساریاں فائلاں",
   "session.files.empty": "کوئی فائل نئیں",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -713,6 +713,7 @@ export const dict = {
   "session.review.noChanges": "Brak zmian",
   "session.review.noUncommittedChanges": "Brak jeszcze niezatwierdzonych zmian",
   "session.review.noBranchChanges": "Brak jeszcze zmian w gałęzi",
+  "session.files.refresh": "Odśwież",
   "session.files.selectToOpen": "Wybierz plik do otwarcia",
   "session.files.all": "Wszystkie pliki",
   "session.files.empty": "Brak plików",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -726,6 +726,7 @@ export const dict = {
   "session.review.noChanges": "Nicio modificare",
   "session.review.noUncommittedChanges": "Nicio modificare necomisă încă",
   "session.review.noBranchChanges": "Nicio modificare pe ramură încă",
+  "session.files.refresh": "Reîmprospătează",
   "session.files.selectToOpen": "Selectează un fișier pentru deschidere",
   "session.files.all": "Toate fișierele",
   "session.files.empty": "Niciun fișier",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -766,6 +766,7 @@ export const dict = {
   "session.review.noChanges": "Нет изменений",
   "session.review.noUncommittedChanges": "Пока нет незафиксированных изменений",
   "session.review.noBranchChanges": "Пока нет изменений в ветке",
+  "session.files.refresh": "Обновить",
   "session.files.selectToOpen": "Выберите файл, чтобы открыть",
   "session.files.all": "Все файлы",
   "session.files.empty": "Нет файлов",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -721,6 +721,7 @@ export const dict: Record<string, string> = {
   "session.review.noChanges": "වෙනස්කම් නොමැත",
   "session.review.noUncommittedChanges": "තවමත් කැප නොකළ වෙනස්කම් නොමැත",
   "session.review.noBranchChanges": "තවම ශාඛාවේ වෙනසක් නැත",
+  "session.files.refresh": "නැවුම් කරන්න",
   "session.files.selectToOpen": "විවෘත කිරීමට ගොනුවක් තෝරන්න",
   "session.files.all": "සියලුම ගොනු",
   "session.files.empty": "ගොනු නැත",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -722,6 +722,7 @@ export const dict = {
   "session.review.noChanges": "Žiadne zmeny",
   "session.review.noUncommittedChanges": "Zatiaľ žiadne neuložené zmeny",
   "session.review.noBranchChanges": "Zatiaľ žiadne zmeny vetvy",
+  "session.files.refresh": "Obnoviť",
   "session.files.selectToOpen": "Vyberte súbor na otvorenie",
   "session.files.all": "Všetky súbory",
   "session.files.empty": "Žiadne súbory",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -724,6 +724,7 @@ export const dict = {
   "session.review.noChanges": "Brez sprememb",
   "session.review.noUncommittedChanges": "Ni še nepotrjenih sprememb",
   "session.review.noBranchChanges": "Ni še nobenih sprememb veje",
+  "session.files.refresh": "Osveži",
   "session.files.selectToOpen": "Izberite datoteko, ki jo želite odpreti",
   "session.files.all": "Vse datoteke",
   "session.files.empty": "Ni datotek",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -727,6 +727,7 @@ export const dict = {
   "session.review.noChanges": "Nuk ka ndryshime",
   "session.review.noUncommittedChanges": "Ende nuk ka ndryshime të pazgjedhura",
   "session.review.noBranchChanges": "Ende nuk ka ndryshime në degë",
+  "session.files.refresh": "Rifresko",
   "session.files.selectToOpen": "Zgjidhni një skedar për të hapur",
   "session.files.all": "Të gjithë skedarët",
   "session.files.empty": "Nuk ka skedarë",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -725,6 +725,7 @@ export const dict = {
   "session.review.noChanges": "Нема промена",
   "session.review.noUncommittedChanges": "Још увек нема неизвршених промена",
   "session.review.noBranchChanges": "Још нема промена гране",
+  "session.files.refresh": "Освежи",
   "session.files.selectToOpen": "Изаберите датотеку за отварање",
   "session.files.all": "Све датотеке",
   "session.files.empty": "Нема датотека",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -729,6 +729,7 @@ export const dict = {
   "session.review.noChanges": "Inga ändringar",
   "session.review.noUncommittedChanges": "Inga ändringar som inte har checkats in ännu",
   "session.review.noBranchChanges": "Inga grenändringar ännu",
+  "session.files.refresh": "Uppdatera",
   "session.files.selectToOpen": "Välj en fil att öppna",
   "session.files.all": "Alla filer",
   "session.files.empty": "Inga filer",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -727,6 +727,7 @@ export const dict = {
   "session.review.noChanges": "Тағйирот нест",
   "session.review.noUncommittedChanges": "Ҳанӯз ягон тағйироти беэътиборнашуда",
   "session.review.noBranchChanges": "То ҳол ягон филиал тағир наёфтааст",
+  "session.files.refresh": "Навсозӣ",
   "session.files.selectToOpen": "Барои кушодан файлеро интихоб кунед",
   "session.files.all": "Ҳама файлҳо",
   "session.files.empty": "Файл нест",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -759,6 +759,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "ยังไม่มีการเปลี่ยนแปลงที่รอคอมมิต",
   "session.review.noBranchChanges": "ยังไม่มีการเปลี่ยนแปลงในสาขา",
 
+  "session.files.refresh": "รีเฟรช",
   "session.files.selectToOpen": "เลือกไฟล์เพื่อเปิด",
   "session.files.empty": "ไม่มีไฟล์",
   "session.files.all": "ไฟล์ทั้งหมด",

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -724,6 +724,7 @@ export const dict = {
   "session.review.noChanges": "Üýtgeşme ýok",
   "session.review.noUncommittedChanges": "Entek rugsat berilmedik üýtgeşmeler ýok",
   "session.review.noBranchChanges": "Entek hiç hili şahamça üýtgemeýär",
+  "session.files.refresh": "Täzele",
   "session.files.selectToOpen": "Açmak üçin bir faýl saýlaň",
   "session.files.all": "Fileshli faýllar",
   "session.files.empty": "Faýl ýok",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -772,6 +772,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "Henüz işlenmemiş değişiklik yok",
   "session.review.noBranchChanges": "Henüz dal değişikliği yok",
 
+  "session.files.refresh": "Yenile",
   "session.files.selectToOpen": "Açmak için bir dosya seçin",
   "session.files.all": "Tüm dosyalar",
   "session.files.empty": "Dosya yok",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -794,6 +794,7 @@ export const dict = {
   "session.review.noUncommittedChanges": "Ще немає незафіксованих змін",
   "session.review.noBranchChanges": "Ще немає змін у гілці",
 
+  "session.files.refresh": "Оновити",
   "session.files.selectToOpen": "Виберіть файл для відкриття",
   "session.files.all": "Усі файли",
   "session.files.empty": "Немає файлів",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -736,6 +736,7 @@ export const dict = {
   "session.review.noChanges": "کوئی تبدیلی نہیں۔",
   "session.review.noUncommittedChanges": "ابھی تک کوئی غیر ارتکاب تبدیلیاں نہیں ہیں۔",
   "session.review.noBranchChanges": "ابھی تک برانچ میں کوئی تبدیلی نہیں ہے۔",
+  "session.files.refresh": "ریفریش کریں۔",
   "session.files.selectToOpen": "کھولنے کے لیے ایک فائل منتخب کریں۔",
   "session.files.all": "تمام فائلیں۔",
   "session.files.empty": "کوئی فائل نہیں ہے۔",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -729,6 +729,7 @@ export const dict = {
   "session.review.noChanges": "Oʻzgarishlar yoʻq",
   "session.review.noUncommittedChanges": "Hali tasdiqlanmagan o'zgarishlar yo'q",
   "session.review.noBranchChanges": "Hozircha filial o'zgarmadi",
+  "session.files.refresh": "Yangilash",
   "session.files.selectToOpen": "Ochish uchun faylni tanlang",
   "session.files.all": "Barcha fayllar",
   "session.files.empty": "Fayl yo'q",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -734,6 +734,7 @@ export const dict = {
   "session.review.noChanges": "Không có thay đổi",
   "session.review.noUncommittedChanges": "Chưa có thay đổi nào chưa commit",
   "session.review.noBranchChanges": "Chưa có thay đổi nhánh",
+  "session.files.refresh": "Làm mới",
   "session.files.selectToOpen": "Chọn một tệp để mở",
   "session.files.all": "Tất cả tệp",
   "session.files.empty": "Không có tệp",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -759,6 +759,7 @@ export const dict = {
   "session.review.noChanges": "无更改",
   "session.review.noUncommittedChanges": "尚无未提交的更改",
   "session.review.noBranchChanges": "尚无分支更改",
+  "session.files.refresh": "刷新",
   "session.files.selectToOpen": "选择要打开的文件",
   "session.files.all": "所有文件",
   "session.files.empty": "无文件",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -754,6 +754,7 @@ export const dict = {
   "session.review.noBranchChanges": "尚無分支變更",
   "session.review.noVcs": "未偵測到 Git 版本控制系統，無法顯示變更",
   "session.review.noSnapshot": "設定中已停用快照追蹤，因此無法使用工作階段變更",
+  "session.files.refresh": "重新整理",
   "session.files.selectToOpen": "選取要開啟的檔案",
   "session.files.all": "所有檔案",
   "session.files.empty": "沒有檔案",

--- a/packages/app/src/pages/session/v2/session-file-browser-tab.tsx
+++ b/packages/app/src/pages/session/v2/session-file-browser-tab.tsx
@@ -13,6 +13,9 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { SessionFileView } from "@/pages/session/file-tabs"
 import { applyFileListKeyDown, SessionFileListV2 } from "@/pages/session/v2/session-file-list-v2"
 import { pathKey } from "@/utils/path-key"
+import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 
 const emptyFiles: string[] = []
 
@@ -42,6 +45,7 @@ export function SessionFileBrowserTab(props: {
   const resultsID = `session-file-browser-results-${createUniqueId()}`
   const [filter, setFilter] = createSignal("")
   const [explicitHighlight, setExplicitHighlight] = createSignal<string>()
+  const [refreshing, setRefreshing] = createSignal(false)
   const sidebarOpened = () => props.placeholder || props.state.sidebarOpened()
   const query = createMemo(() => filter().trim())
   const search = createQuery(() => {
@@ -90,6 +94,17 @@ export function SessionFileBrowserTab(props: {
     })
   }
 
+  const refreshLabel = () => language.t("session.files.refresh")
+  const onRefresh = async () => {
+    if (refreshing()) return
+    setRefreshing(true)
+    try {
+      await file.tree.refreshAll()
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   // Keep the sidebar outside Kobalte Tabs.Content: a morphing content value
   // unmounts the whole panel on every file-tab switch and resets sidebar scroll.
   return (
@@ -110,6 +125,19 @@ export function SessionFileBrowserTab(props: {
           filterExpanded={query().length > 0 && files().length > 0}
           width={props.state.sidebarWidth()}
           onWidthChange={props.state.resizeSidebar}
+          actions={
+            <TooltipV2 placement="bottom" value={refreshLabel()}>
+              <IconButtonV2
+                type="button"
+                variant="ghost-muted"
+                size="small"
+                aria-label={refreshLabel()}
+                disabled={refreshing()}
+                onClick={() => void onRefresh()}
+                icon={<IconV2 name="outline-reset" class="size-4" />}
+              />
+            </TooltipV2>
+          }
         >
           <Show
             when={query()}

--- a/packages/session-ui/src/v2/components/session-review-v2.tsx
+++ b/packages/session-ui/src/v2/components/session-review-v2.tsx
@@ -43,6 +43,7 @@ export type SessionReviewV2SidebarProps = {
   transition: boolean
   title?: JSX.Element
   stats?: JSX.Element
+  actions?: JSX.Element
   filter: string
   onFilterChange: (value: string) => void
   onFilterKeyDown?: JSX.EventHandlerUnion<HTMLInputElement, KeyboardEvent>
@@ -85,6 +86,7 @@ export function SessionReviewV2Sidebar(props: SessionReviewV2SidebarProps) {
           <div data-slot="session-review-v2-sidebar-header">
             <div data-slot="session-review-v2-sidebar-title">{props.title}</div>
             {props.stats}
+            {props.actions}
           </div>
           <div data-slot="session-review-v2-sidebar-filter">
             <TextInputV2


### PR DESCRIPTION
### Issue for this PR

Related to #38125 and #27333 — when files change outside the app (or a watcher event is missed), the session file tree stays stale until a full page reload. There is no open issue for this exact button; #30661 asked for one but was auto-closed. Happy to move this under a new issue if you prefer.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The tree only updates from `file.watcher.updated` events, and `invalidateFromWatcher()` in `packages/app/src/context/file/watcher.ts` only refreshes the parent directory of the changed path — and only when that directory is already loaded. So when I copy/edit/add files from outside the app, the sidebar keeps showing the old state until I reload the page.

This adds a small manual escape hatch: a refresh button in the file browser sidebar header that force-reloads every directory currently listed. The tree store already tracks which dirs were listed and dedupes in-flight requests, so `refreshAll()` just force-lists those again (never-loaded dirs are skipped, so nothing expands unexpectedly).

Concretely: `refreshAll()` on the tree store + `file.tree.refreshAll()`, an icon button in the sidebar header (existing `outline-reset` icon; the header gets an optional `actions` slot, existing callers unaffected), a `session.files.refresh` string in all locales, and unit tests for the store.

### How did you verify your code works?

- New unit tests in `packages/app/src/context/file/tree-store.test.ts` (cached dirs not re-fetched on normal ops, force reload picks up new entries, never-loaded dirs are skipped)
- `bun run test:unit` in `packages/app`: 728 pass, 0 fail
- `bun run typecheck` passes for `@opencode-ai/app`, `@opencode-ai/session-ui`, `@opencode-ai/ui`

### Screenshots / recordings

I'll add a short recording of the sidebar header with the new button.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR