### PR TITLE
docs: add opencode-token-norm to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-token-norm](https://github.com/salitaba/opencode-token-norm)                             | Enforce a token budget with self-firing cost reminders, plus a session handoff tool                |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation addition to the community ecosystem plugins list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-token-norm](https://github.com/salitaba/opencode-token-norm) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

The plugin enforces a token budget from inside the session instead of relying on the agent to remember one. It counts tool calls, then attaches a `<system-reminder>` to tool output once the threshold is crossed, so the cost check arrives in the channel the model is already reading. It runs the usage audit itself and injects the numbers, rather than instructing the agent to run one. It also bundles a `handoff` tool that writes the note to disk and then opens a fresh session with the note pre-filled.

I wrote it after a 184-call session ran to 3M effective tokens with a token-discipline rule sitting in context the whole time, unread.

### How did you verify your code works?

Docs-only change: one row appended to the end of the Plugins table. I checked the column alignment matches the surrounding rows and that the description is a single line in the same terse style. The linked repo is public and the package is published at https://www.npmjs.com/package/opencode-token-norm.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
