### PR TITLE
fix(web): resync sessions after mobile reconnects

### DIFF
--- a/packages/app/src/context/global-sync/home-session-index.test.ts
+++ b/packages/app/src/context/global-sync/home-session-index.test.ts
@@ -182,4 +182,23 @@ describe("Home V2 session index", () => {
     expect(queryClient.getQueryData(cache.indexKey)).toBeUndefined()
     expect(cache.sessions({ sessions, eventSequence: 0 }, undefined).map((item) => item.id)).toEqual(["b"])
   })
+
+  test("buffers session events until the Home index is mounted", () => {
+    const queryClient = new QueryClient()
+    const cache = createHomeSessionIndexCache(queryClient, "server")
+    const created = parseHomeSessionIndex([session({ id: "created" })])[0]!
+
+    cache.apply({
+      type: "session.created",
+      properties: { sessionID: created.id, info: created },
+    })
+    queryClient.setQueryData(cache.indexKey, { sessions: [], eventSequence: 0 })
+
+    expect(
+      cache.sessions(
+        queryClient.getQueryData(cache.indexKey),
+        queryClient.getQueryData(cache.eventsKey),
+      ).map((item) => item.id),
+    ).toEqual(["created"])
+  })
 })

--- a/packages/app/src/context/global-sync/home-session-index.ts
+++ b/packages/app/src/context/global-sync/home-session-index.ts
@@ -102,20 +102,17 @@ export function createHomeSessionIndexCache(queryClient: QueryClient, server: st
       return removed.size === 0 ? sessions : sessions.filter((session) => !removed.has(session.id))
     },
     apply(event: HomeSessionEvent) {
-      if (!queryClient.getQueryState(indexKey)) return
       const next = appendHomeSessionEvent(queryClient.getQueryData<HomeSessionEvents>(eventsKey), event)
-      if (queryClient.isFetching({ queryKey: indexKey, exact: true }) > 0) {
+      const index = queryClient.getQueryData<HomeSessionIndex>(indexKey)
+      if (queryClient.isFetching({ queryKey: indexKey, exact: true }) > 0 || !index) {
         queryClient.setQueryData(eventsKey, next)
         return
       }
 
-      const index = queryClient.getQueryData<HomeSessionIndex>(indexKey)
-      if (index) {
-        queryClient.setQueryData<HomeSessionIndex>(indexKey, {
-          sessions: homeSessionIndexSessions(index, next),
-          eventSequence: next.sequence,
-        })
-      }
+      queryClient.setQueryData<HomeSessionIndex>(indexKey, {
+        sessions: homeSessionIndexSessions(index, next),
+        eventSequence: next.sequence,
+      })
       queryClient.setQueryData<HomeSessionEvents>(eventsKey, { sequence: next.sequence, entries: [] })
     },
     remove(sessionID: string) {

--- a/packages/app/src/context/server-sdk.test.ts
+++ b/packages/app/src/context/server-sdk.test.ts
@@ -4,14 +4,14 @@ import type { OpenCodeEvent } from "@opencode-ai/client/promise"
 import type { Event } from "@opencode-ai/sdk/v2/client"
 
 describe("resumeStreamAfterPageShow", () => {
-  test("restarts a stream only after a back-forward cache restore", () => {
+  test("restarts a stream after any page show", () => {
     let starts = 0
     const start = () => starts++
 
-    resumeStreamAfterPageShow({ persisted: false } as PageTransitionEvent, start)
-    resumeStreamAfterPageShow({ persisted: true } as PageTransitionEvent, start)
+    resumeStreamAfterPageShow(start)
+    resumeStreamAfterPageShow(start)
 
-    expect(starts).toBe(1)
+    expect(starts).toBe(2)
   })
 })
 

--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -159,8 +159,7 @@ function currentDeltaFragment(event: CurrentDelta) {
   return event.type === "session.compaction.delta" ? event.data.text : event.data.delta
 }
 
-export function resumeStreamAfterPageShow(event: PageTransitionEvent, start: () => unknown) {
-  if (!event.persisted) return
+export function resumeStreamAfterPageShow(start: () => unknown) {
   start()
 }
 
@@ -324,7 +323,10 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
 
   onMount(() => {
     makeEventListener(window, "pagehide", stop)
-    makeEventListener(window, "pageshow", (event) => resumeStreamAfterPageShow(event, start))
+    makeEventListener(window, "pageshow", () => resumeStreamAfterPageShow(start))
+    makeEventListener(document, "visibilitychange", () => {
+      if (document.visibilityState === "visible") start()
+    })
   })
 
   onCleanup(() => {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1606,6 +1606,15 @@ describe("server session", () => {
     expect(ctx.get).toEqual([])
   })
 
+  test("resyncs pinned sessions after reconnecting", async () => {
+    const ctx = setup({ child: session("child") })
+    ctx.store.pin("child")
+
+    await ctx.store.resync()
+
+    expect(ctx.messages).toEqual([{ sessionID: "child", limit: 20, before: undefined }])
+  })
+
   test("preserves pinned session content under server-wide cache pressure", () => {
     const ctx = setup({})
     ctx.store.pin("active")

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -1419,6 +1419,9 @@ export function createServerSession(
       if (!count || count === 1) pinned.delete(sessionID)
       if (count && count > 1) pinned.set(sessionID, count - 1)
     },
+    resync() {
+      return Promise.all([...pinned.keys()].map((sessionID) => sync(sessionID, { force: true })))
+    },
     apply,
     applyV2,
   }

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -544,6 +544,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
     if (eventType === "integration.connection.updated") void refreshProviders()
 
     if (directory === "global") {
+      if (eventType === "server.connected") void session.resync().catch(() => {})
       if (eventType === "server.connected" && activeSessionsQuery.data === undefined && !activeSessionsQuery.isFetching)
         void activeSessionsQuery.refetch()
       applyGlobalEvent({


### PR DESCRIPTION
### Issue for this PR

Fixes #27837

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

### What does this PR do?

- Buffer Home session events even when the Home index is not mounted, so sessions created while working in another view appear without a manual refresh.
- Restart the browser event stream after every page show and when a mobile browser becomes visible again.
- Force-refresh pinned/open session content after reconnecting so responses missed while Chrome was backgrounded or the phone changed apps are recovered from the server.

This addresses the two synchronization symptoms separately from the Windows path-matching fix in #48177. The mobile lifecycle behavior was reproduced by rapidly backgrounding Chrome, switching apps, and returning to the OpenCode page.

### How did you verify your code works?

- `bun test src/context/global-sync/home-session-index.test.ts src/context/server-session.test.ts` — 85 passed.
- `bun run --cwd packages/app build` — passed.
- Added regression coverage for buffered Home events, reconnect resync of pinned sessions, and page-show stream restart.

The local monorepo typecheck is blocked by the existing Windows checkout representation of `packages/app/src/custom-elements.d.ts` as a text symlink target; the app build and focused tests pass.

### Checklist

- [x] The changes are limited to this PR's purpose.
- [x] I have tested the changes locally.
- [x] This PR references an existing issue.