### PR TITLE
fix(codemode): name the received value in data diagnostics and document intentional gaps

### DIFF
--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -35,10 +35,7 @@ ultimate source of truth.
       `undefined` are no-ops, while arrays are rejected.
 - [x] Template literals with interpolation.
 - [x] Regular-expression literals.
-- [x] `NaN` and `Infinity` globals. The complete global baseline is `tools`, `search`, `undefined`, `NaN`, `Infinity`,
-      the constructors and namespaces listed in this matrix, `parseInt`/`parseFloat`/`isFinite`/`isNaN`, and the URI
-      helpers. There is no `globalThis`, `window`, `self`, timers, `fetch`, `structuredClone`, `TextEncoder`, `Intl`,
-      `crypto`, or `process`.
+- [x] `NaN` and `Infinity` globals.
 - [ ] BigInt literals and in-interpreter BigInt arithmetic; BigInt remains invalid at JSON-like host boundaries.
 - [ ] Arbitrary Symbol primitive values and symbol-keyed properties. The confined `Symbol.iterator` and
       `Symbol.asyncIterator` keys are available only for custom iterator protocols.
@@ -216,14 +213,8 @@ ultimate source of truth.
       synchronous iterator support for `fromEntries`.
 - [x] `Object.keys` over arrays and tool references.
 - [x] Object identity is preserved by in-CodeMode Object helpers.
-- [x] Prototype traversal and mutation through `__proto__`, `constructor`, and `prototype` are blocked. Reading them on
-      any value, including globals such as `Object.prototype`, throws rather than reading as `undefined`; every other
-      unknown static member follows the feature-detection rule below.
-- [x] Circular references are rejected when they would be created (`o.self = o`, `array.push(array)`,
-      `Object.assign(o, { o })`), not at serialization as in JS. Values stay acyclic so every boundary walk terminates.
-- [x] Diagnostics for a non-data argument name what was received (`Object.keys expects a data object or array,
-    received a string.`), distinguishing strings, arrays, un-awaited Promises, tool references, functions, and the
-      built-in value kinds.
+- [x] Prototype traversal and mutation through `__proto__`, `constructor`, and `prototype` are blocked.
+- [x] Circular references are rejected when created (`o.self = o`, `array.push(array)`), not at serialization as in JS.
 - [ ] Legal own data fields named `__proto__`, `constructor`, or `prototype` are rejected at JSON/tool boundaries and
       cannot be created, read, or written in CodeMode; tool path segments with those names remain supported.
 - [x] `Object.is` for supported data values.

--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -35,7 +35,10 @@ ultimate source of truth.
       `undefined` are no-ops, while arrays are rejected.
 - [x] Template literals with interpolation.
 - [x] Regular-expression literals.
-- [x] `NaN` and `Infinity` globals.
+- [x] `NaN` and `Infinity` globals. The complete global baseline is `tools`, `search`, `undefined`, `NaN`, `Infinity`,
+      the constructors and namespaces listed in this matrix, `parseInt`/`parseFloat`/`isFinite`/`isNaN`, and the URI
+      helpers. There is no `globalThis`, `window`, `self`, timers, `fetch`, `structuredClone`, `TextEncoder`, `Intl`,
+      `crypto`, or `process`.
 - [ ] BigInt literals and in-interpreter BigInt arithmetic; BigInt remains invalid at JSON-like host boundaries.
 - [ ] Arbitrary Symbol primitive values and symbol-keyed properties. The confined `Symbol.iterator` and
       `Symbol.asyncIterator` keys are available only for custom iterator protocols.
@@ -213,7 +216,14 @@ ultimate source of truth.
       synchronous iterator support for `fromEntries`.
 - [x] `Object.keys` over arrays and tool references.
 - [x] Object identity is preserved by in-CodeMode Object helpers.
-- [x] Prototype traversal and mutation through `__proto__`, `constructor`, and `prototype` are blocked.
+- [x] Prototype traversal and mutation through `__proto__`, `constructor`, and `prototype` are blocked. Reading them on
+      any value, including globals such as `Object.prototype`, throws rather than reading as `undefined`; every other
+      unknown static member follows the feature-detection rule below.
+- [x] Circular references are rejected when they would be created (`o.self = o`, `array.push(array)`,
+      `Object.assign(o, { o })`), not at serialization as in JS. Values stay acyclic so every boundary walk terminates.
+- [x] Diagnostics for a non-data argument name what was received (`Object.keys expects a data object or array,
+    received a string.`), distinguishing strings, arrays, un-awaited Promises, tool references, functions, and the
+      built-in value kinds.
 - [ ] Legal own data fields named `__proto__`, `constructor`, or `prototype` are rejected at JSON/tool boundaries and
       cannot be created, read, or written in CodeMode; tool path segments with those names remain supported.
 - [x] `Object.is` for supported data values.
