### PR TITLE
fix(session): stop auto-compacting after 3 consecutive attempts that don't shrink the request

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -79,6 +79,13 @@ IMPORTANT:
 - Complete all necessary research and tool calls BEFORE calling this tool
 - This tool provides your final answer - no further actions are taken after calling it`
 
+// Compaction can only shrink the CONVERSATION. When what exceeds the provider's
+// window is the fixed overhead — system prompt plus tool definitions — every
+// compaction "succeeds" (the request really is smaller) and the very next turn
+// overflows again, forever. Cap consecutive compactions so the session reports
+// the real problem instead of looping until someone kills it.
+const MAX_CONSECUTIVE_COMPACTIONS = 3
+
 const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
 
 function mcpResourceBase64Size(value: string) {
@@ -1078,11 +1085,46 @@ const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
+    // The breaker's outcome: surface the real problem on the assistant message
+    // instead of continuing to compact. Compaction cannot shrink the system
+    // prompt or the tool set, so repeating it can never help here — the useful
+    // answer is which knob the user has to turn.
+    const giveUpOnCompaction = Effect.fn("SessionPrompt.giveUpOnCompaction")(function* (input: {
+      sessionID: SessionID
+      lastUser: SessionV1.User
+      model: { providerID: ProviderV2.ID; id: ModelV2.ID }
+      ctx: { directory: string; worktree: string }
+    }) {
+      const error = new SessionV1.ContextOverflowError({
+        message: `Compaction failed to bring the request under the provider's limit after ${MAX_CONSECUTIVE_COMPACTIONS} attempts in a row. The system prompt or the tool set alone likely exceeds it, and compaction cannot reduce either — reduce the active tools/agents, or use a model with a larger context window.`,
+      }).toObject()
+      const message: SessionV1.Assistant = {
+        id: MessageID.ascending(),
+        parentID: input.lastUser.id,
+        role: "assistant",
+        mode: input.lastUser.agent,
+        agent: input.lastUser.agent,
+        variant: input.lastUser.model.variant,
+        path: { cwd: input.ctx.directory, root: input.ctx.worktree },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: input.model.id,
+        providerID: input.model.providerID,
+        time: { created: Date.now(), completed: Date.now() },
+        sessionID: input.sessionID,
+        error,
+        finish: "error",
+      }
+      yield* sessions.updateMessage(message)
+      yield* events.publish(Session.Event.Error, { sessionID: input.sessionID, error })
+    })
+
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        let consecutiveCompactions = 0
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1158,14 +1200,26 @@ const layer = Layer.effect(
             continue
           }
 
