### PR TITLE
fix(provider): give the OpenAI-native path an explicit cache anchor

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -406,6 +406,74 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
   return msgs
 }
 
+// GPT-5.6 and later is where @ai-sdk/openai's explicit cache breakpoints take
+// effect; a request in explicit mode with no breakpoint the model honours
+// gets no prompt caching at all, which is worse than leaving implicit mode
+// alone. Parses "gpt-<major>[.<minor>]" out of the api id, treating a missing
+// minor as 0, e.g. "gpt-5-pro" -> (5, 0), "gpt-5.6-sol" -> (5, 6).
+// NOTE: a sibling PR introduces a similar gpt-N[.M] parse elsewhere in this
+// file; the two can be unified once both have landed.
+const GPT_EXPLICIT_CACHE_VERSION_RE = /gpt-(\d+)(?:\.(\d+))?/
+
+function supportsExplicitCacheBreakpoint(apiId: string): boolean {
+  const match = GPT_EXPLICIT_CACHE_VERSION_RE.exec(apiId)
+  if (!match) return false
+  const major = Number(match[1])
+  const minor = Number(match[2] ?? 0)
+  return major > 5 || (major === 5 && minor >= 6)
+}
+
+// Places an explicit OpenAI prompt cache breakpoint on the same trailing
+// messages applyCaching() targets (first 2 system, last 2 non-system).
+// Kept separate from applyCaching()'s provider map/gate so Anthropic
+// behaviour stays byte-identical and non-openai @ai-sdk/openai-compatible
+// models never receive an openai-namespaced marker.
+//
+// Callers must only invoke this for API-key OpenAI auth. Explicit cache
+// breakpoints are only meaningful alongside the request-level explicit mode
+// options() sets, and that mode can never be sent on the OAuth/Codex path
+// (see the allowExplicitCache gate in message() below) - so on OAuth,
+// breakpoints would be inert content-block keys with no upside, only risk.
+function applyOpenAICacheBreakpoint(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
+  const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
+  const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
+
+  const providerOptions = {
+    openai: {
+      promptCacheBreakpoint: { mode: "explicit" },
+    },
+  }
+
+  for (const msg of unique([...system, ...final])) {
+    // Only text parts carry the breakpoint on the wire for array content:
+    // Chat Completions reads promptCacheBreakpoint exclusively off text
+    // parts, and the Responses API's user/file/output_text serializations
+    // only ever read it off the part, never the message. Marking the last
+    // part of any type (a trailing tool-call, say) produces a marker the SDK
+    // silently drops, so find the last text part instead, and leave the
+    // message unmarked entirely if it has none (this also naturally excludes
+    // tool-approval parts, which are never type "text").
+    if (Array.isArray(msg.content) && msg.content.length > 0) {
+      const lastText = [...msg.content].reverse().find((part) => part && typeof part === "object" && part.type === "text")
+      if (lastText) {
+        lastText.providerOptions = mergeDeep(lastText.providerOptions ?? {}, providerOptions)
+      }
+      continue
+    }
+
+    // String content only occurs here for system messages (SystemModelMessage.content
+    // is a string in the `ai` package). @ai-sdk/openai reads the breakpoint off
+    // message-level providerOptions specifically for the system role, on both
+    // Chat Completions and Responses, so this is the only place a
+    // message-level marker is honoured. Anchoring the system prompt this way
+    // guarantees at least one marker per request even when neither of the
+    // last two non-system messages has a text part to carry one.
+    msg.providerOptions = mergeDeep(msg.providerOptions ?? {}, providerOptions)
+  }
+
+  return msgs
+}
+
 function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
   return msgs.map((msg) => {
     if (msg.role !== "user" || !Array.isArray(msg.content)) return msg
@@ -462,7 +530,12 @@ function mapProviderOptions(
   })
 }
 
-export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
+export function message(
+  msgs: ModelMessage[],
+  model: Provider.Model,
+  options: Record<string, unknown>,
+  allowExplicitCache = false,
+) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
   const usesAnthropicAutomaticCaching =
@@ -483,7 +556,12 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
     msgs = applyCaching(msgs, model)
   }
 
