### PR TITLE
fix(core): send reasoning.effort for GPT-5.6+ on Bedrock Converse

### DIFF
--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -210,6 +210,10 @@ function mapBedrockRequest(input: MapInput): Pick<Mapping, "headers" | "body"> {
   const reasoning = isRecord(settings.reasoningConfig) ? settings.reasoningConfig : undefined
   const anthropic = input.modelID.includes("anthropic")
   const openai = input.modelID.includes("openai.")
+  // Converse passes OpenAI fields through verbatim. gpt-oss (Harmony) takes the
+  // flat chat-completions `reasoning_effort`; GPT-5.6+ reject it and take the
+  // Responses-style `reasoning.effort` instead.
+  const harmony = input.modelID.includes("openai.gpt-oss")
   const effort = typeof reasoning?.maxReasoningEffort === "string" ? reasoning.maxReasoningEffort : undefined
   const type = typeof reasoning?.type === "string" ? reasoning.type : undefined
   const budget = typeof reasoning?.budgetTokens === "number" ? reasoning.budgetTokens : undefined
@@ -236,7 +240,10 @@ function mapBedrockRequest(input: MapInput): Pick<Mapping, "headers" | "body"> {
           },
         }
       : {}),
-    ...(!anthropic && openai && effort !== undefined ? { reasoning_effort: effort } : {}),
+    ...(!anthropic && openai && harmony && effort !== undefined ? { reasoning_effort: effort } : {}),
+    ...(!anthropic && openai && !harmony && effort !== undefined
+      ? { reasoning: { ...(isRecord(additional.reasoning) ? additional.reasoning : {}), effort } }
+      : {}),
     ...(!anthropic && !openai && effort !== undefined
       ? {
           reasoningConfig: {

--- a/packages/core/test/aisdk-native.test.ts
+++ b/packages/core/test/aisdk-native.test.ts
@@ -251,11 +251,28 @@ describe("AISDKNative", () => {
       },
     })
 
-    for (const modelID of ["openai.gpt-oss-120b-1:0", "global.openai.gpt-5.6-sol", "us.openai.gpt-5.6-sol"]) {
+    // gpt-oss (Harmony) keeps the flat chat-completions field.
+    expect(
+      map("@ai-sdk/amazon-bedrock", { reasoningConfig: { maxReasoningEffort: "high" } }, "openai.gpt-oss-120b-1:0")
+        ?.body,
+    ).toEqual({ additionalModelRequestFields: { reasoning_effort: "high" } })
+
+    // GPT-5.6+ reject `reasoning_effort` and take the Responses-style nested field.
+    for (const modelID of ["global.openai.gpt-5.6-sol", "us.openai.gpt-5.6-sol", "us.openai.gpt-6-astra"]) {
       expect(
-        map("@ai-sdk/amazon-bedrock", { reasoningConfig: { maxReasoningEffort: "high" } }, modelID)?.body,
-      ).toEqual({ additionalModelRequestFields: { reasoning_effort: "high" } })
+        map("@ai-sdk/amazon-bedrock", { reasoningConfig: { maxReasoningEffort: "none" } }, modelID)?.body,
+      ).toEqual({ additionalModelRequestFields: { reasoning: { effort: "none" } } })
     }
+    expect(
+      map(
+        "@ai-sdk/amazon-bedrock",
+        {
+          reasoningConfig: { maxReasoningEffort: "high" },
+          additionalModelRequestFields: { reasoning: { summary: "auto" } },
+        },
+        "us.openai.gpt-5.6-sol",
+      )?.body,
+    ).toEqual({ additionalModelRequestFields: { reasoning: { summary: "auto", effort: "high" } } })
   })
 
   test("maps Bedrock Mantle models to their supported native APIs", () => {


### PR DESCRIPTION
## Problem

Selecting any thinking level (including `none`) on `us.openai.gpt-5.6-*`, `global.openai.gpt-5.6-*`, or `*.openai.gpt-6-astra` via Bedrock Converse fails with:

```
Unknown parameter: 'reasoning_effort'.
```

We sent `additionalModelRequestFields.reasoning_effort` for every `openai.` model on Converse. That flat chat-completions field is only accepted by the gpt-oss (Harmony) models; GPT-5.6+ take the Responses-style nested `reasoning.effort` instead.

## Fix

`mapBedrockRequest` now sends `reasoning_effort` only for `openai.gpt-oss*` and `reasoning: { effort }` for other OpenAI models, merging with any user-supplied `additionalModelRequestFields.reasoning`.

## Verification

Live against Bedrock `us-east-1` through the real `@opencode/ai` Converse provider (not just raw HTTP):

| `additionalModelRequestFields` | gpt-oss-120b | GPT-5.6 sol/luna | GPT-6 astra |
|---|---|---|---|
| `{ reasoning_effort }` (before) | ✅ | ❌ unknown parameter | ❌ unknown parameter |
| `{ reasoning: { effort } }` (after) | n/a, still sends flat field | ✅ none/low/high/xhigh/max | ✅ low/max (`none` unsupported by model; models.dev already omits it) |

Also verified tool call → tool result → follow-up, and redacted (encrypted) reasoning blocks replaying across steps.

Unit tests updated in `packages/core/test/aisdk-native.test.ts`; `bun typecheck` passes.