### PR TITLE
fix(cli): print explicitly requested --help to stdout

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -32,14 +32,14 @@ import { Heap } from "./cli/heap"
 
 const args = hideBin(process.argv)
 
-function show(out: string) {
+function show(out: string, stream: NodeJS.WriteStream) {
   const text = out.trimStart()
   if (!text.startsWith("opencode ")) {
-    process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text + EOL)
+    stream.write(UI.logo() + EOL + EOL)
+    stream.write(text + EOL)
     return
   }
-  process.stderr.write(out)
+  stream.write(out)
 }
 
 const cli = yargs(args)
@@ -108,7 +108,7 @@ const cli = yargs(args)
       msg?.startsWith("Invalid values:")
     ) {
       if (err) throw err
-      cli.showHelp(show)
+      cli.showHelp((message) => show(message, process.stderr))
     }
     if (err) throw err
     process.exit(1)
@@ -120,7 +120,7 @@ try {
     await cli.parse(args, (err: Error | undefined, _argv: unknown, out: string) => {
       if (err) throw err
       if (!out) return
-      show(out)
+      show(out, process.stdout)
     })
   } else {
     await cli.parse()

--- a/packages/opencode/test/cli/help/help-snapshots.test.ts
+++ b/packages/opencode/test/cli/help/help-snapshots.test.ts
@@ -100,11 +100,11 @@ describe("opencode CLI help-text snapshots", () => {
       Effect.gen(function* () {
         const topLevel = yield* opencode.spawn(["--help"], { env: SNAPSHOT_ENV })
         expect(topLevel.exitCode).toBe(0)
-        expect(topLevel.stderr.endsWith("\n")).toBe(true)
-        expect(topLevel.stderr).toContain("--mini")
-        expect(topLevel.stderr).not.toContain("--thinking")
-        expect(topLevel.stderr).not.toContain("--variant")
-        expect(topLevel.stderr).not.toContain("--demo")
+        expect(topLevel.stdout.endsWith("\n")).toBe(true)
+        expect(topLevel.stdout).toContain("--mini")
+        expect(topLevel.stdout).not.toContain("--thinking")
+        expect(topLevel.stdout).not.toContain("--variant")
+        expect(topLevel.stdout).not.toContain("--demo")
 
         const argvs: Array<readonly string[]> = [...TOP_LEVEL.map((c) => [c] as const), ...SUBCOMMANDS]
 
@@ -126,10 +126,10 @@ describe("opencode CLI help-text snapshots", () => {
         )
 
         for (const { argv, result } of results) {
-          // yargs writes --help to stderr, not stdout. Snapshotting stderr
-          // means our test catches the help body; stdout for these commands
-          // is expected to be empty.
-          expect(normalize(result.stderr)).toMatchSnapshot(`opencode ${argv.join(" ")} --help`)
+          // Explicitly requested --help goes to stdout; error-triggered help
+          // stays on stderr. Snapshotting stdout means our test catches the
+          // help body; stderr for these commands is expected to be empty.
+          expect(normalize(result.stdout)).toMatchSnapshot(`opencode ${argv.join(" ")} --help`)
         }
         if (failures.length > 0) {
           throw new Error(`Help text failed for:\n  ${failures.join("\n  ")}`)


### PR DESCRIPTION
Explicit help is normal output, only help shown on a usage error belongs on stderr. Writing it to stdout keeps it pipeable and greppable, and separates it from error output.

### Issue for this PR

Fixes #48173

### Type of change

- [x] Bug fix

### What does this PR do?

Explicitly requested help (`--help` / `-h`) is normal output, not a diagnostic, but it was written to stderr, indistinguishable from error output and not pipeable. This PR routes user-requested help to **stdout**; help shown on a usage error still goes to **stderr**.

### How did you verify your code works?

Ran tests locally

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR