### PR TITLE
docs(ecosystem): add opencode-terminal to plugins section

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-| [opencode-terminal](https://github.com/ShivamChavan01/terminal-)                                   | Open native OS terminal window + run shell commands for OpenCode                                   |
+| [opencode-terminal](https://github.com/ShivamChavan01/opencode-terminal)                           | Open native OS terminal window + run shell commands for OpenCode                                   |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-terminal](https://github.com/ShivamChavan01/terminal-)                                   | Open native OS terminal window + run shell commands for OpenCode                                   |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A - docs-only ecosystem addition. Docs PRs are exempt from the linked-issue requirement (`pr-standards.yml` skips `docs`/`refactor`/`feat`).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-terminal](https://github.com/ShivamChavan01/opencode-terminal) to the Plugins table on the ecosystem page. One table row added.

opencode-terminal is my open-source plugin (npm: `opencode-terminal@0.2.0`). Users install it via `"plugin": ["opencode-terminal"]` in `opencode.json` - same npm mechanism as the other listed plugins. It gives OpenCode a native OS terminal plus persistent background sessions with auto-detect, REPL input, and process tree control. The ecosystem page invites community projects to submit PRs, so here it is.

### How did you verify your code works?

Docs-only change, plus verified the linked plugin itself works from a clean install:

1. `npm view opencode-terminal` - 0.2.0 live, repo/homepage point to the new `opencode-terminal` repo name.
2. Fresh `npm i opencode-terminal@0.2.0` in an empty dir, imported `TerminalPlugin` with bun - all 9 tools register: `open_terminal, terminal_detect, close_terminal, terminal_run, terminal_start, terminal_log, terminal_send, terminal_kill, terminal_list`.
3. Executed `terminal_detect` from the installed package - returns valid detection JSON.
4. `tsc --noEmit` passes on the plugin source.
5. Table row matches existing column width (203 chars, same as neighboring rows).

### Screenshots / recordings

https://github.com/user-attachments/assets/ae740ccf-f8d3-478c-9291-29fd6f75c57a



_No UI change - one markdown table row added._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
