### PR TITLE
fix(core): clarify the read tool's offset validation error

### DIFF
--- a/packages/core/src/tool/plugin/read.ts
+++ b/packages/core/src/tool/plugin/read.ts
@@ -19,6 +19,8 @@ const LocationInput = Schema.Struct({
   path: Schema.String.annotate({ description: "File or directory to read" }),
   offset: ReadToolFileSystem.PageInput.fields.offset.annotate({
     description: "The line or directory entry to start reading from (1-based)",
+    message:
+      "The offset must be a non-negative integer. Line and entry numbers are 1-based, so prefer omitting the offset or using 1.",
   }),
   limit: ReadToolFileSystem.PageInput.fields.limit.annotate({
     description: "The maximum number of lines or directory entries to read (defaults to 2000)",

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -213,7 +213,25 @@ describe("ReadTool", () => {
           page: { offset: undefined, limit: undefined },
         },
       ])
-      expect(listCalls).toEqual([])
+    }),
+  )
+
+  it.effect("surfaces 1-based guidance when the model hallucinates a negative offset", () =>
+    Effect.gen(function* () {
+      const registry = yield* Tool.Service
+      const execution = yield* executeTool(registry, {
+        sessionID,
+        ...toolIdentity,
+        call: {
+          type: "tool-call",
+          id: "call-read-negative-offset",
+          name: "read",
+          input: { path: "README.md", offset: -1 },
+        },
+      })
+      expect(execution.status).toBe("error")
+      if (execution.status !== "error") return
+      expect(JSON.stringify(execution.error)).toContain("1-based")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Fixes #46807

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Models occasionally hallucinate a negative value for the optional read `offset` (for example `offset: -1`), and the validation failure only said the value should be `>= 0` without acknowledging that line and entry numbers are 1-based. Annotate the input schema so the failure carries the 1-based guidance and nudges the model toward omitting the offset or using `1`.

Offset `0` remains valid and still normalizes to the first line, matching the existing zero-offset normalization behavior.

### How did you verify your code works?

- New case in `test/tool-read.test.ts`: invoking read with `offset: -1` surfaces the 1-based guidance
- `bun typecheck` in `packages/core`; `bun test test/tool-read.test.ts` (27 passing, including the zero-offset normalization case)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


---

Supersedes #47175 — the PR head fork was accidentally deleted on 2026-09-09 (not intentional, see the notification comment there); re-filing so the review can continue. Original conversation: https://github.com/anomalyco/opencode/pull/47175
