### PR TITLE
fix(codemode): label supported and unsupported syntax in the hint

### DIFF
--- a/packages/codemode/src/interpreter/model.ts
+++ b/packages/codemode/src/interpreter/model.ts
@@ -111,7 +111,7 @@ export class InterpreterRuntimeError extends Error {
 
 // Orient the agent rather than enumerate JavaScript; interpreter-support.md is the full matrix.
 export const supportedSyntaxMessage =
-  "Programs run a JavaScript subset for calling tools: plain and async functions, data literals, destructuring, standard control flow, await/Promise, and common built-ins (Array, Object, Math, JSON, Date, RegExp, Map, Set, URL). Classes, this, getters/setters, tagged templates, BigInt, and custom Symbols are unavailable; use plain functions and data objects instead."
+  "This is a restricted JavaScript-like language. Supported: plain and async functions, data literals, destructuring, standard control flow, await and Promise, and built-ins such as Array, Object, Math, JSON, Date, RegExp, Map, Set, and URL. Unsupported: classes, this, getters/setters, tagged templates, BigInt, and custom Symbols. Use plain functions and data objects instead."
 
 export const unsupportedSyntax = (kind: string, node: AstNode): InterpreterRuntimeError =>
   new InterpreterRuntimeError(

--- a/packages/codemode/test/new-expression.test.ts
+++ b/packages/codemode/test/new-expression.test.ts
@@ -70,7 +70,11 @@ describe("new on a non-constructible callee", () => {
   test("classes remain unsupported syntax", async () => {
     const failure = await error(`class A {}; return new A()`)
     expect(failure.kind).toBe("UnsupportedSyntax")
-    expect(failure.message).toStartWith("Syntax 'ClassDeclaration' is not supported. Programs run a JavaScript subset")
-    expect(failure.message).toContain("Classes, this, getters/setters, tagged templates, BigInt, and custom Symbols")
+    expect(failure.message).toStartWith(
+      "Syntax 'ClassDeclaration' is not supported. This is a restricted JavaScript-like language. Supported: ",
+    )
+    expect(failure.message).toContain(
+      "Unsupported: classes, this, getters/setters, tagged templates, BigInt, and custom Symbols.",
+    )
   })
 })


### PR DESCRIPTION
Follow-up to #48083.

The supported-syntax hint attached to `UnsupportedSyntax` diagnostics read as if its feature list was the restricted set:

> Programs run a JavaScript subset for calling tools: plain and async functions, data literals, …

It now labels each list explicitly and keeps the replacement advice as its own sentence:

```
Syntax 'ClassDeclaration' is not supported. This is a restricted JavaScript-like language. Supported: plain and async functions, data literals, destructuring, standard control flow, await and Promise, and built-ins such as Array, Object, Math, JSON, Date, RegExp, Map, Set, and URL. Unsupported: classes, this, getters/setters, tagged templates, BigInt, and custom Symbols. Use plain functions and data objects instead.
```

Wording only; the test in `test/new-expression.test.ts` that pins the hint is updated.