### PR TITLE
fix(provider): defaultModel should skip recent models from providers this project doesn't configure

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -2022,14 +2022,21 @@ const layer = Layer.effect(
         }),
         Effect.catch(() => Effect.succeed([] as { providerID: ProviderV2.ID; modelID: ModelV2.ID }[])),
       )
+      const configured = Object.keys(cfg.provider ?? {})
       for (const entry of recent) {
+        // The recent-model list lives in Global.Path.state and is shared by every
+        // project that has ever run opencode on this machine. A provider can be
+        // "connected" here purely through a stray env var or a stored credential
+        // while never appearing in THIS project's `provider` config — and the
+        // last-resort branch below already refuses exactly that case. Applying the
+        // same allow-list here makes the function consistent with itself.
+        if (configured.length > 0 && !configured.includes(entry.providerID)) continue
         const provider = s.providers[entry.providerID]
         if (!provider) continue
         if (!provider.models[entry.modelID]) continue
         return { providerID: entry.providerID, modelID: entry.modelID }
       }
 
-      const configured = Object.keys(cfg.provider ?? {})
       const provider = Object.values(s.providers).find((p) => configured.length === 0 || configured.includes(p.id))
       if (!provider) return yield* new NoProvidersError()
       const [model] = sort(Object.values(provider.models))

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test"
-import { mkdir, unlink } from "fs/promises"
+import { mkdir, readFile, unlink, writeFile } from "fs/promises"
 import path from "path"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -376,6 +376,46 @@ it.instance(
     expect(model.modelID).toBeDefined()
   }),
   { config: { provider: {} } },
+)
+
+it.instance(
+  "defaultModel skips a recent entry whose provider is connected but not configured for this project",
+  Effect.gen(function* () {
+    yield* setProcessEnv("ANTHROPIC_API_KEY", "test-api-key")
+    yield* setProcessEnv("OPENAI_API_KEY", "test-openai-key")
+
+    // Global.Path.state is the real state directory unless XDG_STATE_HOME is
+    // redirected, so preserve whatever is already there instead of deleting it.
+    const modelFile = path.join(Global.Path.state, "model.json")
+    const previous = yield* Effect.promise(() => readFile(modelFile, "utf8").catch(() => undefined))
+    yield* Effect.promise(() =>
+      writeFile(
+        modelFile,
+        JSON.stringify({
+          recent: [
+            // openai is connected (env var above) but is NOT in this project's
+            // `provider` config below.
+            { providerID: "openai", modelID: "gpt-5" },
+            // A non-default anthropic model on purpose, so a pass proves the
+            // answer came from THIS entry and not from the last-resort sort().
+            { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          ],
+        }),
+      ),
+    )
+
+    const model = yield* Provider.use.defaultModel().pipe(
+      Effect.ensuring(
+        Effect.promise(() =>
+          (previous === undefined ? unlink(modelFile) : writeFile(modelFile, previous)).catch(() => undefined),
+        ),
+      ),
+    )
+
+    expect(String(model.providerID)).toBe("anthropic")
+    expect(String(model.modelID)).toBe("claude-haiku-4-5")
+  }),
+  { config: { provider: { anthropic: {} } } },
 )
 
 it.instance(


### PR DESCRIPTION
## Body

`Provider.defaultModel()` picks a model from the recent-model list stored in
`Global.Path.state/model.json`. That file is **global to the machine** — every
project that has ever run opencode on it writes there — while a project's
`provider` config is local.

The recent-list loop accepts the first entry whose provider happens to be
*connected*:

```ts
for (const entry of recent) {
  const provider = s.providers[entry.providerID]
  ...
}
```

but the last-resort branch **three lines below** already enforces the project's
own allow-list:

```ts
const configured = Object.keys(cfg.provider ?? {})
const provider = Object.values(s.providers).find((p) => configured.length === 0 || configured.includes(p.id))
```

So the same function applies two different policies depending on which branch it
reaches. A provider that is connected only through a stray environment variable
or a stored credential — never declared in this project — can silently become
"the default model" for a session created without `-m`.

**How we hit it.** A session in a project whose config lists only a local
provider landed on a completely different cloud provider/model, taken from a
choice made while working on an unrelated project on the same machine, and
failed with `402 payment_required` before a single prompt was sent. The
provider pair existed nowhere in that project's configuration.

## The change

One line: apply the allow-list the function already computes to the recent-list
loop as well. Empty config keeps meaning "no allow-list", exactly as before.

## Test

`defaultModel skips a recent entry whose provider is connected but not configured
for this project` — a recent list whose first entry is a connected-but-not-
configured provider, and whose second entry is a **non-default** model of a
configured provider, so a pass proves the answer came from the recent list and
not from the last-resort sort.

Verified in both directions: the test fails without the one-line change and
passes with it.

Note: the test writes `model.json` into `Global.Path.state`, which is the real
state directory unless `XDG_STATE_HOME` is redirected. It now preserves and
restores whatever was already there instead of deleting it.