@@ -364,7 +374,8 @@ ultimate source of truth.
       or without `new`.
 - [x] `AggregateError` with the `(errors, message?)` signature and an own `errors` array, constructed directly or by
       an all-rejected `Promise.any`; direct construction accepts custom synchronous iterators and generators.
-- [x] Error `name`/`message`, error inheritance through `instanceof`, and plain-data serialization.
+- [x] Error `name`/`message`, error inheritance through `instanceof`, and plain-data serialization. Errors have no
+      `stack`; the diagnostic carries the source location instead.
 - [x] `instanceof` for Date, RegExp, Map, Set, URL, URLSearchParams, Array, Object, Promise, and Error types.
 - [x] Catchable user throws, runtime failures raised during interpreted evaluation, awaited tool failures, and awaited
       tool-call-limit failures; parse/compile failures, cooperative timeout, and output bounding remain outside program

--- a/packages/codemode/src/interpreter/references.ts
+++ b/packages/codemode/src/interpreter/references.ts
@@ -77,7 +77,6 @@ export const rejectCircularInsertion = (
   }
 }
 
-/** Names a value for diagnostics: what the program actually passed where data was expected. */
 export const describeValue = (value: unknown): string => {
   if (value === null) return "null"
   if (Array.isArray(value)) return "an array"

--- a/packages/codemode/src/interpreter/references.ts
+++ b/packages/codemode/src/interpreter/references.ts
@@ -77,6 +77,24 @@ export const rejectCircularInsertion = (
   }
 }
 
