### PR TITLE
fix(core): request summarized adaptive thinking

### DIFF
--- a/packages/core/src/github-copilot/models.ts
+++ b/packages/core/src/github-copilot/models.ts
@@ -203,7 +203,7 @@ function variants(remote: UsableModel, messages: boolean): Model.Info["variants"
       settings: {
         thinking: {
           type: "adaptive",
-          ...(remote.id.includes("opus-4.7") ? { display: "summarized" } : {}),
+          display: "summarized",
         },
         effort,
       },


### PR DESCRIPTION
Closes #46593

V2 port of #48269. Uses Copilot’s `adaptive_thinking` capability and always requests `display: "summarized"`, matching VS Code.

Co-authored-by: @afriemann