### PR TITLE
refactor(codemode): collapse repeated loop, promise, and Object shapes

### DIFF
--- a/packages/codemode/src/codemode.ts
+++ b/packages/codemode/src/codemode.ts
@@ -105,7 +105,7 @@ export type Result = typeof Result.Type
 
 /** Reusable confined runtime over explicit tools. */
 export type Runtime<R = never> = {
-  readonly catalog: () => ReadonlyArray<ToolDescription>
+  readonly catalog: ReadonlyArray<ToolDescription>
   readonly execute: (code: string) => Effect.Effect<Result, never, R>
 }
 
@@ -134,7 +134,7 @@ export const make = <const Provided extends Record<string, unknown> = {}>(
   const prepared = ToolRuntime.prepare((options.tools ?? {}) as Tools<Services<Provided>>)
   const limits = resolveExecutionLimits(options.limits)
   return {
-    catalog: () => prepared.catalog,
+    catalog: prepared.catalog,
     execute: (code) => executeProgram(code, prepared, limits, options),
   }
 }

--- a/packages/codemode/src/interpreter/promises.ts
+++ b/packages/codemode/src/interpreter/promises.ts
@@ -32,6 +32,17 @@ export class PromiseRuntime<R> {
 
   constructor(private readonly scope: Scope.Scope) {}
 
+  // Resolution bodies need the promise's own identity to reject `resolve(promise)` self-resolution.
+  createWithSelf(
+    body: (self: { promise?: Values.Promise }) => Effect.Effect<unknown, unknown, R>,
+  ): Effect.Effect<Values.Promise, never, R> {
+    const self: { promise?: Values.Promise } = {}
+    return Effect.map(this.create(body(self)), (promise) => {
+      self.promise = promise
+      return promise
+    })
+  }
+
   create(effect: Effect.Effect<unknown, unknown, R>): Effect.Effect<Values.Promise, never, R> {
     return Effect.suspend(() => {
       // Allocate before forking so reruns get distinct IDs and diagnostics retain creation order.
@@ -126,11 +137,7 @@ export const resolvePromise = <R>(
   node: AstNode,
 ): Effect.Effect<Values.Promise, never, R> => {
   if (value instanceof Values.Promise) return Effect.succeed(value)
-  const box: { promise?: Values.Promise } = {}
-  return Effect.map(promises.create(resolvePromiseValue(runner, value, node, box)), (promise) => {
-    box.promise = promise
-    return promise
-  })
+  return promises.createWithSelf((self) => resolvePromiseValue(runner, value, node, self))
 }
 
 const promiseStatics = ["all", "allSettled", "race", "any", "resolve", "reject"] as const
@@ -254,11 +261,9 @@ const constructPromise = <R>(
   }
   return Effect.gen(function* () {
     const deferred = Deferred.makeUnsafe<unknown, unknown>()
-    const box: { promise?: Values.Promise } = {}
-    const promise = yield* promises.create(
-      Effect.flatMap(Deferred.await(deferred), (value) => resolvePromiseValue(runner, value, node, box)),
+    const promise = yield* promises.createWithSelf((self) =>
+      Effect.flatMap(Deferred.await(deferred), (value) => resolvePromiseValue(runner, value, node, self)),
     )
-    box.promise = promise
     const resolve = capability("resolve", (value) => Deferred.doneUnsafe(deferred, Exit.succeed(value)))
     const reject = capability("reject", (value) => Deferred.doneUnsafe(deferred, Exit.fail(new ProgramThrow(value))))
     const executed = yield* Effect.exit(runner.invokeFunction(executor, [resolve, reject]))
@@ -310,19 +315,16 @@ const chainReaction = <R>(
   method: string,
   node: AstNode,
 ): Effect.Effect<Values.Promise, never, R> => {
-  const box: { promise?: Values.Promise } = {}
-  const body = Effect.gen(function* () {
-    const exit = yield* reactionExit(promises, source)
-    const handler = Exit.isSuccess(exit) ? onFulfilled : onRejected
-    if (handler === undefined) return yield* exit
-    const input = Exit.isSuccess(exit) ? exit.value : caughtErrorValue(Cause.squash(exit.cause))
-    const result = yield* applyCollectionCallback(runner, handler, method, node)([input])
-    return yield* resolvePromiseValue(runner, result, node, box)
-  })
-  return Effect.map(promises.create(body), (derived) => {
-    box.promise = derived
-    return derived
-  })
+  return promises.createWithSelf((self) =>
+    Effect.gen(function* () {
+      const exit = yield* reactionExit(promises, source)
+      const handler = Exit.isSuccess(exit) ? onFulfilled : onRejected
+      if (handler === undefined) return yield* exit
+      const input = Exit.isSuccess(exit) ? exit.value : caughtErrorValue(Cause.squash(exit.cause))
+      const result = yield* applyCollectionCallback(runner, handler, method, node)([input])
+      return yield* resolvePromiseValue(runner, result, node, self)
+    }),
+  )
 }
 
 const chainFinally = <R>(

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -90,6 +90,18 @@ import { enumerableSource } from "../stdlib/object.js"
 import { coerceToNumber, coerceToString, compoundOperators, errorBrandName } from "../stdlib/value.js"
 import { Values } from "../values.js"
 
+// What a loop does with its body's result: exit with a StatementResult, or undefined to keep iterating.
+// Unlabelled break ends this loop; a label the loop does not carry propagates outward.
+const loopExit = (result: StatementResult, labels: ReadonlySet<string> | undefined): StatementResult | undefined => {
+  if (result.kind === "return") return result
+  if (result.kind === "break") {
+    if (result.label !== undefined && !labels?.has(result.label)) return result
+    return { kind: "none" }
+  }
+  if (result.kind === "continue" && result.label !== undefined && !labels?.has(result.label)) return result
+  return undefined
+}
+
 const calleeDescription = (callee: Expression | Super | undefined): string => {
   if (callee?.type === "Identifier") return callee.name
   if (callee?.type === "MemberExpression") {
@@ -466,21 +478,8 @@ class Frame<R> {
     const self = this
     return Effect.gen(function* () {
       while (yield* self.evaluateExpression(node.test)) {
-        const result = yield* self.evaluateStatement(node.body)
-
-        if (result.kind === "continue") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          continue
-        }
-
-        if (result.kind === "break") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          return { kind: "none" } satisfies StatementResult
-        }
-
-        if (result.kind === "return") {
-          return result
-        }
+        const exit = loopExit(yield* self.evaluateStatement(node.body), labels)
+        if (exit !== undefined) return exit
       }
 
       return { kind: "none" } satisfies StatementResult
@@ -494,21 +493,8 @@ class Frame<R> {
     const self = this
     return Effect.gen(function* () {
       do {
-        const result = yield* self.evaluateStatement(node.body)
-
-        if (result.kind === "continue") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          continue
-        }
-
-        if (result.kind === "break") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          return { kind: "none" } satisfies StatementResult
-        }
-
-        if (result.kind === "return") {
-          return result
-        }
+        const exit = loopExit(yield* self.evaluateStatement(node.body), labels)
+        if (exit !== undefined) return exit
       } while (yield* self.evaluateExpression(node.test))
 
       return { kind: "none" } satisfies StatementResult
@@ -554,26 +540,12 @@ class Frame<R> {
       nextIteration()
 
       while (testNode ? yield* self.evaluateExpression(testNode) : true) {
-        const result = yield* self.evaluateStatement(node.body)
-
-        if (result.kind === "return") {
-          return result
-        }
-
-        if (result.kind === "break") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          return { kind: "none" } satisfies StatementResult
-        }
-
-        if (result.kind === "continue" && result.label !== undefined && !labels?.has(result.label)) return result
+        const exit = loopExit(yield* self.evaluateStatement(node.body), labels)
+        if (exit !== undefined) return exit
 
         nextIteration()
         if (updateNode) {
           yield* self.evaluateExpression(updateNode)
-        }
-
-        if (result.kind === "continue") {
-          continue
         }
       }
 
@@ -647,22 +619,10 @@ class Frame<R> {
           }
           return yield* Effect.failCause(bodyExit.cause)
         }
-        const result = bodyExit.value
-
-        if (result.kind === "return") {
+        const exit = loopExit(bodyExit.value, labels)
+        if (exit !== undefined) {
           yield* close()
-          return result
-        }
-
-        if (result.kind === "break") {
-          yield* close()
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          return { kind: "none" } satisfies StatementResult
-        }
-
-        if (result.kind === "continue" && result.label !== undefined && !labels?.has(result.label)) {
-          yield* close()
-          return result
+          return exit
         }
       }
     }).pipe(
@@ -890,19 +850,8 @@ class Frame<R> {
           ),
         )
 
-        if (result.kind === "return") {
-          return result
-        }
-
-        if (result.kind === "break") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          return { kind: "none" } satisfies StatementResult
-        }
-
-        if (result.kind === "continue") {
-          if (result.label !== undefined && !labels?.has(result.label)) return result
-          continue
-        }
+        const exit = loopExit(result, labels)
+        if (exit !== undefined) return exit
       }
 
       return { kind: "none" } satisfies StatementResult

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -134,19 +134,6 @@ const constructObject = (args: Array<unknown>, node: AstNode): unknown => {
   )
 }
 
-// Tool references are not data; only Object.keys(tools) reads them, for tool names.
-const rejectTools = (name: string, args: Array<unknown>, node: AstNode): void => {
-  if (!(args[0] instanceof ToolReference)) return
-  throw new InterpreterRuntimeError(
-    `Object.${name}(...) cannot read tool references: they are not plain data. Use Object.keys(tools) for names, or search({ query }) for signatures.`,
-    node,
-    "InvalidDataValue",
-  )
-}
-
-const objectStatic = (name: string, impl: (args: Array<unknown>, node: AstNode) => unknown) =>
-  sync(`Object.${name}`, impl)
-
 // Object constructs identically with or without new, like JS. Only `keys` copies its result into the
 // program; `values`, `entries`, `assign`, and `fromEntries` hand back the program's own values.
 export const objectGlobal = <R>(runner: Runner<R>, toolKeys: (path: ReadonlyArray<string>) => ReadonlyArray<string>) =>
@@ -164,32 +151,28 @@ export const objectGlobal = <R>(runner: Runner<R>, toolKeys: (path: ReadonlyArra
           "Object.keys result",
         ),
       ),
-      values: objectStatic("values", (args, node) =>
+      values: sync("Object.values", (args, node) =>
         Object.values(enumerableSource("Object.values(...)", args[0], node)),
       ),
-      entries: objectStatic("entries", (args, node) =>
+      entries: sync("Object.entries", (args, node) =>
         Object.entries(enumerableSource("Object.entries(...)", args[0], node)).map(([key, item]) => [key, item]),
       ),
-      hasOwn: objectStatic("hasOwn", (args, node) =>
+      hasOwn: sync("Object.hasOwn", (args, node) =>
         Object.hasOwn(
           enumerableSource("Object.hasOwn(...)", args[0], node),
           args[1] === AsyncIteratorSymbol || args[1] === IteratorSymbol ? args[1] : String(args[1]),
         ),
       ),
-      is: objectStatic("is", (args, node) => {
+      is: sync("Object.is", (args, node) => {
         if (containsOpaqueReference(args[0]) || containsOpaqueReference(args[1])) {
           throw new InterpreterRuntimeError("Object.is requires data values.", node, "InvalidDataValue")
         }
         return Object.is(args[0], args[1])
       }),
-      assign: objectStatic("assign", objectAssign),
+      assign: sync("Object.assign", objectAssign),
       fromEntries: new HostFunction<R>({
         name: "Object.fromEntries",
-        call: (args, node) =>
-          Effect.suspend(() => {
-            rejectTools("fromEntries", args, node)
-            return objectFromEntries(runner, args[0], node)
-          }),
+        call: (args, node) => Effect.suspend(() => objectFromEntries(runner, args[0], node)),
       }),
       groupBy: groupBy(runner, "Object"),
     },

--- a/packages/codemode/test/codemode.test.ts
+++ b/packages/codemode/test/codemode.test.ts
@@ -528,7 +528,7 @@ describe("CodeMode schema flexibility", () => {
     })
     const runtime = CodeMode.make({ tools: { adapter: { call } } })
 
-    expect(runtime.catalog()).toStrictEqual([
+    expect(runtime.catalog).toStrictEqual([
       {
         path: "adapter.call",
         description: "Call an adapter-described tool",
@@ -611,7 +611,7 @@ describe("CodeMode schema flexibility", () => {
     })
     const runtime = CodeMode.make({ tools: { users: { lookup } } })
 
-    expect(runtime.catalog()).toStrictEqual([
+    expect(runtime.catalog).toStrictEqual([
       {
         path: "users.lookup",
         description: "Look up a user",
@@ -631,7 +631,7 @@ describe("CodeMode schema flexibility", () => {
       execute: () => Effect.succeed("pong"),
     })
     const runtime = CodeMode.make({ tools: { net: { ping } } })
-    expect(runtime.catalog()[0]?.signature).toBe("tools.net.ping(input: {\n  host: string,\n}): Promise<void>")
+    expect(runtime.catalog[0]?.signature).toBe("tools.net.ping(input: {\n  host: string,\n}): Promise<void>")
 
     const result = await Effect.runPromise(runtime.execute(`return await tools.net.ping({ host: "example.test" })`))
     expect(result.ok).toBe(true)
@@ -684,7 +684,7 @@ describe("CodeMode public contract", () => {
 
   test("describes the catalog and keeps the search built-in registered", async () => {
     const runtime = CodeMode.make({ tools })
-    expect(runtime.catalog()).toStrictEqual([
+    expect(runtime.catalog).toStrictEqual([
       {
         path: "orders.lookup",
         description: "Look up an order by ID",
@@ -726,8 +726,8 @@ describe("CodeMode public contract", () => {
     const first = CodeMode.make({ tools: { zeta: { zeta, alpha }, alpha: { zeta, alpha } } })
     const second = CodeMode.make({ tools: { alpha: { alpha, zeta }, zeta: { alpha, zeta } } })
 
-    expect(first.catalog()).toStrictEqual(second.catalog())
-    expect(first.catalog().map((tool) => tool.path)).toEqual(["alpha.alpha", "alpha.zeta", "zeta.alpha", "zeta.zeta"])
+    expect(first.catalog).toStrictEqual(second.catalog)
+    expect(first.catalog.map((tool) => tool.path)).toEqual(["alpha.alpha", "alpha.zeta", "zeta.alpha", "zeta.zeta"])
   })
 
   test("renders bracket notation for tool names that are not JavaScript identifiers", async () => {
@@ -739,7 +739,7 @@ describe("CodeMode public contract", () => {
     })
     const runtime = CodeMode.make({ tools: { context7: { "resolve-library-id": resolveLibrary } } })
 
-    expect(runtime.catalog()).toStrictEqual([
+    expect(runtime.catalog).toStrictEqual([
       {
         path: "context7.resolve-library-id",
         description: "Resolve a library ID",

--- a/packages/codemode/test/signature.test.ts
+++ b/packages/codemode/test/signature.test.ts
@@ -740,7 +740,7 @@ describe("JSDoc signatures in catalogs and search results", () => {
       "}",
     ].join("\n")
     const signature = `tools.constrained(input: ${type}): Promise<${type}>`
-    expect(runtime.catalog()[0]?.signature).toBe(signature)
+    expect(runtime.catalog[0]?.signature).toBe(signature)
     const result = await Effect.runPromise(runtime.execute('return search({ query: "tools.constrained" })'))
     expect(result.ok).toBe(true)
     if (!result.ok) throw new Error("search failed")
@@ -796,7 +796,7 @@ describe("JSDoc signatures in catalogs and search results", () => {
   })
 
   test("the catalog uses the same JSDoc signatures as search", async () => {
-    const catalog = runtime.catalog()
+    const catalog = runtime.catalog
     const github = (await search("list issues repository")).items.find(
       ({ path }) => path === "tools.github.list_issues",
     )!
@@ -824,7 +824,7 @@ describe("non-identifier tool paths", () => {
   const runtime = CodeMode.make({ tools: { context7: { "resolve-library-id": resolveLibrary } } })
 
   test("catalog signatures use bracket notation for dashed tool names", () => {
-    expect(runtime.catalog()[0]?.signature).toBe(
+    expect(runtime.catalog[0]?.signature).toBe(
       'tools.context7["resolve-library-id"](input: {\n  query: string,\n  libraryName: string,\n}): Promise<unknown>',
     )
   })

--- a/packages/codemode/test/tool-paths.test.ts
+++ b/packages/codemode/test/tool-paths.test.ts
@@ -26,7 +26,7 @@ describe("dotted tool names", () => {
   const runtime = CodeMode.make({ tools: { api: { "issues.list": echo("List issues", "listed") } } })
 
   test("a dotted name becomes nested namespaces in the catalog", () => {
-    const catalog = runtime.catalog()
+    const catalog = runtime.catalog
     expect(catalog).toHaveLength(1)
     expect(catalog[0]?.path).toBe("api.issues.list")
     expect(catalog[0]?.signature).toStartWith("tools.api.issues.list(")
@@ -51,7 +51,7 @@ describe("dotted tool names", () => {
 
   test("a top-level dotted name nests from the root", async () => {
     const flat = CodeMode.make({ tools: { "issues.list": echo("List issues", "flat") } })
-    expect(flat.catalog()[0]?.path).toBe("issues.list")
+    expect(flat.catalog[0]?.path).toBe("issues.list")
     expect(await value(flat, `return await tools.issues.list({})`)).toBe("flat")
   })
 
@@ -85,7 +85,7 @@ describe("callable namespaces", () => {
   test("a path can hold a tool and child tools at once", async () => {
     expect(await value(runtime, `return await tools.issues({})`)).toBe("all")
     expect(await value(runtime, `return await tools.issues.list({})`)).toBe("list")
-    expect(runtime.catalog().map((tool) => tool.path)).toEqual(["issues", "issues.list"])
+    expect(runtime.catalog.map((tool) => tool.path)).toEqual(["issues", "issues.list"])
   })
 
   test("a callable namespace enumerates its children", async () => {
@@ -145,7 +145,7 @@ describe("tool input diagnostics", () => {
 
   test("an empty-input tool advertises () and runs with zero arguments", async () => {
     const empty = CodeMode.make({ tools: { ping: echo("Ping", "pong") } })
-    expect(empty.catalog()[0]?.signature).toBe("tools.ping(): Promise<string>")
+    expect(empty.catalog[0]?.signature).toBe("tools.ping(): Promise<string>")
     expect(await value(empty, `return await tools.ping()`)).toBe("pong")
   })
 })
@@ -160,7 +160,7 @@ describe("blocked member names on tool paths", () => {
   })
 
   test("tools may use blocked member names because path segments never touch real properties", async () => {
-    expect(runtime.catalog().map((tool) => tool.path)).toEqual(["issues.constructor", "nested.__proto__", "prototype"])
+    expect(runtime.catalog.map((tool) => tool.path)).toEqual(["issues.constructor", "nested.__proto__", "prototype"])
     expect(await value(runtime, `return await tools.prototype({})`)).toBe("proto")
     expect(await value(runtime, `return await tools.issues.constructor({})`)).toBe("ctor")
     expect(await value(runtime, `return await tools["issues.constructor"]({})`)).toBe("ctor")
@@ -172,7 +172,7 @@ describe("blocked member names on tool paths", () => {
     const poisoned = CodeMode.make({
       tools: { ns: { __proto__: echo("Hidden", "hidden"), real: echo("Real tool", "real") } },
     })
-    expect(poisoned.catalog().map((tool) => tool.path)).toEqual(["ns.real"])
+    expect(poisoned.catalog.map((tool) => tool.path)).toEqual(["ns.real"])
     expect(await value(poisoned, `return await tools.ns.real({})`)).toBe("real")
   })
 
@@ -221,7 +221,7 @@ describe("namespace metadata", () => {
   const runtime = CodeMode.make({ tools })
 
   test("the wrapper does not add a segment to callable paths", async () => {
-    expect(runtime.catalog().map((tool) => tool.path)).toEqual(["api.status", "api.users.list", "plain.read"])
+    expect(runtime.catalog.map((tool) => tool.path)).toEqual(["api.status", "api.users.list", "plain.read"])
     expect(await value(runtime, `return await tools.api.users.list({})`)).toBe("users")
   })
 
@@ -260,8 +260,8 @@ describe("canonical path collisions", () => {
       tools: { "issues.list": echo("First", "first"), issues: { list: echo("Second", "second") } },
     })
     expect(await value(runtime, `return await tools.issues.list({})`)).toBe("second")
-    expect(runtime.catalog()).toHaveLength(1)
-    expect(runtime.catalog()[0]?.description).toBe("Second")
+    expect(runtime.catalog).toHaveLength(1)
+    expect(runtime.catalog[0]?.description).toBe("Second")
   })
 
   test("overriding one path keeps sibling tools from both shapes", async () => {
@@ -272,7 +272,7 @@ describe("canonical path collisions", () => {
         "issues.close": echo("Close issue", "closed"),
       },
     })
-    expect(runtime.catalog().map((tool) => tool.path)).toEqual(["issues.close", "issues.get", "issues.list"])
+    expect(runtime.catalog.map((tool) => tool.path)).toEqual(["issues.close", "issues.get", "issues.list"])
     expect(await value(runtime, `return await tools.issues.list({})`)).toBe("second")
     expect(await value(runtime, `return await tools.issues.get({})`)).toBe("got")
     expect(await value(runtime, `return await tools.issues.close({})`)).toBe("closed")

--- a/packages/core/src/codemode/tool.ts
+++ b/packages/core/src/codemode/tool.ts
@@ -166,7 +166,7 @@ export const catalog = (inventory: Inventory) => {
   )
   const root: CatalogNode = { children: new Map() }
   for (const namespace of inventory.namespaces?.values() ?? []) getNode(root, namespace.name).namespace = namespace
-  for (const tool of runtime(inventory, () => Effect.fail(toolError("Execute context is unavailable"))).catalog())
+  for (const tool of runtime(inventory, () => Effect.fail(toolError("Execute context is unavailable"))).catalog)
     getNode(root, tool.path).tool = {
       type: "tool",
       name: tool.path.split(".").at(-1) ?? tool.path,


### PR DESCRIPTION
## Summary

No behaviour change. Four duplicated shapes collapsed, one dead wrapper removed.

```text
runtime.ts     break/continue/return handling written out in 5 loops   →  one loopExit(result, labels)
promises.ts    box = {}; create(...); box.promise = p   ×3             →  PromiseRuntime.createWithSelf(body)
object.ts      rejectTools + objectStatic (dead since #48257)          →  removed; sync("Object.x", …) directly
codemode.ts    Runtime.catalog: () => prepared.catalog                 →  Runtime.catalog: prepared.catalog
```

**`loopExit`** encodes the one rule all five loops shared: `return` propagates, an unlabelled `break` ends this loop, a labelled `break`/`continue` the loop does not own propagates, anything else keeps iterating. `switch` is untouched — it propagates `continue`, so it is a different rule.

**`createWithSelf`** exists because a promise's resolution body has to know the promise's own identity to reject `resolve(promise)` self-resolution, and the promise does not exist until `create` returns. The three sites (`Promise.resolve`, `new Promise`, `.then/.catch`) each hand-rolled the same mutable box.

**`catalog`** was a thunk over an eagerly-computed, immutable array. It is now the array. One caller in `packages/core/src/codemode/tool.ts` drops its `()`; the public `Runtime` type changes shape, so this is the one externally visible edit.

`Object.fromEntries(tools)` loses its bespoke tool-reference hint and now reports the generic `expects a synchronous iterable of entries`, which is accurate.

- [x] `bun typecheck` (codemode, core)
- [x] `bun test` — 1184 pass