### PR TITLE
fix(web): show sessions in Home for Windows subpaths

### DIFF
--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -4,6 +4,7 @@ import { ServerConnection, useServer } from "@/context/server"
 import { useServerSync } from "@/context/server-sync"
 import { useTabs } from "@/context/tabs"
 import { toggleHomeProjectSelection } from "@/pages/layout/helpers"
+import { pathKey } from "@/utils/path-key"
 import { createEffect, createMemo } from "solid-js"
 
 export function createHomeController() {
@@ -27,11 +28,13 @@ export function createHomeController() {
     () => focusedServerCtx()?.projects.recentlyClosed() ?? layout.projects.recentlyClosed(),
   )
   const homedir = createMemo(() => focusedSync().data.path.home ?? "")
-  const selectedProject = createMemo(() => projects().find((project) => project.worktree === selection().directory))
+  const selectedProject = createMemo(() =>
+    projects().find((project) => pathKey(project.worktree) === pathKey(selection().directory ?? "")),
+  )
   const newSessionProject = createMemo(
     () =>
       selectedProject() ??
-      projects().find((project) => project.worktree === focusedServerCtx()?.projects.last()) ??
+      projects().find((project) => pathKey(project.worktree) === pathKey(focusedServerCtx()?.projects.last() ?? "")) ??
       projects()[0],
   )
 
@@ -81,7 +84,7 @@ export function createHomeController() {
           !global
             .ensureServerCtx(conn)
             .projects.list()
-            .some((project) => project.worktree === directory)
+            .some((project) => pathKey(project.worktree) === pathKey(directory))
         )
           return
         setSelection(toggleHomeProjectSelection(selection(), key, directory))
@@ -91,7 +94,7 @@ export function createHomeController() {
         if (!directory) return
         const ctx = global.ensureServerCtx(conn)
         directories.forEach((item) => {
-          if (ctx.projects.list().some((project) => project.worktree === item)) return
+          if (ctx.projects.list().some((project) => pathKey(project.worktree) === pathKey(item))) return
           const location = { directory: item }
           void ctx.sdk.api.file
             .list({ path: ".", location })

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -17,7 +17,7 @@ import { ServerConnection } from "@/context/server"
 import { sessionHasOpenTab, useTabs } from "@/context/tabs"
 import { compareSessionTime, displayName, errorMessage, projectForSession } from "@/pages/layout/helpers"
 import { useSessionTabAvatarState } from "@/pages/layout/project-avatar-state"
-import { pathKey } from "@/utils/path-key"
+import { isSubpath, pathKey } from "@/utils/path-key"
 import { showToast } from "@/utils/toast"
 import { Binary } from "@opencode-ai/core/util/binary"
 import { archiveHomeSession } from "../home-session-archive"
@@ -179,15 +179,17 @@ export function createHomeSessionsController(home: HomeController) {
       canCreate: () => !!home.project.newSession(),
       create: home.project.openNewSession,
       open: (session: Session, options?: OpenSessionOptions) => {
-        const directoryKey = pathKey(session.directory)
+        const directoryKey = session.directory
         const project =
           home.project
             .list()
             .find(
               (item) =>
-                pathKey(item.worktree) === directoryKey ||
-                item.sandboxes?.some((sandbox) => pathKey(sandbox) === directoryKey),
-            ) ?? projectForSession(session, home.project.list(), projectByID())
+                pathKey(item.worktree) === pathKey(directoryKey) ||
+                item.sandboxes?.some((sandbox) => pathKey(sandbox) === pathKey(directoryKey)),
+            ) ??
+          home.project.list().find((item) => isSubpath(directoryKey, item.worktree)) ??
+          projectForSession(session, home.project.list(), projectByID())
         const conn = home.server.focused()
         if (!conn) return
         const directory = project?.worktree ?? session.directory
@@ -253,20 +255,33 @@ function buildHomeSessionRecords(input: {
   projects: () => LocalProject[]
   projectByID: () => Map<string, LocalProject>
 }) {
-  const directories = new Set(input.projectDirectories().map(pathKey))
-  const sessions = input.sessions().filter((session) => directories.has(pathKey(session.directory)))
+  const bases = input.projectDirectories()
+  // Match exact dirs AND sessions nested under an open project (e.g.
+  // session in C:/gitProjects/AIA_tennis when C:/gitProjects is open).
+  // If no open projects are known yet, don't filter everything out —
+  // fall through so "all sessions" (unselected project) still shows data.
+  const sessions =
+    bases.length === 0
+      ? input.sessions()
+      : input.sessions().filter((session) => bases.some((base) => isSubpath(session.directory, base)))
   return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
     .sort(compareSessionTime)
     .flatMap((session) => {
-      const directory = pathKey(session.directory)
+      const directory = session.directory
       const project =
         input
           .projects()
           .find(
             (item) =>
-              pathKey(item.worktree) === directory || item.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
-          ) ?? projectForSession(session, input.projects(), input.projectByID())
-      if (!project) return []
+              pathKey(item.worktree) === pathKey(directory) ||
+              item.sandboxes?.some((sandbox) => pathKey(sandbox) === pathKey(directory)),
+          ) ??
+        input.projects().find((item) => isSubpath(directory, item.worktree)) ??
+        projectForSession(session, input.projects(), input.projectByID()) ??
+        // Fallback: keep the session visible even when its project isn't
+        // in the open-project list (e.g. different server cwd). Use the
+        // session directory as the project worktree so open() still works.
+        ({ worktree: session.directory, expanded: false } as LocalProject)
       return { session, project, projectName: displayName(project) }
     })
 }

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -22,7 +22,7 @@ import {
   sortedRootSessions,
   toggleHomeProjectSelection,
 } from "./helpers"
-import { pathKey } from "@/utils/path-key"
+import { isSubpath, pathKey } from "@/utils/path-key"
 import { ServerConnection } from "@/context/server"
 
 const serverKey = ServerConnection.Key.make
@@ -115,15 +115,21 @@ describe("layout deep links", () => {
 describe("layout workspace helpers", () => {
   test("normalizes trailing slash in workspace key", () => {
     expect(String(pathKey("/tmp/demo///"))).toBe("/tmp/demo")
-    expect(String(pathKey("C:\\tmp\\demo\\\\"))).toBe("C:/tmp/demo")
+    expect(String(pathKey("C:\\tmp\\demo\\\\"))).toBe("c:/tmp/demo")
+  })
+
+  test("normalizes Windows paths case-insensitively", () => {
+    expect(pathKey("C:\\Users\\Alice\\Project")).toBe(pathKey("c:/users/alice/project"))
+    expect(isSubpath("C:\\Users\\Alice\\Project\\child", "c:/users/alice/project")).toBe(true)
+    expect(isSubpath("C:\\Users\\Alice\\Projects", "c:/users/alice/project")).toBe(false)
   })
 
   test("preserves posix and drive roots in workspace key", () => {
     expect(String(pathKey("/"))).toBe("/")
     expect(String(pathKey("///"))).toBe("/")
-    expect(String(pathKey("C:\\"))).toBe("C:/")
-    expect(String(pathKey("C://"))).toBe("C:/")
-    expect(String(pathKey("C:///"))).toBe("C:/")
+    expect(String(pathKey("C:\\"))).toBe("c:/")
+    expect(String(pathKey("C://"))).toBe("c:/")
+    expect(String(pathKey("C:///"))).toBe("c:/")
   })
 
   test("keeps local first while preserving known order", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -1,6 +1,6 @@
 import { getFilename } from "@opencode-ai/core/util/path"
 import { type Session } from "@opencode-ai/sdk/v2/client"
-import { pathKey } from "@/utils/path-key"
+import { isSubpath, pathKey } from "@/utils/path-key"
 import type { ServerConnection } from "@/context/server"
 import type { HomeProjectSelection } from "@/context/layout"
 
@@ -54,7 +54,12 @@ export function toggleHomeProjectSelection(
   server: ServerConnection.Key,
   directory: string,
 ): HomeProjectSelection {
-  if (current?.server === server && current.directory === directory) return { server }
+  if (
+    current?.server === server &&
+    current.directory !== undefined &&
+    pathKey(current.directory) === pathKey(directory)
+  )
+    return { server }
   return { server, directory }
 }
 
@@ -65,7 +70,12 @@ export function closeHomeProject(
   directory: string,
 ) {
   projects.close(directory)
-  if (selected?.server === server && selected.directory === directory) return { server }
+  if (
+    selected?.server === server &&
+    selected.directory !== undefined &&
+    pathKey(selected.directory) === pathKey(directory)
+  )
+    return { server }
   return selected
 }
 
@@ -100,10 +110,18 @@ export function projectForSession<T extends { id?: string; worktree: string; san
 ) {
   const direct = byID.get(session.projectID)
   if (direct) return direct
-  const directory = pathKey(session.directory)
-  return projects.find(
+  const directory = session.directory
+  // Exact match first (fast path), then subpath match so sessions in
+  // child dirs (e.g. C:/gitProjects/AIA_tennis under C:/gitProjects)
+  // still resolve instead of being dropped from the home list.
+  const exact = projects.find(
     (project) =>
-      pathKey(project.worktree) === directory || project.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
+      pathKey(project.worktree) === pathKey(directory) ||
+      project.sandboxes?.some((sandbox) => pathKey(sandbox) === pathKey(directory)),
+  )
+  if (exact) return exact
+  return projects.find(
+    (project) => isSubpath(directory, project.worktree) || project.sandboxes?.some((sandbox) => isSubpath(directory, sandbox)),
   )
 }
 

--- a/packages/app/src/utils/path-key.ts
+++ b/packages/app/src/utils/path-key.ts
@@ -16,9 +16,19 @@ const trimTrailingSlashes = (value: string) => {
 const isWindowsPath = (value: string) => value[1] === ":" || value.startsWith("\\\\")
 
 export const pathKey = (path: string) => {
-  const value = isWindowsPath(path) ? path.replaceAll("\\", "/") : path
+  const isWin = isWindowsPath(path)
+  const value = isWin ? path.replaceAll("\\", "/") : path
   const trimmed = trimTrailingSlashes(value)
-  if (!trimmed && value.startsWith("/")) return "/" as PathKey
-  if (isDrive(trimmed)) return `${trimmed}/` as PathKey
-  return trimmed as PathKey
+  const normalized = isWin ? trimmed.toLowerCase() : trimmed
+  if (!normalized && value.startsWith("/")) return "/" as PathKey
+  if (isDrive(normalized)) return `${normalized}/` as PathKey
+  return normalized as PathKey
+}
+
+export const isSubpath = (candidate: string, parent: string) => {
+  const child = pathKey(candidate)
+  const base = pathKey(parent)
+  if (child === base) return true
+  const prefix = base.endsWith("/") ? base : `${base}/`
+  return child.startsWith(prefix)
 }


### PR DESCRIPTION
### Issue for this PR

Fixes #27837

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

### What does this PR do?

The web server persisted sessions correctly and `/api/session` returned them, but the Home project list could discard them on Windows when the session directory differed only by path casing or was nested below an opened project. Sessions that did not resolve to an already-open project could also disappear from the list.

This normalizes Windows path keys case-insensitively, matches nested directories using path boundaries, compares project selections using normalized keys, and keeps a safe fallback project so the session remains visible and openable.

I spent approximately four hours reproducing this before using Codex to inspect the client/server boundary; once the filtering path was isolated, the local fix took about five minutes.

### How did you verify your code works?

- Reproduced on Windows with `opencode serve` bound to `0.0.0.0:4096` and accessed through Tailscale.
- Confirmed `/api/session?directory=C:\gitProjects` returned five persisted sessions before the UI fix.
- Confirmed the five persisted sessions appeared in the Home project list after the fix without data migration.
- Ran `bun run --cwd packages/app build` successfully.
- Added regression coverage for case-insensitive Windows paths, nested path matching, and path-boundary rejection.
- Ran direct path-key assertions successfully.

The local monorepo typecheck is currently blocked by the Windows checkout representing `packages/app/src/custom-elements.d.ts` as a text symlink target; the same pre-existing checkout issue affects the upstream pre-push hook. The build and focused assertions pass.

### Screenshots / recordings

Before: the Home project showed “Nothing here yet” while the session API returned five sessions.

After: the same project showed all persisted sessions in the Home list after restarting the patched server.

### Checklist

- [x] The changes are limited to this PR's purpose.
- [x] I have tested the changes locally.
- [x] I have included or described verification evidence for UI changes.
- [x] This PR references an existing issue.