### PR TITLE
fix(opencode): request summarized adaptive thinking

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -176,7 +176,7 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
         variants[effort] = {
           thinking: {
             type: "adaptive",
-            ...(model.api.id.includes("opus-4.7") ? { display: "summarized" } : {}),
+            display: "summarized",
           },
           effort,
         }


### PR DESCRIPTION
Closes #46593

Uses Copilot’s `adaptive_thinking` capability and always requests `display: "summarized"`, matching VS Code.

Co-authored-by: @afriemann