### PR TITLE
fix(retry): read duration-string retry-after headers instead of truncating them

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -44,24 +44,51 @@ function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
 
+const RATE_LIMIT_DURATION_UNIT_MS: Record<string, number> = { ms: 1, s: 1000, m: 60_000, h: 3_600_000 }
+
+// A header that is just digits keeps its documented meaning (milliseconds for
+// `retry-after-ms`, seconds for `retry-after`, RFC 9110). Only a value that is
+// NOT a plain number is handed to the duration parser below, so nothing that
+// already parsed correctly changes behaviour.
+function isPlainNumber(value: string): boolean {
+  return /^\s*\d+(?:\.\d+)?\s*$/.test(value)
+}
+
+// Several providers answer with a duration string rather than a number of
+// seconds — "370ms", "6s", "2m59.56s". Order in the alternation matters: "ms"
+// must be tried before "m" alone, or every millisecond value is read as minutes.
+export function parseRateLimitDuration(value: string): number | undefined {
+  const matches = [...value.matchAll(/(\d+(?:\.\d+)?)(ms|h|m|s)/g)]
+  if (matches.length === 0) return undefined
+  return matches.reduce((total, [, amount, unit]) => total + Number.parseFloat(amount) * RATE_LIMIT_DURATION_UNIT_MS[unit], 0)
+}
+
 export function delay(attempt: number, error?: SessionV1.APIError, random = Math.random()) {
   if (error) {
     const headers = error.data.responseHeaders
     if (headers) {
+      // Number.parseFloat stops at the first non-digit, which on a duration
+      // string is not an error but a plausible wrong number, returned silently:
+      // "2m59.56s" becomes 2 -> 2_000 ms instead of 179_560 ms. That is two
+      // seconds instead of three minutes, in the direction that breaks — every
+      // retry is spent inside half a minute against a limit that lasts three,
+      // and then the request gives up.
       const retryAfterMs = headers["retry-after-ms"]
       if (retryAfterMs) {
-        const parsedMs = Number.parseFloat(retryAfterMs)
-        if (!Number.isNaN(parsedMs)) {
+        const parsedMs = isPlainNumber(retryAfterMs) ? Number.parseFloat(retryAfterMs) : parseRateLimitDuration(retryAfterMs)
+        if (parsedMs !== undefined && !Number.isNaN(parsedMs)) {
           return cap(parsedMs)
         }
       }
 
       const retryAfter = headers["retry-after"]
       if (retryAfter) {
-        const parsedSeconds = Number.parseFloat(retryAfter)
-        if (!Number.isNaN(parsedSeconds)) {
-          // convert seconds to milliseconds
-          return cap(Math.ceil(parsedSeconds * 1000))
+        // A bare number is seconds (RFC 9110); a duration string carries its units.
+        const parsedMs = isPlainNumber(retryAfter)
+          ? Number.parseFloat(retryAfter) * 1000
+          : parseRateLimitDuration(retryAfter)
+        if (parsedMs !== undefined && !Number.isNaN(parsedMs)) {
+          return cap(Math.ceil(parsedMs))
         }
         // Try parsing as HTTP date format
         const parsed = Date.parse(retryAfter) - Date.now()

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -57,6 +57,36 @@ describe("session.retry.delay", () => {
     expect(SessionRetry.delay(3, error)).toBe(30000)
   })
 
+  // Number.parseFloat stops at the first non-digit, so a duration string came
+  // back as a plausible wrong number rather than an error: "2m59.56s" -> 2 ->
+  // 2_000 ms instead of 179_560. Two seconds instead of three minutes, in the
+  // direction that breaks.
+  test("reads duration strings on retry-after", () => {
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "2m59.56s" }))).toBe(2 * 60_000 + 59_560)
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "1m30s" }))).toBe(90_000)
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "6s" }))).toBe(6_000)
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "370ms" }))).toBe(370)
+  })
+
+  test("reads duration strings on retry-after-ms", () => {
+    expect(SessionRetry.delay(1, apiError({ "retry-after-ms": "2m59.56s" }))).toBe(2 * 60_000 + 59_560)
+    expect(SessionRetry.delay(1, apiError({ "retry-after-ms": "370ms" }))).toBe(370)
+  })
+
+  // The other direction: a bare number must keep its documented unit, or this
+  // change would silently alter every provider that was already read correctly.
+  test("a bare number keeps its unit: seconds on retry-after, milliseconds on retry-after-ms", () => {
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "30" }))).toBe(30_000)
+    expect(SessionRetry.delay(1, apiError({ "retry-after-ms": "1500" }))).toBe(1500)
+  })
+
+  test("parseRateLimitDuration sums units and rejects a non-duration", () => {
+    expect(SessionRetry.parseRateLimitDuration("370ms")).toBe(370)
+    expect(SessionRetry.parseRateLimitDuration("6s")).toBe(6000)
+    expect(SessionRetry.parseRateLimitDuration("2m59.56s")).toBeCloseTo(2 * 60_000 + 59_560, 0)
+    expect(SessionRetry.parseRateLimitDuration("not-a-duration")).toBeUndefined()
+  })
+
   test("accepts http-date retry-after values", () => {
     const date = new Date(Date.now() + 20000).toUTCString()
     const error = apiError({ "retry-after": date })


### PR DESCRIPTION
## Body

`delay()` reads `retry-after` and `retry-after-ms` with `Number.parseFloat`,
which stops at the first non-digit. Several providers answer with a **duration
string** rather than a plain number of seconds, and the result is not an error —
it is a plausible wrong number, returned silently:

```
retry-after: "2m59.56s"   ->  parseFloat -> 2    ->  2_000 ms    (should be 179_560)
retry-after: "1m30s"      ->              1      ->  1_000 ms    (should be  90_000)
retry-after: "370ms"      ->            370      -> 370_000 ms   (should be     370)
```

Two seconds instead of three minutes. With `RETRY_MAX_RETRIES = 5` the whole
retry budget is spent inside half a minute against a limit that lasts three
minutes, and the request then fails as if the limit were permanent. The
1000×-too-long case is the mirror image: a request that waits six minutes for a
370 ms limit.

Nothing about this looks wrong from the outside: no `NaN`, no exception, no log
line — just a delay that is off by two orders of magnitude in whichever
direction the units happen to fall.

## The change

A bare number keeps its documented meaning (milliseconds for `retry-after-ms`,
seconds for `retry-after`, RFC 9110). Only a value that is **not** a plain
number is handed to a small duration parser, so every provider that was already
read correctly is unaffected. HTTP-date values still fall through to
`Date.parse` exactly as before.

The parser sums unit by unit; the order of the alternation matters — `ms` has to
be tried before `m`, or every millisecond value is read as minutes.

## Tests

Four new tests: duration strings on both headers, a bare number keeping its unit
on both headers (the direction that guards against a silent behaviour change),
and the parser itself including a non-duration returning `undefined`.

Verified in both directions: against the current code three of them fail with
`Expected: 179560 / Received: 2000`.
