### PR TITLE
fix(tui): guard location refresh against startup race

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -71,6 +71,14 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       location: {},
     })
 
+    // Atomic location-slice write: creates the key if missing, merges if present.
+    // Single setStore call — no check-then-act race. Solid `setStore` invokes the
+    // updater with the current value at the last path segment (undefined when the
+    // key is missing) and `prev ?? {}` creates the object without a separate guard.
+    function setLocationSlice(key: string, slice: keyof LocationData, data: unknown) {
+      setStore("location", key, (prev) => ({ ...(prev ?? {}), [slice]: data }))
+    }
+
     const sdk = useSDK()
     const events = useEvent()
     const [defaultLocation, setDefaultLocation] = createSignal<LocationRef>({
@@ -468,6 +476,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         async refresh(ref?: LocationRef) {
           const response = await sdk.client.v2.location.get({ location: locationQuery(ref) }, { throwOnError: true })
           const location = response.data
+          if (!location) return // location services not ready yet (issue #40002)
           const key = locationKey(location)
           if (!store.location[key]) setStore("location", key, {})
           if (!ref) setDefaultLocation({ directory: location.directory, workspaceID: location.workspaceID })
@@ -478,8 +487,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           async refresh(ref?: LocationRef) {
             const result = await sdk.client.v2.agent.list({ location: locationQuery(ref) }, { throwOnError: true })
-            const key = locationKey(result.data.location)
-            setStore("location", key, "agent", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "agent", result.data.data)
           },
         },
         command: {
@@ -488,8 +500,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           async refresh(ref?: LocationRef) {
             const result = await sdk.client.v2.command.list({ location: locationQuery(ref) }, { throwOnError: true })
-            const key = locationKey(result.data.location)
-            setStore("location", key, "command", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "command", result.data.data)
           },
         },
         integration: {
@@ -501,8 +516,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               { location: locationQuery(ref) },
               { throwOnError: true },
             )
-            const key = locationKey(result.data.location)
-            setStore("location", key, "integration", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "integration", result.data.data)
           },
         },
         model: {
@@ -511,8 +529,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           async refresh(ref?: LocationRef) {
             const result = await sdk.client.v2.model.list({ location: locationQuery(ref) }, { throwOnError: true })
-            const key = locationKey(result.data.location)
-            setStore("location", key, "model", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "model", result.data.data)
           },
         },
         provider: {
@@ -521,8 +542,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           async refresh(ref?: LocationRef) {
             const result = await sdk.client.v2.provider.list({ location: locationQuery(ref) }, { throwOnError: true })
-            const key = locationKey(result.data.location)
-            setStore("location", key, "provider", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "provider", result.data.data)
           },
         },
         reference: {
@@ -531,8 +555,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           async refresh(ref?: LocationRef) {
             const result = await sdk.client.v2.reference.list({ location: locationQuery(ref) }, { throwOnError: true })
-            const key = locationKey(result.data.location)
-            setStore("location", key, "reference", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "reference", result.data.data)
           },
         },
         skill: {
@@ -541,8 +568,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           async refresh(ref?: LocationRef) {
             const result = await sdk.client.v2.skill.list({ location: locationQuery(ref) }, { throwOnError: true })
-            const key = locationKey(result.data.location)
-            setStore("location", key, "skill", result.data.data)
+            const location = result.data.location
+            if (!location) return
+            const key = locationKey(location)
+            if (ref?.workspaceID && key !== locationKey(ref)) return
+            setLocationSlice(key, "skill", result.data.data)
           },
         },
       },


### PR DESCRIPTION
### Issue for this PR

Closes #40002

### Type of change

- [x] Bug fix

### What does this PR do?

The TUI Data provider fires **8 concurrent location refreshes** on startup:

```js
Promise.allSettled([
  location.refresh(),
  location.agent.refresh(),
  location.integration.refresh(),
  location.model.refresh(),
  location.provider.refresh(),
  location.reference.refresh(),
  location.command.refresh(),
  location.skill.refresh(),
])
```

Only `location.refresh()` guards the store key creation (`if (!store.location[key]) setStore("location", key, {})`). The 7 sub-refreshes write `setStore("location", key, slice, data)` **without** ensuring the key exists first. If any sub-refresh resolves before `location.refresh()`, `store.location[key]` is `undefined` and Solid's `setPath` crashes:

```
TypeError: undefined is not an object (evaluating 'a[t]')
```

This is timing-dependent (intermittent, more likely under load / second instance), which is why it shows up as a random crash on a "second session" rather than every time.

**Changes:**

1. **`setLocationSlice` helper** — atomic functional `setStore` call that creates the key if missing (`prev ?? {}`) and merges if present. One call, no check-then-act race. This relies on Solid's `setPath`: the updater function is invoked with the current value at the last path segment (`undefined` when missing), so the object is created without a separate existence check.
2. **Null-guard on response location** in every slice refresh (`if (!location) return`) — protects against malformed/partial responses.
3. **TOCTOU revalidation** — if the request was pinned to a `workspaceID` and the response comes back for a different one (workspace switched mid-fetch), the stale data is discarded instead of written.
4. **Null-guard on `location.refresh()` response.data** — fixes the related `U.directory` crash from #40002 when location services are still booting.

`Promise.allSettled` error-tolerance semantics are unchanged. Old location-key cleanup is intentionally out of scope (separate optimization).

### How did you verify your code works?

- Patch applies cleanly to `dev`.
- Added 5 regression tests (see PR comment) exercising the exact `setLocationSlice` helper against Solid's real `createStore`/`setStore`: missing-key creation without throwing, no clobbering of sibling slices, TOCTOU discard on workspace mismatch, null-guard on missing response location, and `allSettled` error tolerance.
- Traced the root cause against the minified bundle and Solid's `setPath` source to confirm the exact race window.

### Screenshots / recordings

_Not applicable — internal race-condition fix in the TUI data provider, no visible UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