-  // Remap providerOptions keys from stored providerID to expected SDK key
+  // Remap providerOptions keys from stored providerID to expected SDK key.
+  // Must run before applyOpenAICacheBreakpoint() below: for models whose SDK
+  // key differs from their providerID (e.g. @ai-sdk/amazon-bedrock/mantle,
+  // key "openai" vs providerID "amazon-bedrock"), this remap overwrites
+  // result[key] with whatever already lived under result[model.providerID].
+  // Placing the breakpoint first would let that overwrite clobber it.
   const key = sdkKey(model.api.npm)
   if (key && key !== model.providerID) {
     const remap = (opts: Record<string, any> | undefined) => {
@@ -496,6 +574,36 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
     }
 
     msgs = mapProviderOptions(msgs, remap)
+  }
+
+  // OpenAI-native explicit cache breakpoint. Scoped to the OpenAI-native path
+  // (Chat Completions + Responses); @ai-sdk/amazon-bedrock/mantle shares it
+  // via sdkKey() mapping onto "openai" without a special case (its "mantle-gpt"
+  // style ids never match GPT_EXPLICIT_CACHE_VERSION_RE, so it's excluded
+  // anyway pending confirmation it accepts OpenAI-shaped body fields). Never
+  // reaches Copilot, whose sdkKey is "copilot". Gated on the same setCacheKey
+  // opt-out options() uses for promptCacheOptions, so the markers are never
+  // placed without the mode that makes them meaningful, and on
+  // supportsExplicitCacheBreakpoint() so pre-5.6 models keep implicit caching
+  // instead of losing it to an unmarked explicit request.
+  //
+  // allowExplicitCache defaults to false (permission the caller must grant,
+  // not an identity the caller declares) because the two failure directions
+  // are asymmetric: a caller that forgets to pass it just loses prompt
+  // caching, an invisible cost, whereas defaulting to true would place a
+  // breakpoint on every call site nobody has vetted, including ChatGPT/Codex
+  // OAuth requests. Those never reach api.openai.com - they route through
+  // the chatgpt.com Codex relay, which 400s on unknown top-level request
+  // params and can never be sent the explicit mode (promptCacheOptions) that
+  // makes these breakpoints meaningful there. Production call sites pass
+  // `!isOpenaiOauth`, so the OAuth path stays byte-identical to stock.
+  if (
+    allowExplicitCache &&
+    sdkKey(model.api.npm) === "openai" &&
+    options.setCacheKey !== false &&
+    supportsExplicitCacheBreakpoint(model.api.id)
+  ) {
+    msgs = applyOpenAICacheBreakpoint(msgs, model)
   }
 
   // Strip Responses item IDs before serialization, following Codex and keeping signed request bodies immutable.
@@ -1208,6 +1316,7 @@ export function options(input: {
   model: Provider.Model
   sessionID: string
   providerOptions?: Record<string, any>
+  allowExplicitCache?: boolean
 }): Record<string, any> {
   const result: Record<string, any> = {}
 
@@ -1319,6 +1428,31 @@ export function options(input: {
       input.providerOptions?.setCacheKey === true
     ) {
       result["promptCacheKey"] = input.sessionID
+    }
+
+    // Disable implicit breakpoint selection so the explicit breakpoints
+    // applyOpenAICacheBreakpoint() places on message content take effect.
+    // Scoped to the OpenAI-native path via sdkKey(); @ai-sdk/amazon-bedrock/mantle
+    // shares it without a special case, and Copilot's sdkKey ("copilot") never matches.
+    // Gated on supportsExplicitCacheBreakpoint() to match message(): pre-5.6
+    // models don't honour explicit breakpoints, so forcing explicit mode here
+    // without message() ever placing a marker would just turn caching off.
+    //
+    // allowExplicitCache defaults to false (permission the caller must grant,
+    // not an identity the caller declares): the failure directions are
+    // asymmetric, a caller that forgets to pass it just loses prompt caching,
+    // an invisible cost, whereas defaulting to true would set explicit mode
+    // on every call site nobody has vetted, including ChatGPT/Codex OAuth
+    // requests, which route through the chatgpt.com Codex relay (not
+    // api.openai.com) and 400 on unknown top-level request params such as
+    // prompt_cache_options. Production call sites pass `!isOpenaiOauth`, so
+    // the OAuth path stays byte-identical to stock.
+    if (
+      input.allowExplicitCache === true &&
+      sdkKey(input.model.api.npm) === "openai" &&
+      supportsExplicitCacheBreakpoint(input.model.api.id)
+    ) {
+      result["promptCacheOptions"] = { mode: "explicit" }
     }
   }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -334,6 +334,7 @@ const live: Layer.Layer<
                       args.params.prompt,
                       input.model,
                       prepared.messageTransformOptions,
+                      !(item.id === "openai" && info?.type === "oauth"),
                     )
                   }
                   return args.params

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -91,7 +91,12 @@ export function stream(input: StreamInput): StreamResult {
     model: input.model,
     apiKey: current.apiKey,
     baseURL: current.baseURL,
-    messages: ProviderTransform.message(input.messages, input.model, input.providerOptions ?? {}),
+    messages: ProviderTransform.message(
+      input.messages,
+      input.model,
+      input.providerOptions ?? {},
+      !(input.provider.id === "openai" && input.auth?.type === "oauth"),
+    ),
     toolChoice: input.toolChoice,
     temperature: input.temperature,
     topP: input.topP,

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -87,6 +87,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
         model: input.model,
         sessionID: input.sessionID,
         providerOptions: input.provider.options,
+        allowExplicitCache: !isOpenaiOauth,
       })
   const options = mergeOptions(mergeOptions(mergeOptions(base, input.model.options), input.agent.options), variant)
   if (

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2310,6 +2310,8 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
       {},
     )
 
