### PR TITLE
fix(tui): keep original file path when pasting image files

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -12,7 +12,7 @@ import type { CommandContext } from "@opentui/keymap"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import { registerOpencodeSpinner } from "../register-spinner"
 import path from "path"
-import { fileURLToPath } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
 import { useLocal } from "../../context/local"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { tint, useTheme } from "../../context/theme"
@@ -1248,7 +1248,7 @@ export function Prompt(props: PromptProps) {
       type: "file" as const,
       mime: file.mime,
       filename: file.filename,
-      url: `data:${file.mime};base64,${file.content}`,
+      url: file.filepath ? pathToFileURL(file.filepath).href : `data:${file.mime};base64,${file.content}`,
       source: {
         type: "file",
         path: file.filepath ?? file.filename ?? "",


### PR DESCRIPTION
### Issue for this PR

Closes #48190

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an image is pasted from a known file (pasted path text, Finder file copy turned into text by the terminal, drag flows that resolve to a path), `pasteAttachment` inlines the bytes as a `data:` URL. The part's `source.path` keeps the original path but is metadata the model never sees, so it cannot reference the file it was given — it only ends up with the image and a materialized temp path.

The server already handles `file:` URL attachments correctly: `packages/opencode/src/session/prompt.ts` emits a synthetic `Called the Read tool with the following input: {"filePath": ...}` text part next to the image and re-reads the bytes at submit time. The TUI paste flow just never produces `file:` URLs.

This submits a `file://` URL instead of inline base64 when `file.filepath` is known. Clipboard bitmap pastes (screenshot, browser copy) have no filepath and keep the previous inline behavior.

Related PR: #47341 takes a different approach for dropped attachments (injecting `Attached file: <path>` text). This PR covers the pasted-file case by reusing the existing `file:` part path instead.

### How did you verify your code works?

- Reproduced the bug on the current TUI: copy a file in Finder, paste it into the composer, submit, then ask the model for the path — it only has the materialized temp path, never the original.
- The new `file://` part flows into the existing `file:` branch in `session/prompt.ts`, which emits the synthetic `{"filePath": ...}` text part before re-encoding the image, so the model sees the original path.
- Bitmap-only clipboard pastes are unchanged: `filepath` is undefined there, so the `data:` URL branch still applies.
- Not exercised locally end-to-end (no Bun toolchain set up on this machine); CI type checks will cover the rest.

### Screenshots / recordings

Not a visual UI change; the difference is in the submitted message parts.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