-          if (
-            lastFinished &&
+          const stillOverflowing =
+            lastFinished !== undefined &&
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
-          ) {
+
+          if (stillOverflowing) {
+            consecutiveCompactions++
+            if (consecutiveCompactions > MAX_CONSECUTIVE_COMPACTIONS) {
+              yield* giveUpOnCompaction({ sessionID, lastUser, model, ctx })
+              break
+            }
             yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
             continue
           }
+
+          // A finished turn that no longer overflows means compaction did its job:
+          // the streak is over. Resetting anywhere else — e.g. on any completed
+          // turn — would defeat the cap in exactly the case it exists for, where
+          // every turn "succeeds" and every turn is still too large.
+          if (lastFinished !== undefined && lastFinished.summary !== true) consecutiveCompactions = 0
 
           const agent = yield* agents.get(lastUser.agent)
           if (!agent) {
@@ -1318,6 +1372,11 @@ const layer = Layer.effect(
 
             if (result === "stop") return "break" as const
             if (result === "compact") {
+              consecutiveCompactions++
+              if (consecutiveCompactions > MAX_CONSECUTIVE_COMPACTIONS) {
+                yield* giveUpOnCompaction({ sessionID, lastUser, model, ctx })
+                return "break" as const
+              }
               yield* compaction.create({
                 sessionID,
                 agent: lastUser.agent,
@@ -1325,6 +1384,7 @@ const layer = Layer.effect(
                 auto: true,
                 overflow: !handle.message.finish,
               })
+              return "continue" as const
             }
             return "continue" as const
           }).pipe(

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -52,7 +52,7 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Format } from "../../src/format"
 import { TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
-import { reply, TestLLMServer } from "../lib/llm-server"
+import { httpError, reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -498,6 +498,100 @@ noLLMServer.instance(
       expect(result.info.id).toBe(assistantID)
     }),
   { config: cfg },
+)
+
+it.instance("loop gives up after repeated auto-compaction instead of looping forever", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+
+    // When what exceeds the provider's window is the SYSTEM PROMPT plus the tool
+    // definitions — not the conversation — compaction can never fix it: it only
+    // trims history. Every compaction "succeeds" (the request really is smaller)
+    // and the very next real turn overflows again, forever.
+    const isCompactionRequest = (hit: { body: Record<string, unknown> }) =>
+      JSON.stringify(hit.body).includes("anchored summary")
+    // The background title() call also hits the mock once and is not a real turn.
+    const isTitleRequest = (hit: { body: Record<string, unknown> }) =>
+      JSON.stringify(hit.body).includes("Generate a title for this conversation")
+    // A real, successful turn that is nevertheless oversized: high token usage
+    // keeps isOverflow() true even though the model answered normally.
+    const oversizedTurn = () =>
+      reply().text("Task completed. No further steps needed.").usage({ input: 95_000, output: 40 }).stop()
+
+    const user = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "user",
+      sessionID: chat.id,
+      agent: "build",
+      model: ref,
+      time: { created: Date.now() },
+    })
+    yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: user.id,
+      sessionID: chat.id,
+      type: "text",
+      text: "say one word",
+    })
+    // Pre-seed an ALREADY-FINISHED oversized assistant reply, so the loop's very
+    // first decision can only come from the preventive isOverflow() check.
+    yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      parentID: user.id,
+      role: "assistant",
+      sessionID: chat.id,
+      mode: "build",
+      agent: "build",
+      path: { cwd: "/", root: "/" },
+      cost: 0,
+      tokens: { input: 95_000, output: 40, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: ref.modelID,
+      providerID: ref.providerID,
+      time: { created: Date.now(), completed: Date.now() },
+      finish: "stop",
+    })
+    // Without a NEWER user message the loop's "nothing left to do" exit fires
+    // first and the preventive check is never reached.
+    const followUp = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "user",
+      sessionID: chat.id,
+      agent: "build",
+      model: ref,
+      time: { created: Date.now() },
+    })
+    yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: followUp.id,
+      sessionID: chat.id,
+      type: "text",
+      text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
+    })
+
+    // Queue more oversized turns than the cap allows: what is measured is how
+    // many the loop TRIES, not whether the queue happens to run out.
+    const many = <A>(n: number, make: () => A) => Array.from({ length: n }, make)
+    yield* llm.pushMatch((hit) => !isCompactionRequest(hit), ...many(8, oversizedTurn))
+    yield* llm.pushMatch(isCompactionRequest, ...many(8, () => reply().text("summary").stop()))
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const hits = yield* llm.hits
+    const realTurnHits = hits.filter((hit) => !isCompactionRequest(hit) && !isTitleRequest(hit))
+
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") {
+      expect(result.info.error?.name).toBe("ContextOverflowError")
+      expect(result.info.finish).toBe("error")
+    }
+    // Bounded, not infinite. Without the cap the loop runs past every queued
+    // oversized reply and ends on the mock's default zero-usage response — a
+    // benign "stop" with no error, which is the worse outcome: the session quietly
+    // stops doing what it was asked instead of saying why it cannot.
+    expect(realTurnHits.length).toBeLessThanOrEqual(5)
+  }),
 )
 
 it.instance("loop exits without an LLM request for interrupted orphan tool calls", () =>


### PR DESCRIPTION
## Body

Compaction can only reduce the **conversation**. When what exceeds the
provider's context window is the fixed overhead — system prompt plus tool
definitions — every compaction genuinely succeeds (the request really is
smaller) and the very next turn overflows again. `isOverflow()` keeps evaluating
true, `compaction.create()` keeps firing, and the loop never terminates.

Observed live: `Build -> "Task completed" -> Compaction -> Build -> "Task
completed" -> Compaction …`, cycling five or more times in about forty-five
seconds, never producing a visible answer.

The failure mode is worse than a visible hang. Once the queue of oversized
replies runs out in a test — or the provider's behaviour shifts slightly in
production — the loop ends on an ordinary small response and finishes with a
benign `stop` and **no error at all**. The session quietly stops doing what it
was asked instead of saying why it cannot.

## The change

A per-run counter of consecutive compactions, capped at 3, on both triggers (the
preventive `isOverflow` check and the reactive mid-stream `result === "compact"`
path). When the cap is exceeded, the assistant message carries a
`ContextOverflowError` naming the actual constraint — the system prompt or the
tool set — and the loop stops.

The counter resets when a finished turn no longer overflows, which is the
precise meaning of "compaction did its job". Resetting on any completed turn
would defeat the cap in exactly the case it exists for, where every turn
succeeds and every turn is still too large.

## Test

`loop gives up after repeated auto-compaction instead of looping forever` seeds
an already-finished oversized reply so the loop's first decision comes from the
preventive check, then queues more oversized turns than the cap allows — so what
is measured is how many the loop *tries*, not whether the queue runs out.

Verified in both directions: against the current code the test fails with
`Expected: "ContextOverflowError" / Received: undefined` — the benign silent
ending described above.