+    // gpt-4 predates GPT-5.6's explicit cache breakpoint support, so no
+    // openai-namespaced marker is added here (see supportsExplicitCacheBreakpoint()).
     expect(result[0].content).toEqual([
       { type: "reasoning", text: "Should not be processed" },
       { type: "text", text: "Answer" },
@@ -3681,6 +3683,328 @@ describe("ProviderTransform.message - cache control on gateway", () => {
         },
       },
     })
+  })
+})
+
+describe("ProviderTransform.message / options - OpenAI explicit cache breakpoint", () => {
+  const buildOpenAIModel = (apiId: string) =>
+    ({
+      id: `openai/${apiId}`,
+      providerID: "openai",
+      api: {
+        id: apiId,
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: false,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  const openaiModel = buildOpenAIModel("gpt-6-astra")
+
+  const anthropicModel = {
+    ...openaiModel,
+    id: "anthropic/claude-sonnet-4",
+    providerID: "anthropic",
+    api: { id: "claude-sonnet-4", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
+  } as any
+
+  const copilotModel = {
+    ...openaiModel,
+    id: "github-copilot/gpt-4",
+    providerID: "github-copilot",
+    api: { id: "gpt-4", url: "https://api.githubcopilot.com", npm: "@ai-sdk/github-copilot" },
+  } as any
+
+  // Real Mantle ids (e.g. "mantle-gpt") carry no "gpt-N" version, so they
+  // never satisfy supportsExplicitCacheBreakpoint() and this path is a no-op
+  // for them regardless of sdkKey() mapping onto "openai".
+  const mantleModel = {
+    ...openaiModel,
+    id: "bedrock/mantle-gpt",
+    providerID: "amazon-bedrock",
+    api: {
+      id: "mantle-gpt",
+      url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      npm: "@ai-sdk/amazon-bedrock/mantle",
+    },
+  } as any
+
+  const buildMessages = (): ModelMessage[] =>
+    [
+      { role: "system", content: "You are a helpful assistant" },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi there" }] },
+    ] as any[]
+
+  for (const testCase of [
+    { apiId: "gpt-6-astra", fires: true },
+    { apiId: "gpt-5.6-sol", fires: true },
+    { apiId: "gpt-5.3-codex-spark", fires: false },
+    { apiId: "gpt-5-pro", fires: false },
+    { apiId: "gpt-4o", fires: false },
+  ]) {
+    const model = buildOpenAIModel(testCase.apiId)
+
+    test(`${testCase.apiId}: places the breakpoint on targeted messages when permitted (fires: ${testCase.fires})`, () => {
+      const result = ProviderTransform.message(buildMessages(), model, {}, true) as any[]
+      for (const msg of result) {
+        if (!Array.isArray(msg.content)) continue
+        const last = msg.content[msg.content.length - 1]
+        if (testCase.fires) {
+          expect(last.providerOptions?.openai?.promptCacheBreakpoint).toEqual({ mode: "explicit" })
+        } else {
+          expect(last.providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+        }
+      }
+    })
+
+    test(`${testCase.apiId}: sets promptCacheOptions in options() when permitted (fires: ${testCase.fires})`, () => {
+      const result = ProviderTransform.options({ model, sessionID: "session-1", allowExplicitCache: true })
+      if (testCase.fires) {
+        expect(result.promptCacheOptions).toEqual({ mode: "explicit" })
+      } else {
+        expect(result.promptCacheOptions).toBeUndefined()
+      }
+    })
+  }
+
+  test("does not set promptCacheOptions when setCacheKey is explicitly disabled, even when permitted", () => {
+    const result = ProviderTransform.options({
+      model: openaiModel,
+      sessionID: "session-1",
+      providerOptions: { setCacheKey: false },
+      allowExplicitCache: true,
+    })
+    expect(result.promptCacheOptions).toBeUndefined()
+  })
+
+  test("@ai-sdk/amazon-bedrock/mantle's version-less id never matches, so no breakpoint or mode is set even when permitted", () => {
+    const result = ProviderTransform.message(buildMessages(), mantleModel, {}, true) as any[]
+    for (const msg of result) {
+      if (!Array.isArray(msg.content)) continue
+      const last = msg.content[msg.content.length - 1]
+      expect(last.providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+    }
+
+    const options = ProviderTransform.options({ model: mantleModel, sessionID: "session-1", allowExplicitCache: true })
+    expect(options.promptCacheOptions).toBeUndefined()
+  })
+
+  test("Anthropic models are unaffected (no openai-namespaced breakpoint or mode), even when permitted", () => {
+    const result = ProviderTransform.message(buildMessages(), anthropicModel, {}, true) as any[]
+    for (const msg of result) {
+      if (!Array.isArray(msg.content)) continue
+      const last = msg.content[msg.content.length - 1]
+      expect(last.providerOptions?.openai).toBeUndefined()
+    }
+
+    const options = ProviderTransform.options({ model: anthropicModel, sessionID: "session-1", allowExplicitCache: true })
+    expect(options.promptCacheOptions).toBeUndefined()
+  })
+
+  test("Copilot models never receive the openai-namespaced breakpoint or mode, even when permitted", () => {
+    const result = ProviderTransform.message(buildMessages(), copilotModel, {}, true) as any[]
+    for (const msg of result) {
+      if (!Array.isArray(msg.content)) continue
+      const last = msg.content[msg.content.length - 1]
+      expect(last.providerOptions?.openai).toBeUndefined()
+    }
+
+    const options = ProviderTransform.options({ model: copilotModel, sessionID: "session-1", allowExplicitCache: true })
+    expect(options.promptCacheOptions).toBeUndefined()
+  })
+
+  test("remap does not clobber a pre-existing breakpoint, for an sdkKey-remapped provider whose id satisfies the version gate", () => {
+    // @ai-sdk/amazon-bedrock/mantle's real ids (e.g. "mantle-gpt") never carry
+    // a version and so never reach applyOpenAICacheBreakpoint(); this id is
+    // synthetic, chosen only to exercise the remap-then-breakpoint ordering
+    // guarantee established when this path was fixed.
+    const versionedMantleModel = {
+      ...mantleModel,
+      api: { ...mantleModel.api, id: "openai.gpt-5.6" },
+    }
+    const messages = [
+      { role: "system", content: "You are a helpful assistant" },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Hi there",
+            providerOptions: { "amazon-bedrock": { foo: "bar" } },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(messages, versionedMantleModel, {}, true) as any[]
+    const last = result[result.length - 1]
+    const lastContent = last.content[last.content.length - 1]
+
+    expect(lastContent.providerOptions?.openai?.foo).toBe("bar")
+    expect(lastContent.providerOptions?.openai?.promptCacheBreakpoint).toEqual({ mode: "explicit" })
+  })
+
+  test("a system message (string content) carries the marker at message level", () => {
+    const result = ProviderTransform.message(buildMessages(), openaiModel, {}, true) as any[]
+    const system = result.find((msg: any) => msg.role === "system")
+
+    expect(typeof system.content).toBe("string")
+    expect(system.providerOptions?.openai?.promptCacheBreakpoint).toEqual({ mode: "explicit" })
+  })
+
+  test("a turn whose last two non-system messages have no text part still gets a marker from the system message", () => {
+    const msgs = [
+      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "user",
+        content: [{ type: "file", mediaType: "image/png", data: "aGVsbG8=" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "1", toolName: "bash", input: {} }],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, openaiModel, {}, true) as any[]
+    const system = result.find((msg: any) => msg.role === "system")
+    const user = result.find((msg: any) => msg.role === "user")
+    const assistant = result.find((msg: any) => msg.role === "assistant")
+
+    expect(system.providerOptions?.openai?.promptCacheBreakpoint).toEqual({ mode: "explicit" })
+    expect(user.content[0].providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+    expect(assistant.content[0].providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+
+    const markedParts = [system, ...user.content, ...assistant.content].filter(
+      (part: any) => part.providerOptions?.openai?.promptCacheBreakpoint !== undefined,
+    )
+    expect(markedParts).toHaveLength(1)
+  })
+
+  test("an assistant message ending in a tool call gets the marker on its last text part, not the tool-call part", () => {
+    const msgs = [
+      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check that" },
+          { type: "tool-call", toolCallId: "1", toolName: "bash", input: {} },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, openaiModel, {}, true) as any[]
+    const assistant = result.find((msg: any) => msg.role === "assistant")
+    const textPart = assistant.content.find((part: any) => part.type === "text")
+    const toolCallPart = assistant.content.find((part: any) => part.type === "tool-call")
+
+    expect(textPart.providerOptions?.openai?.promptCacheBreakpoint).toEqual({ mode: "explicit" })
+    expect(toolCallPart.providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+  })
+
+  test("setCacheKey: false disables both the breakpoint markers and promptCacheOptions, even when permitted", () => {
+    const result = ProviderTransform.message(buildMessages(), openaiModel, { setCacheKey: false }, true) as any[]
+    for (const msg of result) {
+      if (Array.isArray(msg.content)) {
+        const last = msg.content[msg.content.length - 1]
+        expect(last.providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+      } else {
+        expect(msg.providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+      }
+    }
+
+    const options = ProviderTransform.options({
+      model: openaiModel,
+      sessionID: "session-1",
+      providerOptions: { setCacheKey: false },
+      allowExplicitCache: true,
+    })
+    expect(options.promptCacheOptions).toBeUndefined()
+  })
+
+  // allowExplicitCache defaults to false: an omitted argument must withhold
+  // caching, not grant it. The two failure directions are asymmetric - losing
+  // caching is invisible, but defaulting to "on" at every call site nobody has
+  // vetted is exactly the shape of bug that broke ChatGPT/Codex OAuth here.
+  test("default pin: message() with the argument omitted places no breakpoint, even for an API-key-shaped GPT-5.6+ model", () => {
+    const stock = buildMessages()
+    const result = ProviderTransform.message(buildMessages(), openaiModel, {}) as any[]
+    expect(result).toEqual(stock)
+    for (const msg of result) {
+      if (Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          expect(part.providerOptions).toBeUndefined()
+        }
+      } else {
+        expect(msg.providerOptions).toBeUndefined()
+      }
+    }
+  })
+
+  test("default pin: options() with allowExplicitCache omitted emits no promptCacheOptions", () => {
+    const result = ProviderTransform.options({ model: openaiModel, sessionID: "session-1" })
+    expect(result.promptCacheOptions).toBeUndefined()
+  })
+
+  test("OAuth: a GPT-5.6+ model gets no breakpoint anywhere - message() output is byte-identical to stock", () => {
+    const stock = buildMessages()
+    const result = ProviderTransform.message(buildMessages(), openaiModel, {}, false) as any[]
+    expect(result).toEqual(stock)
+    for (const msg of result) {
+      if (Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          expect(part.providerOptions).toBeUndefined()
+        }
+      } else {
+        expect(msg.providerOptions).toBeUndefined()
+      }
+    }
+  })
+
+  test("OAuth: a GPT-5.6+ model gets no promptCacheOptions - options() output is byte-identical to stock", () => {
+    const oauthResult = ProviderTransform.options({
+      model: openaiModel,
+      sessionID: "session-1",
+      allowExplicitCache: false,
+    })
+    const apiKeyResult = ProviderTransform.options({
+      model: openaiModel,
+      sessionID: "session-1",
+      allowExplicitCache: true,
+    })
+    expect(apiKeyResult.promptCacheOptions).toEqual({ mode: "explicit" })
+    expect(oauthResult.promptCacheOptions).toBeUndefined()
+
+    const { promptCacheOptions: _dropped, ...apiKeyWithoutCacheOptions } = apiKeyResult
+    expect(oauthResult).toEqual(apiKeyWithoutCacheOptions)
+  })
+
+  test("API-key auth (allowExplicitCache: true): the same model still gets both, exactly as today", () => {
+    const result = ProviderTransform.message(buildMessages(), openaiModel, {}, true) as any[]
+    const system = result.find((msg: any) => msg.role === "system")
+    expect(system.providerOptions?.openai?.promptCacheBreakpoint).toEqual({ mode: "explicit" })
+
+    const options = ProviderTransform.options({
+      model: openaiModel,
+      sessionID: "session-1",
+      allowExplicitCache: true,
+    })
+    expect(options.promptCacheOptions).toEqual({ mode: "explicit" })
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #48246

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`applyCaching()` is called behind a model-family gate that admits Anthropic-family models only, so models on `@ai-sdk/openai` never get an explicit cache anchor. They run on implicit prefix caching, and once anything mutates the message array mid-conversation, reuse pins at a fixed offset for the rest of the session.

Measured over 10 days on my own usage, the split follows model family rather than provider: ~32,000 Anthropic-family turns hold 100.0% cache reuse with essentially zero collapse, while `gpt-6-astra` sits at 92.1% with 8.5% of turns collapsed — about 39M tokens re-sent. `gpt-5.6-sol` is worse at 64.9%.

The change is two sites, because a message-path change alone ships half of it:

- **Breakpoint (message path).** A new `applyOpenAICacheBreakpoint()` places `promptCacheBreakpoint: { mode: "explicit" }` on the last content part of the same messages `applyCaching()` targets — first two system, last two non-system. That is at most four breakpoints, which is exactly OpenAI's documented per-request cache-write limit.
- **Mode (model path).** `prompt_cache_options` serializes from model-level options, so `promptCacheOptions: { mode: "explicit" }` goes in `options()` next to the existing `promptCacheKey`. Without it, implicit breakpoint selection stays on and the explicit markers do not take effect.

I deliberately did **not** widen the existing `applyCaching()` gate. That gate decides which models get `cache_control` / `cachePoint` blocks injected into message content, and admitting `@ai-sdk/openai` would mean enumerating which other `(provider, model)` pairs newly reach the function — in particular whether non-Claude `@ai-sdk/openai-compatible` models would start receiving `cache_control: { type: "ephemeral" }` blocks their upstream rejects. A separate path makes "Anthropic behaviour is unchanged" true by construction instead of by argument.

Both sites gate on `sdkKey(npm) === "openai"`. That is deliberately the same key the provider-options remap already uses, so `@ai-sdk/amazon-bedrock/mantle` comes along without a special case, and Copilot — whose `sdkKey` is `"copilot"` — is never touched. Copilot-hosted GPT models have the same gap for a different reason and need their own fix.

One difference from `applyCaching()` worth noting: where that function falls back to message-level `providerOptions` when the last content part is unusable, this one skips the message. The OpenAI SDK reads `promptCacheBreakpoint` from part-level provider options only, so a message-level write would be silently dead.

### How did you verify your code works?

`test/provider/transform.test.ts` gains a describe block covering the OpenAI-native path, `@ai-sdk/amazon-bedrock/mantle` sharing it via `sdkKey()`, an Anthropic model proving no `openai`-namespaced options appear, and a Copilot model proving the same.

One existing assertion changed: `"Non-DeepSeek providers leave reasoning content unchanged"` uses an `@ai-sdk/openai` model as its control and asserts exact content equality, so it now carries the new `providerOptions`. That is the expected consequence, not an unrelated edit.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