+/** Names a value for diagnostics: what the program actually passed where data was expected. */
+export const describeValue = (value: unknown): string => {
+  if (value === null) return "null"
+  if (Array.isArray(value)) return "an array"
+  if (value instanceof Values.Promise) return "an un-awaited Promise"
+  if (value instanceof ToolReference) return "a tool reference"
+  if (value instanceof Values.Date) return "a Date"
+  if (value instanceof Values.RegExp) return "a RegExp"
+  if (value instanceof Values.Map) return "a Map"
+  if (value instanceof Values.Set) return "a Set"
+  if (value instanceof Values.URL) return "a URL"
+  if (value instanceof Values.URLSearchParams) return "a URLSearchParams"
+  if (value instanceof CodeModeGenerator) return "a generator"
+  if (isRuntimeReference(value)) return "a function"
+  if (typeof value === "object") return "a data object"
+  return `a ${typeof value}`
+}
+
 export const typeofValue = (value: unknown): string => {
   if (
     value instanceof HostFunction ||

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -71,7 +71,13 @@ import { HostFunction, HostNamespace } from "./host.js"
 import { invokeIntrinsic } from "./methods.js"
 import { preserveConsumerError, type Runner } from "./runner.js"
 import { invokePromiseInstanceMethod, PromiseRuntime, resolvePromise, resolvePromiseValue } from "./promises.js"
-import { containsOpaqueReference, isRuntimeReference, rejectCircularInsertion, typeofValue } from "./references.js"
+import {
+  containsOpaqueReference,
+  describeValue,
+  isRuntimeReference,
+  rejectCircularInsertion,
+  typeofValue,
+} from "./references.js"
 import { ScopeStack } from "./scope.js"
 import { arrayMethods, mapMethods, setMethods } from "../stdlib/collections.js"
 import { dateMethods } from "../stdlib/date.js"
@@ -1025,7 +1031,7 @@ class Frame<R> {
       if (pattern.type === "ObjectPattern") {
         if (value === null || typeof value !== "object" || isRuntimeReference(value)) {
           throw new InterpreterRuntimeError(
-            "Object destructuring requires a data object or array value.",
+            `Object destructuring requires a data object or array value, received ${describeValue(value)}.`,
             pattern,
             "InvalidDataValue",
           )
@@ -1091,7 +1097,7 @@ class Frame<R> {
       if (pattern.type === "ObjectPattern") {
         if (value === null || typeof value !== "object" || isRuntimeReference(value)) {
           throw new InterpreterRuntimeError(
-            "Object destructuring requires a data object or array value.",
+            `Object destructuring requires a data object or array value, received ${describeValue(value)}.`,
             pattern,
             "InvalidDataValue",
           )
@@ -1896,7 +1902,11 @@ class Frame<R> {
           const spread = yield* self.evaluateExpression(property.argument)
           if (spread === null || spread === undefined || Values.isValue(spread)) continue
           if (typeof spread !== "object" || Array.isArray(spread) || isRuntimeReference(spread)) {
-            throw new InterpreterRuntimeError("Object spread requires a data object.", property, "InvalidDataValue")
+            throw new InterpreterRuntimeError(
+              `Object spread requires a data object, received ${describeValue(spread)}.`,
+              property,
+              "InvalidDataValue",
+            )
           }
           for (const [key, value] of Object.entries(spread)) {
             if (isBlockedMember(key)) throw new InterpreterRuntimeError(`Property '${key}' is not available.`, property)
@@ -2126,7 +2136,7 @@ class Frame<R> {
 
       if (isRuntimeReference(objectValue)) {
         throw new InterpreterRuntimeError(
-          "Runtime references are opaque and do not expose properties.",
+          `Cannot read properties of ${describeValue(objectValue)}; only data values expose properties.`,
           objectNode,
           "InvalidDataValue",
         )

--- a/packages/codemode/src/stdlib/array.ts
+++ b/packages/codemode/src/stdlib/array.ts
@@ -1,8 +1,8 @@
 import { Effect } from "effect"
 import { HostFunction, sync, syncCall } from "../interpreter/host.js"
 import { type AstNode, CodeModeGenerator, InterpreterRuntimeError } from "../interpreter/model.js"
+import { describeValue } from "../interpreter/references.js"
 import { applyCollectionCallback, preserveConsumerError, type Runner } from "../interpreter/runner.js"
-import { Values } from "../values.js"
 
 const constructArray = (args: Array<unknown>, node: AstNode): Array<unknown> => {
   if (args.length !== 1) return [...args]
@@ -16,13 +16,6 @@ const constructArray = (args: Array<unknown>, node: AstNode): Array<unknown> => 
 }
 
 const arrayLikeSource = (source: unknown, node: AstNode): { readonly length: number; readonly source: object } => {
-  if (source instanceof Values.Promise) {
-    throw new InterpreterRuntimeError(
-      "Array.from received an un-awaited Promise; await it before creating the array.",
-      node,
-      "InvalidDataValue",
-    )
-  }
   if (
     source !== null &&
     typeof source === "object" &&
@@ -35,7 +28,7 @@ const arrayLikeSource = (source: unknown, node: AstNode): { readonly length: num
     return { length: normalized, source }
   }
   throw new InterpreterRuntimeError(
-    "Array.from expects an array, string, Map, Set, or array-like value.",
+    `Array.from expects an array, string, Map, Set, or array-like value, received ${describeValue(source)}.`,
     node,
     "InvalidDataValue",
   )

--- a/packages/codemode/src/stdlib/collections.ts
+++ b/packages/codemode/src/stdlib/collections.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import { isBlockedMember, type SafeObject } from "../data.js"
 import { HostFunction, requiresNew } from "../interpreter/host.js"
 import { type AstNode, InterpreterRuntimeError, isRecord } from "../interpreter/model.js"
-import { isRuntimeReference } from "../interpreter/references.js"
+import { describeValue, isRuntimeReference } from "../interpreter/references.js"
 import { applyCollectionCallback, preserveConsumerError, type Runner, toPrimitive } from "../interpreter/runner.js"
 import { Values } from "../values.js"
 import { coerceToString } from "./value.js"
@@ -73,7 +73,11 @@ const coerceGroupByPropertyKey = <R>(
 ): Effect.Effect<string, unknown, R> => {
   if (value instanceof Values.Promise) return Effect.succeed("[object Promise]")
   if (!Values.isValue(value) && isRuntimeReference(value)) {
-    throw new InterpreterRuntimeError("Object.groupBy callback must return a data value.", node, "InvalidDataValue")
+    throw new InterpreterRuntimeError(
+      `Object.groupBy callback must return a data value, received ${describeValue(value)}.`,
+      node,
+      "InvalidDataValue",
+    )
   }
   return Effect.map(toPrimitive(runner, value, "string", node), coerceToString)
 }

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -2,7 +2,12 @@ import { Effect } from "effect"
 import { isBlockedMember, toProgram } from "../data.js"
 import { HostFunction, sync, syncCall } from "../interpreter/host.js"
 import { type AstNode, AsyncIteratorSymbol, InterpreterRuntimeError, IteratorSymbol } from "../interpreter/model.js"
-import { containsOpaqueReference, rejectCircularInsertion, typeofValue } from "../interpreter/references.js"
+import {
+  containsOpaqueReference,
+  describeValue,
+  rejectCircularInsertion,
+  typeofValue,
+} from "../interpreter/references.js"
 import { preserveConsumerError, type Runner } from "../interpreter/runner.js"
 import { ToolReference } from "../tool-runtime.js"
 import { Values } from "../values.js"
@@ -12,19 +17,13 @@ import { coerceToString } from "./value.js"
 const requireObject = (name: string, input: unknown, node: AstNode): Record<string, unknown> => {
   if (Array.isArray(input)) return input as unknown as Record<string, unknown>
   if (Values.isValue(input)) return {}
-  if (input instanceof Values.Promise) {
+  const prototype = input === null || typeof input !== "object" ? undefined : Object.getPrototypeOf(input)
+  if (prototype !== null && prototype !== Object.prototype) {
     throw new InterpreterRuntimeError(
-      `Object.${name} received an un-awaited Promise; await it before inspecting the result.`,
+      `Object.${name} expects a data object or array, received ${describeValue(input)}.`,
       node,
       "InvalidDataValue",
     )
-  }
-  if (input === null || typeof input !== "object") {
-    throw new InterpreterRuntimeError(`Object.${name} expects a data object or array.`, node, "InvalidDataValue")
-  }
-  const prototype = Object.getPrototypeOf(input)
-  if (prototype !== null && prototype !== Object.prototype) {
-    throw new InterpreterRuntimeError(`Object.${name} expects a data object or array.`, node, "InvalidDataValue")
   }
   return input as Record<string, unknown>
 }

--- a/packages/codemode/test/enumeration.test.ts
+++ b/packages/codemode/test/enumeration.test.ts
@@ -85,9 +85,22 @@ describe("Object.keys over arrays", () => {
     expect(await value(`return Object.keys({ a: 1, b: 2 })`)).toEqual(["a", "b"])
   })
 
-  test("non-object inputs still fail clearly", async () => {
-    const failure = await error(`return Object.keys("nope")`)
-    expect(failure.message).toContain("Object.keys expects a data object or array")
+  test("non-object inputs name what was received", async () => {
+    expect((await error(`return Object.keys("nope")`)).message).toContain(
+      "Object.keys expects a data object or array, received a string.",
+    )
+    expect((await error(`return Object.entries(42)`)).message).toContain("received a number.")
+    expect((await error(`return Object.values(null)`)).message).toContain("received null.")
+    expect((await error(`return Object.keys(tools.github.list_issues({ value: "x" }))`)).message).toContain(
+      "received an un-awaited Promise.",
+    )
+    expect((await error(`return Object.entries(() => 1)`)).message).toContain("received a function.")
+    expect((await error(`return { ...[1] }`)).message).toContain(
+      "Object spread requires a data object, received an array.",
+    )
+    expect((await error(`const { a } = new Map(); return a`)).message).toContain("received a Map.")
+    expect((await error(`return Array.from(7)`)).message).toContain("received a number.")
+    expect((await error(`return (() => 1).x`)).message).toContain("Cannot read properties of a function")
   })
 })
 


### PR DESCRIPTION
## Summary

Closes out the CodeMode `execute` investigation (P0 diagnostics side, P2, P3). P1 and the `new` diagnostic landed in #48083/#48200; the core-side MCP JSON handling is parked.

### Diagnostics say what they received

Every `InvalidDataValue` message said what was *expected* ("a data object or array") but never what the program actually passed, so an agent holding a JSON string, an un-awaited Promise, or a tool reference saw the same text and could not self-correct. One `describeValue(value)` in `references.ts` names the value from the interpreter's closed set of kinds, and the single-value rejection sites append it:

```text
Object.keys("…")                 Object.keys expects a data object or array, received a string.
Object.keys(tools.x.y(...))      … received an un-awaited Promise.
{ ...[1] }                       Object spread requires a data object, received an array.
const { a } = new Map()          Object destructuring requires a data object or array value, received a Map.
Array.from(7)                    Array.from expects an array, string, Map, Set, or array-like value, received a number.
(() => 1).x                      Cannot read properties of a function; only data values expose properties.
```

The bespoke "received an un-awaited Promise; await it before …" branches in `requireObject` and `arrayLikeSource` fold into the same helper. Sites that reject a value *nested* inside a data object (`containsOpaqueReference`) are unchanged, since naming the outer value would mislead.

### `interpreter-support.md`

Two rows for language state that differs from JS and was unstated: cycles are rejected at insertion, not serialization; errors have no `stack`.

## Test plan

- [x] `bun typecheck`
- [x] `bun test` — 1148 pass; `enumeration.test.ts` pins one message per value kind