### PR TITLE
fix(tui): ignore parked synthetic inbox for tab busy

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -169,7 +169,12 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
           : members.some((id) => (data.session.form.list(id)?.length ?? 0) > 0)
             ? ("question" as const)
             : (false as const),
-        busy: members.some((id) => data.session.status(id) === "running" || data.session.pending.list(id).length > 0),
+        // Parked synthetic context (user shells, plan reminders) stays pending without execution; only work counts as busy.
+        busy: members.some(
+          (id) =>
+            data.session.status(id) === "running" ||
+            data.session.pending.list(id).some((item) => item.type !== "synthetic"),
+        ),
         renaming: data.session.title.pending(session),
       }
     }


### PR DESCRIPTION
User-invoked shells (!command) admit a synthetic completion with resume:false, which parks in the inbox without execution. Tab busy counted any pending row, so the tab showed running forever until the next prompt.

Busy now counts only work items (user/compaction/move); parked synthetic context no longer marks the tab busy.

- packages/tui/src/context/session-tabs.tsx: filter synthetic pending from busy
- packages/tui/test/context/session-tabs.test.tsx: regression test + busy assertion