### PR TITLE
fix(core): preserve configured Cloudflare gateway auth

### DIFF
--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -348,9 +348,14 @@ export const layer = Layer.effect(
 )
 
 function hasConfiguredAuth(model: Info) {
-  return [model.settings?.apiKey, model.settings?.authToken, model.settings?.accessToken].some(
-    (value) => typeof value === "string" && value !== "",
-  )
+  return [
+    model.settings?.apiKey,
+    model.settings?.authToken,
+    model.settings?.accessToken,
+    Provider.packageName(model.package) === "@opencode/ai/providers/cloudflare-ai-gateway"
+      ? model.settings?.gatewayApiKey
+      : undefined,
+  ].some((value) => typeof value === "string" && value !== "")
 }
 
 function usesAPIKeyAuth(packageName: string | undefined) {

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -301,7 +301,7 @@ describe("ModelResolver", () => {
     ),
   )
 
-  it.effect("uses no native API-key auth for explicitly enabled providers without credentials", () => {
+  it.effect("preserves configured auth for explicitly enabled providers without integration credentials", () => {
     const selected = model(Provider.aisdk("@ai-sdk/google"), {
       providerID: Provider.ID.make("gateway"),
       canonical: Provider.ID.google,
@@ -317,7 +317,7 @@ describe("ModelResolver", () => {
       }),
       model("@opencode/ai/providers/mistral", {
         providerID: Provider.ID.make("gateway"),
-        settings: { baseURL: "https://native-mistral.example.com/v1" },
+        settings: { baseURL: "https://native-mistral.example.com/v1", gatewayApiKey: "gateway-fixture" },
         headers: { "cf-access-token": "access-token" },
       }),
       ...["baseten", "cloudflare-ai-gateway", "cloudflare-workers-ai", "deepseek", "fireworks"].map((name) =>
@@ -406,7 +406,43 @@ describe("ModelResolver", () => {
             expect(headers["cf-access-token"]).toBe("access-token")
             expect(headers.authorization).toBeUndefined()
             expect(headers["x-goog-api-key"]).toBeUndefined()
+            expect(headers["cf-aig-authorization"]).toBeUndefined()
           }),
+        )
+        yield* Effect.forEach(
+          [
+            { settings: { gatewayApiKey: "gateway-fixture" }, gateway: "Bearer gateway-fixture", upstream: undefined },
+            {
+              settings: { gatewayApiKey: "gateway-fixture", apiKey: "upstream-fixture" },
+              gateway: "Bearer gateway-fixture",
+              upstream: "Bearer upstream-fixture",
+            },
+            { settings: { apiKey: "upstream-fixture" }, gateway: undefined, upstream: "Bearer upstream-fixture" },
+            { settings: { gatewayApiKey: "" }, gateway: undefined, upstream: undefined },
+          ],
+          (entry) =>
+            Effect.forEach(["@opencode/ai", "@opencode-ai/ai"], (name) =>
+              Effect.gen(function* () {
+                const resolved = yield* resolver.resolveModel(
+                  model(`${name}/providers/cloudflare-ai-gateway`, {
+                    providerID: selected.providerID,
+                    settings: { baseURL: "https://gateway.test/v1/compat", ...entry.settings },
+                    headers: { "cf-access-token": "access-fixture" },
+                  }),
+                )
+                const headers = yield* resolved.model.route.auth.apply({
+                  request: LLM.request({ model: resolved.model, prompt: "Hello" }),
+                  method: "POST",
+                  url: "https://gateway.test/v1/compat/chat/completions",
+                  body: "{}",
+                  headers: Headers.fromInput(resolved.model.route.defaults.headers),
+                })
+
+                expect<string | undefined>(headers["cf-aig-authorization"]).toBe(entry.gateway)
+                expect<string | undefined>(headers.authorization).toBe(entry.upstream)
+                expect(headers["cf-access-token"]).toBe("access-fixture")
+              }),
+            ),
         )
       }).pipe(Effect.provide(layer)),
     )


### PR DESCRIPTION
### Issue for this PR

Closes #48293

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps configured `gatewayApiKey` authentication when resolving an enabled native
Cloudflare AI Gateway provider without an integration credential. Keyless behavior
and other providers remain unchanged.

Regression coverage includes separate gateway/upstream credentials, empty keys,
custom headers and the historical native package name.

### How did you verify your code works?

Fixture-only resolver output for a gateway-only key:

```json
{"case":"gateway-only","cf-aig-authorization":"Bearer gateway-fixture","authorization":null,"cf-access-token":"access-fixture"}
```

`null` represents an absent header. No live Cloudflare request was made.

- Core: `bun run test test/model-resolver.test.ts test/catalog.test.ts test/config/provider.test.ts` (79 passed); `bun typecheck` passed.
- AI: `bun test test/provider/cloudflare.test.ts` (9 passed); `bun typecheck` passed.
- Workspace: `bun typecheck` (35 tasks passed with Node 24 and Astro telemetry disabled).
- Full Core: 5,363 passed, 41 skipped, 25 failed, 4 errors. The same failing test names and timeout/watcher errors occur on the unmodified baseline.

### Screenshots / recordings

Not applicable. No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
