### PR TITLE
fix(core): run compaction hooks before appending the summary prompt

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -446,7 +446,6 @@ export const layer = Layer.effect(
     const compactionRequest = (
       input: ExecuteInput,
       messages: readonly SessionMessage.Info[],
-      prompt: Message[],
       webSocket?: "session",
     ) => {
       const context = input.context
@@ -466,7 +465,6 @@ export const layer = Layer.effect(
         messages: [
           ...transcript.messages,
           ...(input.instructionUpdate ? [Message.system(input.instructionUpdate)] : []),
-          ...prompt,
         ],
         webSocket,
       })
@@ -486,7 +484,7 @@ export const layer = Layer.effect(
           inputID: input.inputID,
           error: { type: "provider.unsupported-operation", message },
         })
-      const prepared = yield* compactionRequest(input, context.messages, [], "session")
+      const prepared = yield* compactionRequest(input, context.messages, "session")
       if (prepared.event.result) {
         yield* started(input, "")
         return yield* supplied(input, prepared.event.result, "")
@@ -603,10 +601,12 @@ export const layer = Layer.effect(
       )
       // Checkpoints from the previous template ran far longer than this one asks for; its catch-all heading identifies them.
       const legacy = previous?.summary.includes(LEGACY_HEADING) ?? false
-      const prepared = yield* compactionRequest(input, history.messages, [
-        Message.user(buildPrompt(previous !== undefined, legacy)),
-      ])
+      const prepared = yield* compactionRequest(input, history.messages)
       if (prepared.event.result) return yield* supplied(input, prepared.event.result, history.recent)
+      // Hooks see the transcript alone; the summary prompt is appended after they run.
+      const first = LLMRequest.update(prepared.request, {
+        messages: [...prepared.request.messages, Message.user(buildPrompt(previous !== undefined, legacy))],
+      })
       // Both requests share the retry allowance; rejected output never enters the reminder request.
       const transient = SessionRunnerRetry.transient(yield* SessionRunnerRetry.policy(context.session.id), {
         agent: context.agent.id,
@@ -614,10 +614,10 @@ export const layer = Layer.effect(
         hook: prepared.retry,
       })
       for (const request of [
-        prepared.request,
-        LLMRequest.update(prepared.request, {
+        first,
+        LLMRequest.update(first, {
           messages: [
-            ...prepared.request.messages,
+            ...first.messages,
             Message.user(
               "The previous response did not fill in the required summary template. Do not call tools. Return the summary as text using the exact section headings from the template.",
             ),

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -358,6 +358,14 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     }
     const session = yield* insertSession(sessionID, { parent_id: parentID })
     const modelRequests = yield* SessionModelRequest.Service
+    const hooks = yield* PluginHooks.Service
+    let hooked = 0
+    yield* hooks.register("session", "compaction", (event) =>
+      Effect.sync(() => {
+        hooked = event.messages.length
+        expect(JSON.stringify(event.messages)).not.toContain("Summarize only what")
+      }),
+    )
     const messages = [
       userMessage,
       SessionMessage.Shell.make({
@@ -410,6 +418,8 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(JSON.stringify(requests[0]?.messages)).toContain("Manual compaction should include this short conversation.")
     expect(JSON.stringify(requests[0]?.messages)).toContain("Use Effect services and generators.")
     expect(JSON.stringify(requests[0]?.messages)).toContain("User shell pwd completed: /project")
+    expect(requests[0]?.messages).toHaveLength(hooked + 1)
+    expect(JSON.stringify(requests[0]?.messages.at(-1))).toContain("Summarize only what")
     expect(JSON.stringify(requests[0]?.messages)).not.toContain("display-only-output")
     // The compaction message carries its own request usage so clients can show what compacting cost.
     expect(yield* store.context(sessionID)).toMatchObject([

--- a/services/www/src/docs/content/build/plugins/index.mdx
+++ b/services/www/src/docs/content/build/plugins/index.mdx
@@ -1204,8 +1204,9 @@ kind of request a session issues has its own hook, so a plugin can treat the age
 differently:
 
 - `context` runs for the agent loop, including tool-driven continuations.
-- `compaction` runs for checkpoint summaries. Set `result` to record the compaction yourself and skip the model
-  call; it takes the same fields as a completed compaction message.
+- `compaction` runs for checkpoint summaries. `messages` is the transcript being summarized; OpenCode appends its
+  summary prompt after hooks run. Set `result` to record the compaction yourself and skip the model call; it takes the
+  same fields as a completed compaction message.
 - `generate` runs for transient `ctx.session.generate` calls.
 - `title` runs for title generation. It has no `agent` or `tools`. Set `result` to supply the title yourself.
 


### PR DESCRIPTION
The \`compaction\` hook saw \`messages\` as \`[...transcript, Message.user(<summary template>)]\`, so the summary prompt sat inside the mutable array. Generic message rewriters (e.g. \`optimize\`) touched it by accident, and replacing it meant finding the last user message.

Hooks now see the transcript alone (plus any instruction update); core appends the template prompt after hooks run, matching how the provider path already presents the request. \`compactionRequest\` drops its \`prompt\` parameter.

Test: the manual compaction test registers a hook and asserts it never sees the template while the outgoing request ends with it.