### PR TITLE
feat(app): rtl header for Hebrew and Arabic systems

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -171,6 +171,7 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
   return (
     <header
       data-slot={useV2Titlebar() ? "titlebar-v2" : undefined}
+      dir={language.systemDirection()}
       classList={{
         "shrink-0 relative flex flex-row": true,
         "h-9 bg-v2-background-bg-deep overflow-visible": useV2Titlebar(),
@@ -183,8 +184,11 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
         "padding-left": macTrafficLights() ? `${macTrafficLightsBaseWidth / zoom()}px` : 0,
         width: windows() ? `env(titlebar-area-width, calc(100vw - ${windowsControlsWidth()}))` : undefined,
         "max-width": windows() ? `env(titlebar-area-width, calc(100vw - ${windowsControlsWidth()}))` : undefined,
-        // Native Windows caption controls remain on the physical right in both writing directions.
-        "margin-right": windows() ? "auto" : undefined,
+        // The native Windows caption buttons sit on the left in RTL system languages
+        // and on the right in LTR ones. The header reserves space on that side.
+        // Its direction follows the OS language only, never the UI language or content.
+        "margin-right": windows() && language.systemDirection() === "ltr" ? "auto" : undefined,
+        "margin-left": windows() && language.systemDirection() === "rtl" ? "auto" : undefined,
       }}
       data-tauri-drag-region
     >

--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -9,6 +9,7 @@ import { dict as uiEn } from "@opencode-ai/ui/i18n/en"
 import {
   createDesktopNativeBundle,
   detectDesktopNativeLocale,
+  systemPrefersRtl,
   DESKTOP_NATIVE_ENGLISH,
   DESKTOP_NATIVE_LABELS,
   DESKTOP_NATIVE_LOCALES,
@@ -24,6 +25,13 @@ const RTL_LOCALES: ReadonlySet<Locale> = new Set(["ar", "ur", "pa", "fa", "dv"])
 
 function localeDirection(locale: Locale): Direction {
   return RTL_LOCALES.has(locale) ? "rtl" : "ltr"
+}
+
+function systemLanguages(): readonly string[] {
+  if (typeof navigator !== "object") return []
+  if (navigator.languages?.length) return navigator.languages
+  if (typeof navigator.language === "string") return [navigator.language]
+  return []
 }
 
 type RawDictionary = typeof en & typeof uiEn
@@ -179,6 +187,12 @@ export const { use: useLanguage, provider: LanguageProvider } = createSimpleCont
     const intl = createMemo(() => INTL[locale()])
     const [layout, setLayout] = createStore({ direction: undefined as Direction | undefined })
     const direction = createMemo(() => layout.direction ?? localeDirection(locale()))
+    // Native window chrome (caption buttons) follows the OS language, never the UI
+    // language or conversation content. Only the header consumes this.
+    // In Electron `navigator.languages` reflects the OS language.
+    const systemDirection = createMemo<Direction>(() =>
+      systemPrefersRtl(systemLanguages()) ? "rtl" : "ltr",
+    )
     const layoutLocale = createMemo(() => {
       if (!layout.direction) return intl()
       // Kobalte derives menu direction from locale rather than accepting a direction override.
@@ -226,6 +240,7 @@ export const { use: useLanguage, provider: LanguageProvider } = createSimpleCont
       locale,
       intl,
       direction,
+      systemDirection,
       layoutLocale,
       locales: LOCALES,
       label,

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "ብርሃን",
   "theme.scheme.dark": "ጨለማ",
   "command.sidebar.toggle": "የጎን አሞሌን ቀይር",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "ክፍት ፕሮጀክት",
   "command.project.previous": "የቀድሞው ፕሮጀክት",
   "command.project.next": "ቀጣይ ፕሮጀክት",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -119,6 +119,7 @@ export const dict = {
   "theme.scheme.light": "فاتح",
   "theme.scheme.dark": "داكن",
   "command.sidebar.toggle": "تبديل الشريط الجانبي",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "فتح مشروع",
   "command.project.previous": "المشروع السابق",
   "command.project.next": "المشروع التالي",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "Açıq",
   "theme.scheme.dark": "Tünd",
   "command.sidebar.toggle": "Yan paneli aç/bağla",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Layihəni aç",
   "command.project.previous": "Əvvəlki layihə",
   "command.project.next": "Növbəti layihə",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "светлина",
   "theme.scheme.dark": "Тъмно",
   "command.sidebar.toggle": "Превключване на страничната лента",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Отворен проект",
   "command.project.previous": "Предишен проект",
   "command.project.next": "Следващ проект",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -114,6 +114,7 @@ export const dict: Record<string, string> = {
   "theme.scheme.light": "আলো",
   "theme.scheme.dark": "অন্ধকার",
   "command.sidebar.toggle": "সাইডবার টগল করুন",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "প্রকল্প খুলুন",
   "command.project.previous": "আগের প্রকল্প",
   "command.project.next": "পরবর্তী প্রকল্প",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -121,6 +121,7 @@ export const dict = {
   "theme.scheme.light": "Claro",
   "theme.scheme.dark": "Escuro",
   "command.sidebar.toggle": "Alternar barra lateral",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Abrir projeto",
   "command.project.previous": "Projeto anterior",
   "command.project.next": "Próximo projeto",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -123,6 +123,7 @@ export const dict = {
   "theme.scheme.dark": "Tamno",
 
   "command.sidebar.toggle": "Prikaži/sakrij bočnu traku",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Otvori projekat",
   "command.project.previous": "Prethodni projekat",
   "command.project.next": "Sljedeći projekat",

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "Llum",
   "theme.scheme.dark": "Fosc",
   "command.sidebar.toggle": "Canvia la barra lateral",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Projecte obert",
   "command.project.previous": "Projecte anterior",
   "command.project.next": "Projecte següent",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Světlo",
   "theme.scheme.dark": "Tmavý",
   "command.sidebar.toggle": "Přepnout postranní panel",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Otevřete projekt",
   "command.project.previous": "Předchozí projekt",
   "command.project.next": "Další projekt",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -22,6 +22,7 @@ export const dict = {
   "theme.scheme.dark": "Mørk",
 
   "command.sidebar.toggle": "Skift sidebjælke",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Åbn projekt",
   "command.project.previous": "Forrige projekt",
   "command.project.next": "Næste projekt",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -24,6 +24,7 @@ export const dict = {
   "theme.scheme.light": "Hell",
   "theme.scheme.dark": "Dunkel",
   "command.sidebar.toggle": "Seitenleiste umschalten",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Projekt öffnen",
   "command.project.previous": "Vorheriges Projekt",
   "command.project.next": "Nächstes Projekt",

--- a/packages/app/src/i18n/desktop-native.test.ts
+++ b/packages/app/src/i18n/desktop-native.test.ts
@@ -7,6 +7,7 @@ import {
   DESKTOP_NATIVE_LOCALES,
   DESKTOP_NATIVE_LOCALE_TAGS,
   detectDesktopNativeLocale,
+  systemPrefersRtl,
   DESKTOP_NATIVE_MAX_PAYLOAD_BYTES,
   formatDesktopNativeMessage,
   parseDesktopNativeBundle,
@@ -132,6 +133,37 @@ describe("desktop native locale detection", () => {
     expect(detectDesktopNativeLocale(["no"])).toBe("no")
     expect(detectDesktopNativeLocale(["nb-NO"])).toBe("no")
     expect(detectDesktopNativeLocale(["nn-NO"])).toBe("no")
+  })
+
+  test("Hebrew system language falls back to English UI", () => {
+    expect(detectDesktopNativeLocale(["he-IL"])).toBe("en")
+    expect(detectDesktopNativeLocale(["iw-IL", "en"])).toBe("en")
+  })
+})
+
+describe("system RTL detection", () => {
+  test("Hebrew and Arabic systems prefer RTL", () => {
+    expect(systemPrefersRtl(["he-IL"])).toBe(true)
+    expect(systemPrefersRtl(["he"])).toBe(true)
+    expect(systemPrefersRtl(["iw-IL"])).toBe(true)
+    expect(systemPrefersRtl(["ar-EG"])).toBe(true)
+    expect(systemPrefersRtl(["ar"])).toBe(true)
+    expect(systemPrefersRtl(["fa-IR"])).toBe(true)
+    expect(systemPrefersRtl(["ur-PK"])).toBe(true)
+  })
+
+  test("LTR systems do not prefer RTL", () => {
+    expect(systemPrefersRtl(["en-US"])).toBe(false)
+    expect(systemPrefersRtl(["fr-FR"])).toBe(false)
+    expect(systemPrefersRtl(["de-DE", "en"])).toBe(false)
+    expect(systemPrefersRtl([])).toBe(false)
+  })
+
+  test("follows preference order and normalizes tags", () => {
+    expect(systemPrefersRtl(["en-US", "he-IL"])).toBe(true)
+    expect(systemPrefersRtl(["HE-il"])).toBe(true)
+    expect(systemPrefersRtl(["he_IL"])).toBe(true)
+    expect(systemPrefersRtl(["not_a_locale"])).toBe(false)
   })
 })
 

--- a/packages/app/src/i18n/desktop-native.ts
+++ b/packages/app/src/i18n/desktop-native.ts
@@ -209,6 +209,19 @@ export function detectDesktopNativeLocale(languages: readonly string[]): Desktop
   return "en"
 }
 
+// System (OS) languages implying RTL layout even when the UI locale falls back to English.
+// Hebrew has no UI bundle yet, so a Hebrew system would otherwise render LTR.
+// `iw` is the legacy ISO code for Hebrew still seen in navigator.languages.
+// `pa` is intentionally excluded: only Shahmukhi (Arab script) is RTL, Gurmukhi is LTR.
+const RTL_LANGUAGE_CODES: ReadonlySet<string> = new Set(["ar", "he", "iw", "fa", "ur", "dv", "yi", "ps"])
+
+export function systemPrefersRtl(languages: readonly string[]): boolean {
+  return languages.some((tag) => {
+    const code = tag.split(/[-_]/)[0]?.toLowerCase()
+    return code !== undefined && RTL_LANGUAGE_CODES.has(code)
+  })
+}
+
 export function desktopNativePluralCategories(locale: DesktopNativeLocale) {
   return new Intl.PluralRules(DESKTOP_NATIVE_LOCALE_TAGS[locale]).resolvedOptions().pluralCategories
 }

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -116,6 +116,7 @@ export const dict = {
   "theme.scheme.light": "އަލި",
   "theme.scheme.dark": "އަނދިރި",
   "command.sidebar.toggle": "ސައިޑްބާ ޓޮގްލް ކުރާށެވެ",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "އޯޕަން ޕްރޮޖެކްޓް",
   "command.project.previous": "ކުރީގެ މަޝްރޫޢު",
   "command.project.next": "ދެން އޮތް މަޝްރޫޢެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -116,6 +116,7 @@ export const dict: Record<string, string> = {
   "theme.scheme.light": "ཡང་འཕྲོས་འཕྲོས",
   "theme.scheme.dark": "གནག་དུང་དུ",
   "command.sidebar.toggle": "ཟུར་ཁའི་ཕྲ་རིང་སོར་སྟོན་འབད།",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "ལས་གཞི་ཁ་ཕྱེ།",
   "command.project.previous": "ལས་གཞི་སྔོན་མ།",
   "command.project.next": "ལས་གཞི་རྗེས་མ།",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Φωτεινό",
   "theme.scheme.dark": "Σκούρο",
   "command.sidebar.toggle": "Εναλλαγή πλαϊνής γραμμής",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Άνοιγμα έργου",
   "command.project.previous": "Προηγούμενο έργο",
   "command.project.next": "Επόμενο έργο",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -26,6 +26,7 @@ export const dict = {
   "theme.scheme.dark": "Dark",
 
   "command.sidebar.toggle": "Toggle sidebar",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Open project",
   "command.project.previous": "Previous project",
   "command.project.next": "Next project",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -123,6 +123,7 @@ export const dict = {
   "theme.scheme.dark": "Oscuro",
 
   "command.sidebar.toggle": "Mostrar u ocultar barra lateral",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Abrir proyecto",
   "command.project.previous": "Proyecto anterior",
   "command.project.next": "Siguiente proyecto",

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Valgus",
   "theme.scheme.dark": "Tume",
   "command.sidebar.toggle": "Lülita külgriba sisse",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Avatud projekt",
   "command.project.previous": "Eelmine projekt",
   "command.project.next": "Järgmine projekt",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "نور",
   "theme.scheme.dark": "تاریک",
   "command.sidebar.toggle": "نوار کناری را تغییر دهید",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "پروژه را باز کنید",
   "command.project.previous": "پروژه قبلی",
   "command.project.next": "پروژه بعدی",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -20,6 +20,7 @@ export const dict = {
   "theme.scheme.light": "Vaalea",
   "theme.scheme.dark": "Tumma",
   "command.sidebar.toggle": "Näytä tai piilota sivupalkki",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Avaa projekti",
   "command.project.previous": "Edellinen projekti",
   "command.project.next": "Seuraava projekti",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Ljós",
   "theme.scheme.dark": "Myrkt",
   "command.sidebar.toggle": "Skift síðulinjuna",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Opin verkætlan",
   "command.project.previous": "Fyrra verkætlan",
   "command.project.next": "Næsta verkætlan",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -121,6 +121,7 @@ export const dict = {
   "theme.scheme.light": "Clair",
   "theme.scheme.dark": "Sombre",
   "command.sidebar.toggle": "Basculer la barre latérale",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Ouvrir un projet",
   "command.project.previous": "Projet précédent",
   "command.project.next": "Projet suivant",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -120,6 +120,7 @@ export const dict = {
   "theme.scheme.light": "हल्की",
   "theme.scheme.dark": "गहरी",
   "command.sidebar.toggle": "साइडबार टॉगल करें",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "प्रोजेक्ट खोलें",
   "command.project.previous": "पिछला प्रोजेक्ट",
   "command.project.next": "अगला प्रोजेक्ट",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -117,6 +117,7 @@ export const dict = {
   "theme.scheme.light": "Svijetlo",
   "theme.scheme.dark": "Tamno",
   "command.sidebar.toggle": "Uključi/isključi bočnu traku",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Otvori projekt",
   "command.project.previous": "Prethodni projekt",
   "command.project.next": "Sljedeći projekt",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -117,6 +117,7 @@ export const dict = {
   "theme.scheme.light": "Világos",
   "theme.scheme.dark": "Sötét",
   "command.sidebar.toggle": "Oldalsáv váltása",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Projekt megnyitása",
   "command.project.previous": "Előző projekt",
   "command.project.next": "Következő projekt",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "Բաց",
   "theme.scheme.dark": "Մուգ",
   "command.sidebar.toggle": "Փոխարկել կողագոտին",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Բացել նախագիծ",
   "command.project.previous": "Նախորդ նախագիծ",
   "command.project.next": "Հաջորդ նախագիծ",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -123,6 +123,7 @@ export const dict = {
   "theme.scheme.dark": "Gelap",
 
   "command.sidebar.toggle": "Alihkan panel samping",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Buka proyek",
   "command.project.previous": "Proyek sebelumnya",
   "command.project.next": "Proyek berikutnya",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -117,6 +117,7 @@ export const dict = {
   "theme.scheme.light": "Ljóst",
   "theme.scheme.dark": "Dökkt",
   "command.sidebar.toggle": "Skiptu um hliðarstiku",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Opna verkefni",
   "command.project.previous": "Fyrra verkefni",
   "command.project.next": "Næsta verkefni",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -21,6 +21,7 @@ export const dict = {
   "theme.scheme.light": "Chiaro",
   "theme.scheme.dark": "Scuro",
   "command.sidebar.toggle": "Mostra o nascondi la barra laterale",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Apri progetto",
   "command.project.previous": "Progetto precedente",
   "command.project.next": "Progetto successivo",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -119,6 +119,7 @@ export const dict = {
   "theme.scheme.light": "ライト",
   "theme.scheme.dark": "ダーク",
   "command.sidebar.toggle": "サイドバーの切り替え",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "プロジェクトを開く",
   "command.project.previous": "前のプロジェクト",
   "command.project.next": "次のプロジェクト",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "ღია",
   "theme.scheme.dark": "მუქი",
   "command.sidebar.toggle": "გვერდითი ზოლის გადართვა",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "გახსნა პროექტი",
   "command.project.previous": "წინა პროექტი",
   "command.project.next": "შემდეგი პროექტი",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "ពន្លឺ",
   "theme.scheme.dark": "ងងឹត",
   "command.sidebar.toggle": "បិទ/បើករបារចំហៀង",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "គម្រោងបើក",
   "command.project.previous": "គម្រោងមុន។",
   "command.project.next": "គម្រោងបន្ទាប់",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -20,6 +20,7 @@ export const dict = {
   "theme.scheme.light": "라이트",
   "theme.scheme.dark": "다크",
   "command.sidebar.toggle": "사이드바 표시/숨기기",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "프로젝트 열기",
   "command.provider.connect": "공급자 연결",
   "command.server.switch": "서버 전환",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "ແສງສະຫວ່າງ",
   "theme.scheme.dark": "ມືດ",
   "command.sidebar.toggle": "ສະຫຼັບແຖບດ້ານຂ້າງ",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "ເປີດໂຄງການ",
   "command.project.previous": "ໂຄງການທີ່ຜ່ານມາ",
   "command.project.next": "ໂຄງການຕໍ່ໄປ",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -117,6 +117,7 @@ export const dict = {
   "theme.scheme.light": "Šviesi",
   "theme.scheme.dark": "Tamsi",
   "command.sidebar.toggle": "Perjungti šoninę juostą",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Atidaryti projektą",
   "command.project.previous": "Ankstesnis projektas",
   "command.project.next": "Kitas projektas",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Gaišs",
   "theme.scheme.dark": "Tumšs",
   "command.sidebar.toggle": "Pārslēgt sānjoslu",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Atvērt projektu",
   "command.project.previous": "Iepriekšējais projekts",
   "command.project.next": "Nākamais projekts",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Светлина",
   "theme.scheme.dark": "Темно",
   "command.sidebar.toggle": "Вклучете ја страничната лента",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Отворен проект",
   "command.project.previous": "Претходен проект",
   "command.project.next": "Следен проект",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "Гэрэл",
   "theme.scheme.dark": "Харанхуй",
   "command.sidebar.toggle": "Хажуугийн самбарыг сэлгэх",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Нээлттэй төсөл",
   "command.project.previous": "Өмнөх төсөл",
   "command.project.next": "Дараагийн төсөл",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Cerah",
   "theme.scheme.dark": "Gelap",
   "command.sidebar.toggle": "Togol bar sisi",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Buka projek",
   "command.project.previous": "Projek sebelum",
   "command.project.next": "Projek seterusnya",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "အလင်း",
   "theme.scheme.dark": "အမှောင်",
   "command.sidebar.toggle": "ဘေးဘားကို ပြောင်းရန်",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "ပရောဂျက်ကို ဖွင့်ပါ။",
   "command.project.previous": "ယခင်ပရောဂျက်",
   "command.project.next": "နောက်ပရောဂျက်",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -114,6 +114,7 @@ export const dict: Record<string, string> = {
   "theme.scheme.light": "उज्यालो",
   "theme.scheme.dark": "अँध्यारो",
   "command.sidebar.toggle": "साइडबार टगल गर्नुहोस्",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "परियोजना खोल्नुहोस्",
   "command.project.previous": "अघिल्लो परियोजना",
   "command.project.next": "अर्को परियोजना",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Licht",
   "theme.scheme.dark": "Donker",
   "command.sidebar.toggle": "Zijbalk tonen of verbergen",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Project openen",
   "command.project.previous": "Vorig project",
   "command.project.next": "Volgende project",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -125,6 +125,7 @@ export const dict = {
   "theme.scheme.dark": "Mørk",
 
   "command.sidebar.toggle": "Veksle sidepanel",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Åpne prosjekt",
   "command.provider.connect": "Koble til leverandør",
   "command.server.switch": "Bytt server",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -119,6 +119,7 @@ export const dict = {
   "theme.scheme.light": "ہلکا",
   "theme.scheme.dark": "گہرا",
   "command.sidebar.toggle": "سائڈبار نوں ٹوگل کرو",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "پروجیکٹ کھولو",
   "command.project.previous": "پچھلا پروجیکٹ",
   "command.project.next": "اگلا پروجیکٹ",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -120,6 +120,7 @@ export const dict = {
   "theme.scheme.light": "Jasny",
   "theme.scheme.dark": "Ciemny",
   "command.sidebar.toggle": "Przełącz pasek boczny",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Otwórz projekt",
   "command.project.previous": "Poprzedni projekt",
   "command.project.next": "Następny projekt",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Luminoasă",
   "theme.scheme.dark": "Întunecată",
   "command.sidebar.toggle": "Comută bara laterală",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Deschide proiectul",
   "command.project.previous": "Proiectul anterior",
   "command.project.next": "Proiectul următor",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -122,6 +122,7 @@ export const dict = {
   "theme.scheme.dark": "Тёмная",
 
   "command.sidebar.toggle": "Переключить боковую панель",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Открыть проект",
   "command.project.previous": "Предыдущий проект",
   "command.project.next": "Следующий проект",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -113,6 +113,7 @@ export const dict: Record<string, string> = {
   "theme.scheme.light": "ආලෝකය",
   "theme.scheme.dark": "අඳුරු",
   "command.sidebar.toggle": "පැති තීරුව ටොගල් කරන්න",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "විවෘත ව්යාපෘතිය",
   "command.project.previous": "පෙර ව්යාපෘතිය",
   "command.project.next": "ඊළඟ ව්යාපෘතිය",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Svetlý",
   "theme.scheme.dark": "Tmavý",
   "command.sidebar.toggle": "Prepnúť bočný panel",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Otvoriť projekt",
   "command.project.previous": "Predchádzajúci projekt",
   "command.project.next": "Nasledujúci projekt",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -113,6 +113,7 @@ export const dict = {
   "theme.scheme.light": "Svetloba",
   "theme.scheme.dark": "Temno",
   "command.sidebar.toggle": "Preklop stranske vrstice",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Odprt projekt",
   "command.project.previous": "Prejšnji projekt",
   "command.project.next": "Naslednji projekt",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Drita",
   "theme.scheme.dark": "E errët",
   "command.sidebar.toggle": "Ndrysho shiritin anësor",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Projekt i hapur",
   "command.project.previous": "Projekti i mëparshëm",
   "command.project.next": "Projekti i radhës",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Светло",
   "theme.scheme.dark": "Тамно",
   "command.sidebar.toggle": "Пребаци бочну траку",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Отвори пројекат",
   "command.project.previous": "Претходни пројекат",
   "command.project.next": "Следећи пројекат",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Ljus",
   "theme.scheme.dark": "Mörk",
   "command.sidebar.toggle": "Växla sidofältet",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Öppna projekt",
   "command.project.previous": "Föregående projekt",
   "command.project.next": "Nästa projekt",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Нур",
   "theme.scheme.dark": "Торик",
   "command.sidebar.toggle": "Паҳлӯи паҳлӯро иваз кунед",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Лоиҳаи кушода",
   "command.project.previous": "Лоиҳаи қаблӣ",
   "command.project.next": "Лоиҳаи навбатӣ",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -121,6 +121,7 @@ export const dict = {
   "theme.scheme.dark": "มืด",
 
   "command.sidebar.toggle": "สลับแถบข้าง",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "เปิดโปรเจกต์",
   "command.project.previous": "โปรเจกต์ก่อนหน้า",
   "command.project.next": "โปรเจกต์ถัดไป",

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -114,6 +114,7 @@ export const dict = {
   "theme.scheme.light": "Lightagtylyk",
   "theme.scheme.dark": "Garaňky",
   "command.sidebar.toggle": "Gapdal paneli çalyşyň",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Açyk taslama",
   "command.project.previous": "Öňki taslama",
   "command.project.next": "Indiki taslama",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -127,6 +127,7 @@ export const dict = {
   "theme.scheme.dark": "Koyu",
 
   "command.sidebar.toggle": "Kenar çubuğunu aç/kapat",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Proje aç",
   "command.project.previous": "Önceki proje",
   "command.project.next": "Sonraki proje",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -123,6 +123,7 @@ export const dict = {
   "theme.scheme.dark": "Темна",
 
   "command.sidebar.toggle": "Перемкнути бічну панель",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Відкрити проєкт",
   "command.project.previous": "Попередній проєкт",
   "command.project.next": "Наступний проєкт",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -121,6 +121,7 @@ export const dict = {
   "theme.scheme.light": "روشن",
   "theme.scheme.dark": "تاریک",
   "command.sidebar.toggle": "سائیڈ بار دکھائیں یا چھپائیں",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "پروجیکٹ کھولیں۔",
   "command.project.previous": "پچھلا پروجیکٹ",
   "command.project.next": "اگلا پروجیکٹ",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -115,6 +115,7 @@ export const dict = {
   "theme.scheme.light": "Nur",
   "theme.scheme.dark": "Qorong'i",
   "command.sidebar.toggle": "Yon panelni almashtirish",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Ochiq loyiha",
   "command.project.previous": "Oldingi loyiha",
   "command.project.next": "Keyingi loyiha",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -120,6 +120,7 @@ export const dict = {
   "theme.scheme.light": "Sáng",
   "theme.scheme.dark": "Tối",
   "command.sidebar.toggle": "Bật/tắt thanh bên",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "Mở dự án",
   "command.project.previous": "Dự án trước đó",
   "command.project.next": "Dự án tiếp theo",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -125,6 +125,7 @@ export const dict = {
   "theme.scheme.dark": "深色",
 
   "command.sidebar.toggle": "切换侧边栏",
+  "command.direction.toggle": "Toggle layout direction",
 
   "command.project.open": "打开项目",
   "command.project.previous": "上一个项目",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -125,6 +125,7 @@ export const dict = {
   "theme.scheme.dark": "深色",
 
   "command.sidebar.toggle": "切換側邊欄",
+  "command.direction.toggle": "Toggle layout direction",
   "command.project.open": "開啟專案",
   "command.project.previous": "上一個專案",
   "command.project.next": "下一個專案",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -905,6 +905,13 @@ export default function LegacyLayout(props: ParentProps) {
         onSelect: () => layout.sidebar.toggle(),
       },
       {
+        id: "direction.toggle",
+        title: language.t("command.direction.toggle"),
+        category: language.t("command.category.view"),
+        keybind: "mod+shift+d",
+        onSelect: () => language.setDirection(language.direction() === "rtl" ? "ltr" : "rtl"),
+      },
+      {
         id: "project.open",
         title: language.t("command.project.open"),
         category: language.t("command.category.project"),

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />


### PR DESCRIPTION
### Issue for this PR

N/A — found while running desktop dev on Hebrew Windows (no existing issue).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Hebrew/Arabic Windows the native caption buttons (minimize/maximize/close) sit on the left side of the window, but the desktop titlebar always reserved space on the right (`margin-right: auto`) and never switched to RTL, so the header overlapped the caption controls.

Changes:
- `systemPrefersRtl()` in `packages/app/src/i18n/desktop-native.ts` detects RTL OS languages from `navigator.languages` (which is the OS language in Electron), including Hebrew (`he` plus legacy `iw`). Hebrew has no UI bundle, so it keeps English strings but now gets RTL chrome.
- New `language.systemDirection()` in the language context, consumed only by the titlebar: `<header dir>` plus `margin-left: auto` under RTL system languages / `margin-right: auto` under LTR ones. Document direction and conversation content still follow the UI locale — only the header follows the OS language, because only the native window chrome depends on it.
- New `direction.toggle` command (`mod+shift+d`, View category) that flips the content direction, same as the debug-bar DIR switch. `command.direction.toggle` was added with English fallback text in the locale files; real translations should go through `translate:app`.

The second commit (`fix: restore triple-slash references in custom-elements`) is included because `bun typecheck` (and the pre-push hook) fails without it: `packages/app` and `packages/enterprise` `custom-elements.d.ts` contained a bare path instead of `/// <reference path=... />`. It fails identically on clean `dev`. Happy to split it into its own PR if preferred.

### How did you verify your code works?

- `bun test src/i18n/desktop-native.test.ts` (new `systemPrefersRtl` cases: `he-IL`, `iw-IL`, `ar-EG`, LTR negatives, tag normalization) plus the command/layout suites: 27 pass, 0 fail.
- Full monorepo `bun typecheck`: 30/30 successful.
- Ran `electron-vite dev` on Hebrew Windows and watched the header mirror with `margin-left: auto`; toggled content direction with the new hotkey.

### Screenshots / recordings

Screenshot of the running dev build on Hebrew Windows to follow — verified live, will attach.

### Checklist

- [x] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR — see note above about the `custom-elements.d.ts` fix, which unblocks typecheck on `dev`
