### PR TITLE
fix(session): cap summary diffs; prune superseded message.updated events

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -27,6 +27,7 @@ import { lt } from "drizzle-orm"
 import { or } from "drizzle-orm"
 import type { SQL } from "drizzle-orm"
 import { PartTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { EventTable } from "@opencode-ai/core/event/sql"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { MessageV2 } from "./message-v2"
 import type { InstanceContext } from "../project/instance-context"
@@ -450,6 +451,7 @@ export interface Interface {
   readonly remove: (sessionID: SessionID) => Effect.Effect<void, NotFound>
   readonly updateMessage: <T extends SessionV1.Info>(msg: T) => Effect.Effect<T>
   readonly removeMessage: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<MessageID>
+  readonly pruneMessageEvents: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<number>
   readonly removePart: (input: { sessionID: SessionID; messageID: MessageID; partID: PartID }) => Effect.Effect<PartID>
   readonly getPart: (input: {
     sessionID: SessionID
@@ -861,6 +863,36 @@ const layer: Layer.Layer<
       return input.messageID
     })
 
+    const pruneMessageEvents = Effect.fn("Session.pruneMessageEvents")(function* (input: {
+      sessionID: SessionID
+      messageID: MessageID
+    }) {
+      // Keep only the newest message.updated snapshot per message: older ones
+      // are fully superseded (each event carries complete message state).
+      // Called by summarize(), the main producer of fat snapshots.
+      // MESSAGE_UPDATED_SLIM_EVENTS_004
+      const rows = yield* db
+        .select({ id: EventTable.id, seq: EventTable.seq, data: EventTable.data })
+        .from(EventTable)
+        .where(and(eq(EventTable.aggregate_id, input.sessionID), like(EventTable.type, "message.updated%")))
+        .all()
+        .pipe(Effect.orDie)
+      const mine = rows
+        .filter((row) => (row.data as { info?: { id?: unknown } } | null)?.info?.id === input.messageID)
+        .sort((a, b) => b.seq - a.seq)
+      const stale = mine.slice(1).map((row) => row.id)
+      if (stale.length === 0) return 0
+      // NOTE: the Effect client's run() resolves without a driver result
+      // (no changes count), so report the targeted count; callers that need
+      // certainty re-read (tests poll the table).
+      yield* db
+        .delete(EventTable)
+        .where(and(eq(EventTable.aggregate_id, input.sessionID), inArray(EventTable.id, stale)))
+        .run()
+        .pipe(Effect.orDie)
+      return stale.length
+    })
+
     const removePart = Effect.fn("Session.removePart")(function* (input: {
       sessionID: SessionID
       messageID: MessageID
@@ -926,6 +958,7 @@ const layer: Layer.Layer<
       remove,
       updateMessage,
       removeMessage,
+      pruneMessageEvents,
       removePart,
       updatePart,
       getPart,

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -63,6 +63,39 @@ function unquoteGitPath(input: string) {
   return Buffer.from(bytes).toString()
 }
 
+// Bound on the worktree-diff snapshot stored per user message and republished
+// on every message.updated event. Uncapped, long sessions grew this to tens of
+// MB per event and GBs per session (one 17 MB snapshot x ~1000 events).
+// MESSAGE_UPDATED_SLIM_EVENTS_004
+export const MAX_SUMMARY_DIFF_BYTES = 256 * 1024
+export const MAX_SUMMARY_FILE_PATCH_BYTES = 64 * 1024
+
+// Pure: keep whole-file patches in order within the budgets; always keeps at
+// least the first file (capped). Counts (additions/deletions) stay truthful
+// totals — only the stored patch text is bounded. Revert recomputes fresh
+// diffs, so the stored copy is display-only.
+export function truncateDiffs(
+  diffs: Snapshot.FileDiff[],
+  totalBudget: number = MAX_SUMMARY_DIFF_BYTES,
+  fileBudget: number = MAX_SUMMARY_FILE_PATCH_BYTES,
+): Snapshot.FileDiff[] {
+  const out: Snapshot.FileDiff[] = []
+  let used = 0
+  for (const item of diffs) {
+    const patch = item.patch ?? ""
+    const capped =
+      patch.length > fileBudget
+        ? patch.slice(0, fileBudget) + `\n...[diff truncated: omitted ${patch.length - fileBudget} chars]`
+        : patch
+    if (out.length > 0 && used + capped.length > totalBudget) break
+    const finalPatch = capped.slice(0, totalBudget)
+    out.push({ ...item, patch: finalPatch })
+    used += finalPatch.length
+    if (used >= totalBudget) break
+  }
+  return out
+}
+
 export interface Interface {
   readonly summarize: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<void>
   readonly diff: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Snapshot.FileDiff[]>
@@ -121,9 +154,15 @@ const layer = Layer.effect(
       )
       const target = messages.find((m) => m.info.id === input.messageID)
       if (!target || target.info.role !== "user") return
-      const msgDiffs = yield* computeDiff({ messages })
+      const msgDiffs = truncateDiffs(yield* computeDiff({ messages }))
       target.info.summary = { ...target.info.summary, diffs: msgDiffs }
       yield* sessions.updateMessage(target.info)
+      // The update above just published another full snapshot: retire the
+      // older ones for this message so the event log cannot grow without
+      // bound. Maintenance only — never fail the summarize itself.
+      yield* sessions
+        .pruneMessageEvents({ sessionID: input.sessionID, messageID: target.info.id })
+        .pipe(Effect.catchCause((cause) => Effect.logWarning("summary prune failed", { cause })))
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {

--- a/packages/opencode/test/session/summary.test.ts
+++ b/packages/opencode/test/session/summary.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Database } from "@opencode-ai/core/database/database"
+import { node as DatabaseNode } from "@opencode-ai/core/database/database"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { EventSequenceTable, EventTable } from "@opencode-ai/core/event/sql"
+import { Session } from "@/session/session"
+import {
+  MAX_SUMMARY_DIFF_BYTES,
+  MAX_SUMMARY_FILE_PATCH_BYTES,
+  truncateDiffs,
+} from "../../src/session/summary"
+import type { Snapshot } from "../../src/snapshot"
+import {
+  disposeAllInstances,
+  testInstanceStoreLayer,
+  } from "../fixture/fixture"
+import { pollWithTimeout, testEffect } from "../lib/effect"
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const layer = Layer.mergeAll(
+  LayerNode.compile(LayerNode.group([Session.node, CrossSpawnSpawner.node, DatabaseNode])),
+  testInstanceStoreLayer,
+)
+const withLayer = testEffect(layer)
+
+const withSessionRow = Effect.fn("SummaryTest.withSessionRow")(function* () {
+  const sessions = yield* Session.Service
+  const { db } = yield* Database.Service
+  const info = yield* sessions.create({})
+  yield* db
+    .insert(SessionTable)
+    .values({
+      id: info.id,
+      project_id: info.projectID,
+      slug: info.slug,
+      directory: info.directory,
+      title: info.title,
+      version: info.version,
+      time_created: info.time.created,
+      time_updated: info.time.updated,
+    })
+    .onConflictDoNothing()
+    .run()
+    .pipe(Effect.orDie)
+  return info
+})
+
+const diff = (file: string, patchSize: number): Snapshot.FileDiff =>
+  ({
+    file,
+    patch: "x".repeat(patchSize),
+    additions: patchSize,
+    deletions: 0,
+  }) as Snapshot.FileDiff
+
+describe("summary diff cap", () => {
+  test("passes small diffs through untouched", () => {
+    const input = [diff("a.ts", 100), diff("b.ts", 200)]
+    expect(truncateDiffs(input)).toEqual(input)
+  })
+
+  test("caps single-file patches and keeps totals", () => {
+    const out = truncateDiffs([diff("big.ts", MAX_SUMMARY_FILE_PATCH_BYTES + 1000)])
+    expect(out.length).toBe(1)
+    expect(out[0].patch!.length).toBeLessThanOrEqual(MAX_SUMMARY_FILE_PATCH_BYTES + 100)
+    expect(out[0].patch).toContain("[diff truncated")
+    expect(out[0].additions).toBe(MAX_SUMMARY_FILE_PATCH_BYTES + 1000)
+  })
+
+  test("bounds the total across files", () => {
+    const input = Array.from({ length: 20 }, (_, i) => diff(`f${i}.ts`, 100 * 1024))
+    const out = truncateDiffs(input)
+    const total = out.reduce((sum, item) => sum + (item.patch?.length ?? 0), 0)
+    expect(total).toBeLessThanOrEqual(MAX_SUMMARY_DIFF_BYTES)
+    expect(out.length).toBeGreaterThanOrEqual(1)
+    expect(out.length).toBeLessThan(input.length)
+  })
+
+  test("empty stays empty", () => {
+    expect(truncateDiffs([])).toEqual([])
+  })
+})
+
+describe("pruneMessageEvents", () => {
+  const putEvent = (aggregateID: string, seq: number, type: string, messageID: string, bytes: number) =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(EventSequenceTable)
+        .values({ aggregate_id: aggregateID, seq, owner_id: null })
+        .onConflictDoNothing()
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(EventTable)
+        .values({
+          id: `evt_prune_${seq}` as never,
+          aggregate_id: aggregateID,
+          seq,
+          type,
+          data: {
+            sessionID: aggregateID,
+            info: { id: messageID, padding: "x".repeat(bytes) },
+          },
+        })
+        .run()
+        .pipe(Effect.orDie)
+    })
+
+  const updatedCount = (aggregateID: string) =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      const rows = yield* db.select().from(EventTable).all().pipe(Effect.orDie)
+      return rows.filter((row) => row.aggregate_id === aggregateID && row.type.startsWith("message.updated")).length
+    })
+
+  withLayer.instance("keeps only the newest snapshot per message", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const session = yield* withSessionRow()
+      yield* putEvent(session.id, 1, "message.updated.1", "msg_a", 200 * 1024)
+      yield* putEvent(session.id, 2, "message.updated.1", "msg_a", 200 * 1024)
+      yield* putEvent(session.id, 3, "message.updated.1", "msg_a", 200 * 1024)
+      yield* putEvent(session.id, 4, "message.updated.1", "msg_b", 100)
+      yield* putEvent(session.id, 5, "message.created.1", "msg_a", 100)
+      const pruned = yield* sessions.pruneMessageEvents({ sessionID: session.id, messageID: "msg_a" as never })
+      expect(pruned).toBe(2)
+      const remaining = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const count = yield* updatedCount(session.id)
+          if (count !== 2) return undefined
+          return count
+        }),
+        "superseded snapshots were not pruned",
+      )
+      expect(remaining).toBe(2)
+    }),
+  )
+})


### PR DESCRIPTION
Relates to #42748 (and #48241, closed as dupe family).

`SessionSummary.summarize` runs at step 1 of every run and `Session.updateMessage` persists + publishes the entire `info`, diffs included — unbounded per-run event growth (observed: 1063 events / ~5.8 GB for one long session). This composes two bounds, both in `packages/opencode/src/session/`: cap `summary.diffs` (pure `truncateDiffs`: 256 KB total, 64 KB per file, truthful counts — the stored copy is display-only) and prune superseded snapshots (`pruneMessageEvents`: keep only the newest `message.updated` per message id). No projector/client contract changes.

Includes unit coverage per the entry verification plan. Tested against v1.18.29.