### PR TITLE
feat(cli): select individual debug paths

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -119,7 +119,26 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
       commands: [
         Spec.make("agents", { description: "List all agents" }),
         Spec.make("config", { description: "List configuration sources" }),
-        Spec.make("paths", { description: "Show global paths (data, config, cache, state)" }),
+        Spec.make("paths", {
+          description: "Show global paths (data, config, cache, state)",
+          params: {
+            name: Argument.choice("name", [
+              "db",
+              "home",
+              "data",
+              "config",
+              "cache",
+              "state",
+              "tmp",
+              "bin",
+              "log",
+              "repos",
+            ]).pipe(
+              Argument.withDescription("Print only one path: db, home, data, config, cache, state, tmp, bin, log, repos"),
+              Argument.optional,
+            ),
+          },
+        }),
       ],
     }),
     Spec.make("auth", {

--- a/packages/cli/src/commands/handlers/debug/paths.ts
+++ b/packages/cli/src/commands/handlers/debug/paths.ts
@@ -1,15 +1,21 @@
 import { EOL } from "os"
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import { Global } from "@opencode/util/global"
 import { Commands } from "../../commands"
 import { Runtime } from "../../../framework/runtime"
+import { databasePath } from "../../../database-path"
 
 export default Runtime.handler(
   Commands.commands.debug.commands.paths,
-  Effect.fn("cli.debug.paths")(function* () {
+  Effect.fn("cli.debug.paths")(function* (input) {
     const global = yield* Global.Service
+    const paths = { ...global, db: databasePath(global.data) }
+    if (Option.isSome(input.name)) {
+      process.stdout.write(paths[input.name.value] + EOL)
+      return
+    }
     process.stdout.write(
-      Object.entries(global)
+      Object.entries(paths)
         .map(([key, value]) => `${key.padEnd(10)} ${value}${EOL}`)
         .join(""),
     )

--- a/packages/cli/src/database-path.ts
+++ b/packages/cli/src/database-path.ts
@@ -1,0 +1,13 @@
+import path from "node:path"
+import { OPENCODE_CHANNEL } from "./version"
+
+export function databasePath(data: string) {
+  const filename =
+    process.env.OPENCODE_DB ??
+    (["latest", "dev", "beta", "next", "prod"].includes(OPENCODE_CHANNEL) ||
+    process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
+    process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
+      ? "opencode.db"
+      : `opencode-${OPENCODE_CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
+  return filename === ":memory:" ? filename : path.resolve(data, filename)
+}

--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -15,6 +15,7 @@ import { ServiceConfig } from "./services/service-config"
 import { ServiceRegistration } from "./services/service-registration"
 import { Updater } from "./services/updater"
 import { WebUi } from "./services/web-ui"
+import { databasePath } from "./database-path"
 
 export type Mode = "default" | "service" | "stdio"
 
@@ -94,13 +95,7 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
           pty: { handoff },
           simulation: truthy(process.env.OPENCODE_SIMULATE),
           database: {
-            path:
-              process.env.OPENCODE_DB ??
-              (["latest", "dev", "beta", "next", "prod"].includes(OPENCODE_CHANNEL) ||
-              process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
-              process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
-                ? "opencode.db"
-                : `opencode-${OPENCODE_CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`),
+            path: databasePath(global.data),
           },
           models: {
             url: process.env.OPENCODE_MODELS_URL,

--- a/services/www/src/docs/content/cli/index.mdx
+++ b/services/www/src/docs/content/cli/index.mdx
@@ -57,6 +57,25 @@ opencode2 --server http://localhost:4096
 
 See [Troubleshooting](/troubleshooting) for shared service diagnostics and the [API reference](/api) for server endpoints.
 
+## Paths
+
+Print a specific local path for use with other tools:
+
+```bash
+opencode2 debug paths db
+sqlite3 "$(opencode2 debug paths db)"
+```
+
+The optional selector accepts `db`, `home`, `data`, `config`, `cache`, `state`, `tmp`, `bin`, `log`, or `repos` and prints
+only the path and a newline. The database path respects the release channel and `OPENCODE_DB`; relative database overrides
+resolve under the data directory, and `:memory:` is printed as-is. This command does not start a server or open the database.
+
+Omit the selector to show all paths with labels:
+
+```bash
+opencode2 debug paths
+```
+
 ## Uninstall
 
 Preview the files and installation that will be removed:


### PR DESCRIPTION
### Issue for this PR

Maintainer-requested CLI improvement; no linked issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an optional selector to `opencode2 debug paths`: `db`, `home`, `data`, `config`, `cache`, `state`, `tmp`, `bin`, `log`, or `repos`. A selected path prints without a label, so commands such as `sqlite3 "$(opencode2 debug paths db)"` work directly. Without a selector, the labeled list now includes `db`.

Shares database path resolution with server startup, preserving channel naming, `OPENCODE_DB`, relative overrides, and `:memory:`. Path inspection does not start a server or open the database. Invalid selectors exit nonzero with valid choices on stderr. Documents the command and shell usage.

### How did you verify your code works?

- CLI typecheck and repository pre-push typechecks passed (35 tasks).
- Seven existing tests passed: debug paths, import boundaries, and standalone server lifecycle.
- Temporary CLI checks covered all ten selectors, labeled output, paths with spaces, config overrides, relative/absolute/in-memory database overrides, channel-disable settings, invalid selectors, and absence of database/service creation.
- Temporary bundled checks covered seven release/development/custom channels.
- Docs typecheck, generated-file check, and production build passed.
- Formatting and diff checks passed; lint reported no errors and two existing server-process warnings.

### Screenshots / recordings

Not applicable; text-only CLI output.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR