### PR TITLE
fix(server): require authentication for frontend requests

### DIFF
--- a/packages/server/src/process.ts
+++ b/packages/server/src/process.ts
@@ -193,7 +193,6 @@ function dispatch(
     const app = yield* Ref.get(application)
     const ready = state.type === "ready" && Option.isSome(app)
     if (
-      (url.pathname === "/api" || url.pathname.startsWith("/api/") || url.pathname === "/openapi.json") &&
       (!ready || (!hasPtyConnectTicketURL(url) && !hasPersistentPtyConnectTicketURL(url))) &&
       !(yield* authorizedRequest(request, auth))
     )

--- a/packages/server/test/process.test.ts
+++ b/packages/server/test/process.test.ts
@@ -4,7 +4,7 @@ import { HttpServer, HttpServerError, HttpServerResponse } from "effect/unstable
 import { it } from "../../core/test/lib/effect"
 import { ServerProcess } from "../src/process"
 
-it.live("allows browser preflight requests without credentials", () =>
+it.live("authenticates API and frontend requests while allowing browser preflight", () =>
   Effect.gen(function* () {
     const fallback = "fallback".repeat(256)
     const server = yield* ServerProcess.start<never, never>(
@@ -128,6 +128,36 @@ it.live("allows browser preflight requests without credentials", () =>
         const response = yield* Effect.promise(() => fetch(new URL(pathname, HttpServer.formatAddress(server.address))))
         expect(response.status).toBe(401)
         expect(yield* Effect.promise(() => response.text())).toBe("")
+      }),
+    )
+
+    yield* Effect.forEach(["/", "/workspace/example", "/_assets/app.js", "/icons/icon.svg", "/sw.js"], (pathname) =>
+      Effect.gen(function* () {
+        yield* Effect.forEach(["GET", "HEAD"], (method) =>
+          Effect.gen(function* () {
+            yield* Effect.forEach([undefined, `Basic ${btoa("opencode:wrong")}`], (authorization) =>
+              Effect.gen(function* () {
+                const response = yield* Effect.promise(() =>
+                  fetch(new URL(pathname, HttpServer.formatAddress(server.address)), {
+                    method,
+                    headers: authorization ? { authorization } : undefined,
+                  }),
+                )
+                expect(response.status).toBe(401)
+                expect(response.headers.get("www-authenticate")).toBe('Basic realm="Secure Area"')
+                expect(yield* Effect.promise(() => response.text())).toBe("")
+              }),
+            )
+            const response = yield* Effect.promise(() =>
+              fetch(new URL(pathname, HttpServer.formatAddress(server.address)), {
+                method,
+                headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+              }),
+            )
+            expect(response.status).toBe(200)
+            expect(yield* Effect.promise(() => response.text())).toBe(method === "HEAD" ? "" : fallback)
+          }),
+        )
       }),
     )
   }),

--- a/packages/tui/src/component/dialog-pair.tsx
+++ b/packages/tui/src/component/dialog-pair.tsx
@@ -5,6 +5,7 @@ import { renderUnicodeCompact } from "uqr"
 import { useClient } from "../context/client"
 import { useTheme } from "../context/theme"
 import { useDialog } from "../ui/dialog"
+import { Link } from "../ui/link"
 import { errorMessage } from "../util/error"
 
 export type DialogPairCredentials = {
@@ -50,16 +51,34 @@ export function DialogPair(props: { credentials?: DialogPairCredentials }) {
   const content = () => {
     const value = info()
     if (!value) return
+    const href = (input: string) => {
+      const url = new URL(input)
+      url.username = encodeURIComponent(value.username)
+      url.password = encodeURIComponent(value.password)
+      return url.toString()
+    }
     return (
       <box flexDirection={horizontal() ? "row" : "column"} alignItems={horizontal() ? "flex-start" : "center"} gap={2}>
         <box width={horizontal() ? 29 : "100%"} flexShrink={0} gap={1}>
           <box>
             <text fg={theme.text.subdued}>This device</text>
-            <text fg={theme.text.default}>{localhost()}</text>
+            <Show when={localhost()}>
+              {(url) => (
+                <Link href={href(url())} fg={theme.text.default}>
+                  {url()}
+                </Link>
+              )}
+            </Show>
           </box>
           <box>
             <text fg={theme.text.subdued}>URLs</text>
-            <For each={value.urls}>{(url) => <text fg={theme.text.default}>{url}</text>}</For>
+            <For each={value.urls}>
+              {(url) => (
+                <Link href={href(url)} fg={theme.text.default}>
+                  {url}
+                </Link>
+              )}
+            </For>
           </box>
           <box>
             <text fg={theme.text.subdued}>Username</text>


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Require the existing server password for frontend pages and assets. The dispatch auth check previously covered only API paths and `/openapi.json`, letting frontend requests through without credentials.

Keep CORS preflight handling and ticket-authenticated PTY connections intact.

Make Pair dialog URLs clickable using the existing Link component: credentials are percent-encoded in hyperlink targets while labels remain credential-free.

### How did you verify your code works?

- Regression coverage for GET/HEAD requests to the root, SPA paths, assets, icons, and service worker: missing/wrong passwords return 401 with a Basic auth challenge; the correct password succeeds.
- Server process/auth tests and CLI web UI tests passed.
- Temporary Pair dialog renderer verification passed for hidden credentials, special-character passwords, and IPv6 hyperlink targets; removed after verification.
- Typecheck and formatting checks passed. PTY integration tests skipped because the required binary is unavailable.

### Screenshots / recordings

Not applicable; HTTP authentication change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

