### PR TITLE
fix(provider): parse dotless gpt major versions in the transform version gate

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1328,8 +1328,11 @@ export function options(input: {
 
   // Any gpt version above 5.4 in combination with azure does not support reasoningEffort
   // so we should return early here.
-  const [, gptMajorVersion, gptMinorVersion] = input.model.api.id.match(/gpt-(\d+)\.(\d+)/) ?? []
-  const isGpt55OrNewer = Number(gptMajorVersion) > 5 || (Number(gptMajorVersion) === 5 && Number(gptMinorVersion) >= 5)
+  const [, gptMajorVersion, gptMinorVersion] = input.model.api.id.match(/gpt-(\d+)(?:\.(\d+))?/) ?? []
+  const gptMajor = Number(gptMajorVersion)
+  const gptMinor = Number(gptMinorVersion ?? 0)
+  const hasGptMinorVersion = gptMinorVersion !== undefined
+  const isGpt55OrNewer = gptMajor > 5 || (gptMajor === 5 && gptMinor >= 5)
   if (input.model.api.npm === "@ai-sdk/azure" && input.providerOptions?.useCompletionUrls) {
     if (!isGpt55OrNewer) {
       result["reasoningEffort"] = "medium"
@@ -1337,8 +1340,8 @@ export function options(input: {
     return result
   }
 
-  if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
-    if (!input.model.api.id.includes("gpt-5-pro")) {
+  if (gptMajor >= 5 && !input.model.api.id.includes(`gpt-${gptMajor}-chat`)) {
+    if (!input.model.api.id.includes(`gpt-${gptMajor}-pro`)) {
       result["reasoningEffort"] = "medium"
       if (
         input.model.api.npm === "@ai-sdk/openai" ||
@@ -1356,7 +1359,7 @@ export function options(input: {
     // Generic OpenAI-compatible APIs do not necessarily support OpenAI's verbosity parameter.
     // Only enable the default for integrations known to implement it.
     if (
-      input.model.api.id.includes("gpt-5.") &&
+      (gptMajor > 5 || hasGptMinorVersion) &&
       !input.model.api.id.includes("codex") &&
       !input.model.api.id.includes("-chat") &&
       (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle")

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -625,6 +625,47 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
     expect(result.textVerbosity).toBeUndefined()
   })
+
+  test("gpt-6-astra should have textVerbosity set to low (dotless gpt-6+ id)", () => {
+    const model = createGpt5Model("gpt-6-astra")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.textVerbosity).toBe("low")
+  })
+
+  test("gpt-5.6-luna should have textVerbosity set to low (dotted path unchanged)", () => {
+    const model = createGpt5Model("gpt-5.6-luna")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.textVerbosity).toBe("low")
+  })
+
+  test("gpt-5-pro should NOT have textVerbosity set (no minor version)", () => {
+    const model = createGpt5Model("gpt-5-pro")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.textVerbosity).toBeUndefined()
+  })
+
+  test("gpt-5.3-codex-spark should NOT have textVerbosity set (codex models excluded)", () => {
+    const model = createGpt5Model("gpt-5.3-codex-spark")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.textVerbosity).toBeUndefined()
+  })
+
+  test("gpt-6-chat should NOT have textVerbosity set (chat excluded, same as gpt-5-chat)", () => {
+    const model = createGpt5Model("gpt-6-chat")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.textVerbosity).toBeUndefined()
+  })
+
+  // gpt-6-pro DOES get textVerbosity: the "-pro" guard only withholds the
+  // inner reasoningEffort/reasoningSummary/include options, never
+  // textVerbosity. This matches the existing gpt-5.2-pro precedent (a dotted
+  // -pro id also gets textVerbosity="low"); only the dotless gpt-5-pro lacks
+  // it, because it has no minor version at all.
+  test("gpt-6-pro should have textVerbosity set to low (matches dotted -pro precedent)", () => {
+    const model = createGpt5Model("gpt-6-pro")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.textVerbosity).toBe("low")
+  })
 })
 
 describe("ProviderTransform.options - gpt-5 reasoningEffort", () => {
@@ -714,6 +755,42 @@ describe("ProviderTransform.options - gpt-5 reasoningEffort", () => {
 
     expect(result.reasoningEffort).toBe("medium")
   })
+
+  // Pins the gpt version gate outcomes for dotless ids (e.g. gpt-6-astra) alongside
+  // the existing dotted ids, so a future family only shifts the ids it should.
+  // Only gpt-6-astra changes: azure+useCompletionUrls medium true->false,
+  // responses-path medium false->true.
+  // gpt-6-chat and gpt-6-pro pin the generalized (major-templated) chat/pro
+  // exclusions: both are correctly excluded from the responses-path block,
+  // same as gpt-5-chat/gpt-5-pro. Their completions-path value differs from
+  // the 5.x rows because isGpt55OrNewer (a separate, already-correct gate)
+  // is true for any major > 5.
+  test.each([
+    ["gpt-6-astra", false, true],
+    ["gpt-5.6-luna", false, true],
+    ["gpt-5.3-codex-spark", true, true],
+    ["gpt-5-pro", true, false],
+    ["gpt-5-chat", true, false],
+    ["gpt-6-chat", false, false],
+    ["gpt-6-pro", false, false],
+  ])(
+    "%s: azure completions medium=%s, responses medium=%s",
+    (apiId, completionsSetsMedium, responsesSetsMedium) => {
+      const completionsResult = ProviderTransform.options({
+        model: createModel(apiId),
+        sessionID,
+        providerOptions: { useCompletionUrls: true },
+      })
+      expect(completionsResult.reasoningEffort === "medium").toBe(completionsSetsMedium)
+
+      const responsesResult = ProviderTransform.options({
+        model: createModel(apiId),
+        sessionID,
+        providerOptions: {},
+      })
+      expect(responsesResult.reasoningEffort === "medium").toBe(responsesSetsMedium)
+    },
+  )
 })
 
 describe("ProviderTransform.options - gateway", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #48247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The version gate in `transform.ts` reads a model's GPT version with `/gpt-(\d+)\.(\d+)/`, which requires a dotted minor. `gpt-6-astra` has no minor, so the match fails, both capture groups are `undefined`, and `isGpt55OrNewer` evaluates `false` for a GPT-6 model. The comment above it says the gate exists because "any gpt version above 5.4 in combination with azure does not support reasoningEffort" — so a GPT-6 landing on `false` is the gate failing its own stated purpose.

`session/system.ts` already recognises the family (`if (model.api.id.includes("gpt-6")) return [PROMPT_ASTRA]`), so the two files currently disagree about how to identify the same model.

Three sites consume the parse, and fixing only the first leaves the visible symptom in place:

1. The regex itself — minor is now optional and defaults to `0`. The old code got `gpt-5-pro` right by accident: the match failed, so `Number(undefined)` was `NaN` and every comparison against `NaN` is false. This version gets it right because 5.0 < 5.5.
2. `id.includes("gpt-5")` at the family gate — now `gptMajor >= 5`, still excluding `gpt-5-chat`.
3. `id.includes("gpt-5.")` at the `textVerbosity` check — that substring means "has a minor", so it is now `gptMajor > 5 || hasGptMinorVersion`. Without this one, `gpt-6-astra` still misses `textVerbosity: "low"`, which is the user-visible half of the bug.

The version is parsed once and reused rather than re-tested three ways. Note this changes site 2 from "the id contains `gpt-5` anywhere" to "the first parsed `gpt-N` is >= 5". I could not find a catalog id where those differ, and the full `test/provider/` suite passes unchanged, but it is a semantic change rather than a pure refactor and worth a maintainer's eye.

**One deliberate behaviour change worth flagging:** correcting `isGpt55OrNewer` to `true` for GPT-6 means the Azure + `useCompletionUrls` early return stops setting `reasoningEffort: "medium"` for GPT-6 models. That follows directly from the comment above it — GPT-6 is above 5.4 — but it is a real change on that path, not just a parsing fix, so it should be a deliberate call rather than a side effect.

### How did you verify your code works?

I probed the real `ProviderTransform.options` with azure and openai model fixtures across five ids, ran it against this branch and against `dev`, and diffed the results:

| id | azure + `useCompletionUrls` medium | responses medium | openai `textVerbosity` |
| --- | --- | --- | --- |
| `gpt-6-astra` | **true → false** | **false → true** | **undefined → "low"** |
| `gpt-5.6-luna` | false → false | true → true | "low" → "low" |
| `gpt-5.3-codex-spark` | true → true | true → true | undefined → undefined |
| `gpt-5-pro` | true → true | false → false | undefined → undefined |
| `gpt-5-chat` | true → true | false → false | undefined → undefined |

Only `gpt-6-astra` moves, on all three axes.

`test/provider/transform.test.ts` gains a parametrized table over those five ids and four `textVerbosity` cases — 570 pass, 0 fail. Reverting the source change while keeping the tests fails exactly two: the `gpt-6-astra` row and the `gpt-6-astra` verbosity case. `bun run typecheck` is clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
