### PR TITLE
test(core): spawn a binary, not a shell builtin, in the combined-output test

### DIFF
--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -195,7 +195,7 @@ describe("cross-spawn spawner", () => {
     fx.effect(
       "captures stdout via .all when no stderr",
       Effect.gen(function* () {
-        const handle = yield* ChildProcess.make("echo", ["hello from stdout"])
+        const handle = yield* js('process.stdout.write("hello from stdout")')
         const all = yield* decodeByteStream(handle.all)
         expect(all).toBe("hello from stdout")
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #48229

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

One line in `packages/core/test/effect/cross-spawn-spawner.test.ts`. The case "captures stdout via .all when no stderr" spawned `echo`, so what it asserted depended on whether a real `echo` binary was on `PATH`:

- Linux: `echo` is `/bin/echo`, a binary, and prints the argument unquoted. Assertion holds.
- Windows without `echo.exe`: cross-spawn falls back to `cmd.exe` and quotes the argument, and `cmd`'s builtin `echo` prints the rest of the line verbatim. The stream carries the quote characters and the assertion fails.

The spawner is correct in both cases — the test was checking a shell builtin's output formatting rather than combined-output capture, which is what the case is for.

The fix uses the file's own `js()` helper to run `node -e`, which is what the twin case one block below, "captures stderr via .all when no stdout", already does. The assertion is untouched, nothing is skipped, and there is no platform branch.

### How did you verify your code works?

First, that the difference is `PATH` and not the spawner. Same Windows machine, same cross-spawn 7.0.6, only the shell differing:

```
# PowerShell — `where.exe echo` finds nothing
echo resolves to: (not on PATH)
stdout: "\"hello from stdout\"\r\n"

# Git Bash — Git for Windows ships one
echo resolves to: C:\Program Files\Git\usr\bin\echo.EXE
stdout: "hello from stdout\n"
```

Then the suite. Running that file from PowerShell, before and after, on the same checkout:

```
=== BEFORE (echo spawned) ===
error: expect(received).toBe(expected)
Expected: "hello from stdout"
Received: ""hello from stdout""
(fail) cross-spawn spawner > combined output (all) > captures stdout via .all when no stderr
 23 pass

=== AFTER (js helper) ===
 24 pass
 0 fail
```

I also ran the whole `packages/core` suite after the change: 1362 pass / 0 fail / 7 skip across 178 files. In fairness about provenance: those runs are from a downstream checkout of this repo, whose copy of this file differs from `dev` only in import paths and the layer construction at the top — the `js()` helper, the case, and the assertion are identical. I have not run `dev` itself on Windows. Linux behaviour is unchanged, since `node -e` writing to stdout produces the same bytes there as `/bin/echo` did.

Note for reviewers: this case is green on the Windows CI job today because `test.yml` runs it with `shell: bash`, where that `echo.exe` is on `PATH`. So merging this does not turn a red check green — it removes a failure that only Windows contributors running the suite from PowerShell or `cmd` currently hit.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
