### PR TITLE
fix(tui): exit cleanly when startup probes cannot reach the server

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -208,7 +208,11 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
   const location = yield* Effect.tryPromise(() => api.file.list({ location: { directory: process.cwd() } })).pipe(
     Effect.map((response) => response.location),
     Effect.catch(() => Effect.tryPromise(() => api.location.get())),
+    // A server that is electing or cold-booting after an update can be unreachable for longer
+    // than both probes; exit through the CLI error channel instead of escaping as a raw defect.
+    Effect.catch((error) => Effect.succeed({ error })),
   )
+  if ("error" in location) return { epilogue: undefined, reason: location.error }
   const directory = location.directory
   const pluginDirectories = yield* Effect.promise(() => localPluginDirectories(process.cwd(), global.config))
   const handoff = input.terminalHandoff ? yield* Effect.promise(input.terminalHandoff) : undefined

--- a/packages/tui/src/util/error.ts
+++ b/packages/tui/src/util/error.ts
@@ -1,3 +1,4 @@
+import { ClientError } from "@opencode-ai/client"
 import { isRecord } from "./record"
 
 type ConfigIssue = { message: string; path: string[] }
@@ -8,6 +9,11 @@ export function cliErrorMessage(input: unknown): string | undefined {
     if (formatted) return formatted
   }
 
+  if (input instanceof ClientError) {
+    process.exitCode = 1
+    const detail = input.cause instanceof Error ? `: ${input.cause.message}` : ""
+    return `Could not reach the OpenCode server${detail}. If it was updating or restarting, wait a moment and try again.`
+  }
   if (tagged(input, "CliError")) {
     if (typeof input.exitCode === "number") process.exitCode = input.exitCode
     return field(input, "message") ?? ""

--- a/packages/tui/test/error-message.test.ts
+++ b/packages/tui/test/error-message.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { ClientError } from "@opencode-ai/client"
+import { cliErrorMessage } from "../src/util/error"
+
+test("client transport errors format as a friendly message", () => {
+  const error = new ClientError("Transport", {
+    cause: new Error("Unable to connect. Is the computer able to access the url?"),
+  })
+  try {
+    const message = cliErrorMessage(error)
+    expect(message).toContain("Could not reach the OpenCode server")
+    expect(message).toContain("Unable to connect. Is the computer able to access the url?")
+    expect(process.exitCode).toBe(1)
+  } finally {
+    process.exitCode = 0
+  }
+})
+
+test("unknown errors are left to the fallback formatter", () => {
+  expect(cliErrorMessage(new Error("boom"))).toBeUndefined()
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #36688

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A TUI started while the background server is electing or cold-booting after an update can fail both startup location probes and crash with an unhandled `ClientError` through `Effect.tryPromise`. Route the startup failure through the existing CLI error channel so the TUI exits with a friendly "could not reach the server" message and exit code 1 instead of a raw stack dump.

### How did you verify your code works?

- `bun typecheck` in `packages/tui` and `packages/cli`
- `bun test` in `packages/tui` (1176 passing) and `packages/cli` (254 passing)
- New `test/error-message.test.ts` covers the ClientError formatting and exit code

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


---

Supersedes #46726 — the PR head fork was accidentally deleted on 2026-09-09 (not intentional, see the notification comment there); re-filing so the review can continue. Original conversation: https://github.com/anomalyco/opencode/pull/46726
