### PR TITLE
docs: update Anthropic provider auth steps

### DIFF
--- a/packages/web/src/content/docs/es/providers.mdx
+++ b/packages/web/src/content/docs/es/providers.mdx
@@ -286,39 +286,34 @@ Para perfiles de inferencia personalizados, utilice el modelo y el nombre del pr
 
 ### Anthropic
 
-1. Una vez que se haya registrado, ejecute el comando `/connect` y seleccione Anthropic.
+1. Después de registrarte, crea una clave API desde la [consola de Anthropic](https://console.anthropic.com/settings/keys).
+
+2. Ejecuta el comando `/connect` y selecciona Anthropic.
 
    ```txt
    /connect
    ```
 
-2. Aquí puedes seleccionar la opción **Claude Pro/Max** y se abrirá tu navegador.
-   y pedirle que se autentique.
+3. Selecciona **Manually enter API Key** y pega tu clave API de Anthropic.
 
    ```txt
    ┌ Select auth method
    │
-   │ Claude Pro/Max
-   │ Create an API Key
    │ Manually enter API Key
    └
    ```
 
-3. Ahora todos los modelos Anthropic deberían estar disponibles cuando use el comando `/models`.
+4. Ahora todos los modelos de Anthropic deberían estar disponibles cuando uses el comando `/models`.
 
    ```txt
    /models
    ```
 
 :::info
-El uso de su suscripción Claude Pro/Max en OpenCode no está oficialmente respaldado por [Anthropic](https://anthropic.com).
+OpenCode usa Anthropic mediante claves API. La autenticación con suscripciones Claude Pro/Max no está soportada.
+
+Las versiones anteriores de OpenCode incluían plugins para Claude Pro/Max, pero Anthropic prohíbe ese uso y los plugins ya no vienen incluidos desde la versión 1.3.0.
 :::
-
-##### Usando las teclas API
-
-También puede seleccionar **Crear una clave API** si no tiene una suscripción Pro/Max. También abrirá su navegador y le pedirá que inicie sesión en Anthropic y le dará un código que puede pegar en su terminal.
-
-O si ya tienes una clave API, puedes seleccionar **Ingresar manualmente la clave API** y pegarla en tu terminal.
 
 ---
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -331,14 +331,15 @@ For custom inference profiles, use the model and provider name in the key and se
 
 ### Anthropic
 
-1. Once you've signed up, run the `/connect` command and select Anthropic.
+1. Once you've signed up, create an API key from the [Anthropic Console](https://console.anthropic.com/settings/keys).
+
+2. Run the `/connect` command and select Anthropic.
 
    ```txt
    /connect
    ```
 
-2. Here you can select the **Claude Pro/Max** option and it'll open your browser
-   and ask you to authenticate.
+3. Select **Manually enter API Key** and paste your Anthropic API key.
 
    ```txt
    ┌ Select auth method
@@ -347,18 +348,18 @@ For custom inference profiles, use the model and provider name in the key and se
    └
    ```
 
-3. Now all the Anthropic models should be available when you use the `/models` command.
+4. Now all the Anthropic models should be available when you use the `/models` command.
 
    ```txt
    /models
    ```
 
 :::info
-There are plugins that allow you to use your Claude Pro/Max models with
-OpenCode. Anthropic explicitly prohibits this.
+OpenCode supports Anthropic through API keys. Claude Pro/Max subscription auth
+is not supported.
 
-Previous versions of OpenCode came bundled with these plugins but that is no
-longer the case as of 1.3.0
+Previous versions of OpenCode bundled plugins for Claude Pro/Max, but Anthropic
+prohibits that usage and the plugins are no longer bundled as of 1.3.0.
 
 Other companies support freedom of choice with developer tooling - you can use
 the following subscriptions in OpenCode with zero setup:


### PR DESCRIPTION
### Issue for this PR

Closes #48207

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the Anthropic provider docs so they match the current auth flow. The English and Spanish pages now point users to create an Anthropic API key, choose "Manually enter API Key" in /connect, and paste the key.

The old text mentioned Claude Pro/Max subscription auth and a "Create an API Key" auth method, but those options are no longer available in the current flow. The note now says Anthropic is supported through API keys and that Claude Pro/Max subscription auth is not supported.

### How did you verify your code works?

- Ran git diff --check HEAD~1..HEAD
- Reviewed the changed English and Spanish docs locally
- Could not run bun run astro check because bun is not available in this environment

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR