### PR TITLE
feat(tui): add minimal and hidden tool call modes

### DIFF
--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -94,6 +94,14 @@ export const settings: Setting[] = [
     keywords: ["transcript", "messages", "reads", "searches"],
   },
   {
+    title: "Tool calls",
+    category: "Session",
+    path: ["session", "tool_calls"],
+    default: "show",
+    values: ["hide", "minimal", "show"],
+    keywords: ["tools", "hide", "minimal", "collapse", "tool output"],
+  },
+  {
     title: "Transcript images",
     category: "Session",
     path: ["session", "image_preview"],

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -156,6 +156,9 @@ export const Info = Schema.Struct({
       grouping: Schema.optional(Schema.Literals(["auto", "none"])).annotate({
         description: "Group related transcript items automatically or render each item separately",
       }),
+      tool_calls: Schema.optional(Schema.Literals(["show", "minimal", "hide"])).annotate({
+        description: "Show tool calls normally, collapse each to one line, or hide them; permission prompts remain visible",
+      }),
       image_preview: Schema.optional(Schema.Boolean).annotate({
         description: "Show user attachment and tool-result images in the session transcript",
       }),

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -89,6 +89,7 @@ import { usePlugin } from "../../plugin/context"
 import {
   cacheReuseDrop,
   createSessionRows,
+  isToolRow,
   messageBoundaryIDs,
   resolvePart,
   sessionRowID,
@@ -280,13 +281,18 @@ export function Session(props: {
   })
   const editor = useEditorContext()
   const [rowsSynced, setRowsSynced] = createSignal(false)
-  const rows = createSessionRows(
+  const transcript = createSessionRows(
     () => route.sessionID,
     (id) => {
       if (id === sessionID) setRowsSynced(true)
     },
   )
-  const boundaries = createMemo(() => messageBoundaryIDs(rows, messages()))
+  const rows = createMemo(() =>
+    config.session?.tool_calls === "hide"
+      ? transcript.filter((row) => !isToolRow(row, (id) => data.session.message.get(route.sessionID, id)))
+      : transcript,
+  )
+  const boundaries = createMemo(() => messageBoundaryIDs(rows(), messages()))
   const boundaryIDs = createMemo(() => new Set(boundaries().filter((id) => id !== undefined)))
   const [navigationMessage, setNavigationMessage] = createSignal<string>()
   const [navigationSlack, setNavigationSlack] = createSignal(0)
@@ -406,9 +412,9 @@ export function Session(props: {
   // at the bottom the hidden span follows appends; leaving the bottom pins it to preserve the viewport.
   const [hiddenRows, setHiddenRows] = createSignal<number>()
   const [visibleRowsEnd, setVisibleRowsEnd] = createSignal<number>()
-  const hidden = createMemo(() => Math.max(0, Math.min(hiddenRows() ?? Infinity, rows.length - TRANSCRIPT_TAIL_ROWS)))
-  const visibleEnd = createMemo(() => Math.max(hidden(), Math.min(visibleRowsEnd() ?? rows.length, rows.length)))
-  const visibleRows = createMemo(() => rows.slice(hidden(), visibleEnd()))
+  const hidden = createMemo(() => Math.max(0, Math.min(hiddenRows() ?? Infinity, rows().length - TRANSCRIPT_TAIL_ROWS)))
+  const visibleEnd = createMemo(() => Math.max(hidden(), Math.min(visibleRowsEnd() ?? rows().length, rows().length)))
+  const visibleRows = createMemo(() => rows().slice(hidden(), visibleEnd()))
   const prependHistory = createHistoryPrepend({
     sessionID: () => route.sessionID,
     more: (id) => data.session.message.more(id),
@@ -442,15 +448,15 @@ export function Session(props: {
     const current = visibleEnd()
     if (
       revealingNewerRows ||
-      current === rows.length ||
+      current === rows().length ||
       !scroll ||
       scroll.isDestroyed ||
       scroll.scrollTop + scroll.viewport.height < scroll.scrollHeight - scroll.viewport.height
     )
       return false
     revealingNewerRows = true
-    const next = Math.min(rows.length, current + TRANSCRIPT_BACKFILL_CHUNK)
-    setVisibleRowsEnd(next === rows.length ? undefined : next)
+    const next = Math.min(rows().length, current + TRANSCRIPT_BACKFILL_CHUNK)
+    setVisibleRowsEnd(next === rows().length ? undefined : next)
     afterLayout(() => {
       revealingNewerRows = false
       scroll.scrollBy(scrollBy)
@@ -461,7 +467,7 @@ export function Session(props: {
   /** Message navigation needs the full transcript mounted before walking or jumping. */
   const ensureAllRows = (continuation: () => void) => {
     if (firstJump()) clearMessageNavigation()
-    if (!ensureAllRowsPending && hidden() === 0 && visibleEnd() === rows.length) return continuation()
+    if (!ensureAllRowsPending && hidden() === 0 && visibleEnd() === rows().length) return continuation()
     if (ensureAllRowsPending) {
       ensureAllRowsPending.push(continuation)
       return
@@ -480,7 +486,7 @@ export function Session(props: {
   function isAwayFromBottom() {
     if (revealingOlderRows || revealingNewerRows || ensureAllRowsPending || navigationMessage() || firstJump())
       return true
-    if (visibleEnd() < rows.length) return true
+    if (visibleEnd() < rows().length) return true
     return scroll.scrollTop < Math.max(0, scroll.scrollHeight - scroll.viewport.height)
   }
   function updateAwayFromBottom() {
@@ -527,8 +533,8 @@ export function Session(props: {
       return
     }
     setHiddenRows(Math.max(0, index - TRANSCRIPT_BACKFILL_CHUNK))
-    const end = Math.min(rows.length, index + TRANSCRIPT_BACKFILL_CHUNK)
-    setVisibleRowsEnd(end === rows.length ? undefined : end)
+    const end = Math.min(rows().length, index + TRANSCRIPT_BACKFILL_CHUNK)
+    setVisibleRowsEnd(end === rows().length ? undefined : end)
     scroll.stickyScroll = false
     const restore = () =>
       afterLayout(() => {
@@ -543,9 +549,9 @@ export function Session(props: {
         const contentY = scroll.scrollTop + boundary.y - scroll.viewport.y
         const target = contentY - anchor.screenY
         const maximum = Math.max(0, scroll.scrollHeight - scroll.viewport.height)
-        if (target > maximum && visibleEnd() < rows.length) {
-          const next = Math.min(rows.length, visibleEnd() + TRANSCRIPT_BACKFILL_CHUNK)
-          setVisibleRowsEnd(next === rows.length ? undefined : next)
+        if (target > maximum && visibleEnd() < rows().length) {
+          const next = Math.min(rows().length, visibleEnd() + TRANSCRIPT_BACKFILL_CHUNK)
+          setVisibleRowsEnd(next === rows().length ? undefined : next)
           restore()
           return
         }
@@ -794,7 +800,7 @@ export function Session(props: {
               () => {
                 commit()
                 if (firstJump() !== cancel || scroll.isDestroyed) return
-                if (rows.length <= TRANSCRIPT_BACKFILL_CHUNK) setVisibleRowsEnd(undefined)
+                if (rows().length <= TRANSCRIPT_BACKFILL_CHUNK) setVisibleRowsEnd(undefined)
                 scroll.scrollTo(0)
                 afterLayout(() => {
                   if (firstJump() !== cancel) return
@@ -1515,7 +1521,8 @@ function TurnTokenUsage(props: {
   // open the full per-step table, click again to close.
   const [expanded, setExpanded] = createSignal(false)
   const [hover, setHover] = createSignal(false)
-  const verbose = () => config.data.debug?.turn_tokens === "verbose"
+  const verbose = () =>
+    config.data.debug?.turn_tokens === "verbose" && (config.data.session?.tool_calls ?? "show") === "show"
   const steps = createMemo(() => {
     let previousCache = props.previousCache
     return props.messageIDs.flatMap((messageID) => {
@@ -1923,7 +1930,7 @@ function SessionGroupView(props: {
   return (
     <Show when={grouped().length > 0 || pending().length > 0}>
       <Show
-        when={ctx.groupExploration()}
+        when={ctx.groupExploration() && ctx.config.session?.tool_calls !== "minimal"}
         fallback={<For each={[...grouped(), ...pending()]}>{(part) => <ToolPart part={part} />}</For>}
       >
         <Show when={grouped().length > 0}>
@@ -2619,6 +2626,56 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText; mes
 // Pending messages moved to individual tool pending functions
 
 function ToolPart(props: { part: SessionMessageAssistantTool; images?: boolean }) {
+  const ctx = use()
+  const renderer = useRenderer()
+  const theme = useTheme()
+  return (
+    <Show
+      when={ctx.config.session?.tool_calls === "minimal"}
+      fallback={<ToolPartContent part={props.part} images={props.images} />}
+    >
+      {(_) => {
+        const [expanded, setExpanded] = createSignal(false)
+        const [hover, setHover] = createSignal(false)
+        const failed = () => props.part.state.status === "error"
+        const summary = createMemo(() => {
+          const input = props.part.state.input
+          const label = minimalToolSummary(props.part.name, typeof input === "string" ? {} : input)
+          const error = props.part.state.status === "error" ? ` — failed: ${props.part.state.error.message}` : ""
+          return `${label}${error}`.replace(/\s+/g, " ")
+        })
+        return (
+          <>
+            <InlineToolRow
+              id={`minimal-tool:${props.part.name}:${props.part.id}`}
+              singleLine
+              icon={failed() ? "✗" : expanded() ? "▾" : "▸"}
+              complete
+              pending={props.part.name}
+              spinner={props.part.state.status === "streaming" || props.part.state.status === "running"}
+              failed={failed()}
+              color={hover() ? theme.text.default : theme.text.subdued}
+              errorColor={theme.text.feedback.error.default}
+              onMouseOver={() => setHover(true)}
+              onMouseOut={() => setHover(false)}
+              onMouseUp={() => {
+                if (renderer.getSelection()?.getSelectedText()) return
+                setExpanded((value) => !value)
+              }}
+            >
+              {summary()}
+            </InlineToolRow>
+            <Show when={expanded()}>
+              <ToolPartContent part={props.part} images={props.images} />
+            </Show>
+          </>
+        )
+      }}
+    </Show>
+  )
+}
+
+function ToolPartContent(props: { part: SessionMessageAssistantTool; images?: boolean }) {
   const display = createMemo(() => toolDisplay(props.part.name))
 
   const toolprops = {
@@ -2834,6 +2891,16 @@ export function genericToolSummary(tool: string, input: Record<string, unknown>)
   return `${tool}${args ? ` ${args}` : ""}`
 }
 
+export function minimalToolSummary(tool: string, input: Record<string, unknown>) {
+  const patch = stringValue(input.patchText)
+  const primary = patch
+    ? [...patch.matchAll(/\*\*\* (?:Add|Update|Delete) File: ([^\r\n]+)/g)].map((match) => match[1].trim()).join(", ")
+    : ["description", "path", "filePath", "command", "pattern", "url", "query"]
+        .map((key) => stringValue(input[key]))
+        .find((value) => value?.trim())
+  return `${tool}${primary ? ` ${primary}` : ""}`.replace(/\s+/g, " ")
+}
+
 function useToolPermission(part: () => SessionMessageAssistantTool | undefined) {
   const ctx = use()
   const data = useData()
@@ -2919,6 +2986,8 @@ function InlineTool(props: {
 }
 
 export function InlineToolRow(props: {
+  id?: string
+  singleLine?: boolean
   icon: string
   iconColor?: RGBA
   color?: RGBA
@@ -2938,8 +3007,36 @@ export function InlineToolRow(props: {
   onMouseUp?: () => void
 }) {
   return (
-    <box paddingLeft={3} onMouseOver={props.onMouseOver} onMouseOut={props.onMouseOut} onMouseUp={props.onMouseUp}>
+    <box
+      id={props.id}
+      paddingLeft={3}
+      onMouseOver={props.onMouseOver}
+      onMouseOut={props.onMouseOut}
+      onMouseUp={props.onMouseUp}
+    >
       <Switch>
+        <Match when={props.singleLine}>
+          <box flexDirection="row" height={1}>
+            <box width={INLINE_TOOL_ICON_WIDTH} flexShrink={0}>
+              <Show
+                when={props.spinner}
+                fallback={<text fg={props.failed ? props.errorColor : props.color}>{props.icon}</text>}
+              >
+                <Spinner color={props.color} />
+              </Show>
+            </box>
+            <text
+              flexGrow={1}
+              minWidth={0}
+              height={1}
+              wrapMode="none"
+              truncate
+              fg={props.failed ? props.errorColor : props.color}
+            >
+              {props.children}
+            </text>
+          </box>
+        </Match>
         <Match when={props.spinner}>
           <Show when={props.status} fallback={<Spinner color={props.color} children={props.children} />}>
             {(status) => (

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -86,11 +86,13 @@ import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
 import { Slot } from "../../plugin/render"
 import { usePlugin } from "../../plugin/context"
+import { ToolPresentation, useToolDetails, useToolStatus } from "./tool-presentation"
 import {
   cacheReuseDrop,
   createSessionRows,
   isToolRow,
   messageBoundaryIDs,
+  survivingScrollAnchor,
   resolvePart,
   sessionRowID,
   turnDuration,
@@ -287,8 +289,9 @@ export function Session(props: {
       if (id === sessionID) setRowsSynced(true)
     },
   )
+  const [toolCalls, setToolCalls] = createSignal(config.session?.tool_calls ?? "show")
   const rows = createMemo(() =>
-    config.session?.tool_calls === "hide"
+    toolCalls() === "hide"
       ? transcript.filter((row) => !isToolRow(row, (id) => data.session.message.get(route.sessionID, id)))
       : transcript,
   )
@@ -376,7 +379,7 @@ export function Session(props: {
     if (restored || !synced() || !rowsSynced() || !scroll || scroll.isDestroyed) return
     restored = true
     // Initial synchronization can finish after the reader has already navigated.
-    if (!isAwayFromBottom()) restoreScrollPosition()
+    if (!isAwayFromBottom()) restoreScrollPosition(sessionTabs.scrollAnchor(sessionID))
   })
   let awayTimer: ReturnType<typeof setTimeout> | undefined
   onCleanup(() => {
@@ -508,10 +511,10 @@ export function Session(props: {
   function saveScrollAnchor() {
     // Initial layout must not overwrite the saved position before synchronization restores it.
     if (!restored) return
-    if (!isAwayFromBottom()) {
-      sessionTabs.setScrollAnchor(sessionID, undefined)
-      return
-    }
+    sessionTabs.setScrollAnchor(sessionID, readScrollAnchor())
+  }
+  function readScrollAnchor() {
+    if (!isAwayFromBottom()) return
     let first: { messageID: string; screenY: number } | undefined
     let anchor: { messageID: string; screenY: number } | undefined
     for (const child of scroll.getChildren()) {
@@ -521,13 +524,13 @@ export function Session(props: {
       if (item.screenY <= 0) anchor = item
     }
     anchor ??= first
-    if (anchor) sessionTabs.setScrollAnchor(sessionID, anchor)
-    else sessionTabs.setScrollAnchor(sessionID, undefined)
+    return anchor
   }
-  function restoreScrollPosition() {
-    const anchor = sessionTabs.scrollAnchor(sessionID)
+  function restoreScrollPosition(saved: ReturnType<typeof readScrollAnchor>) {
+    const anchor = survivingScrollAnchor(saved, boundaries(), messages())
     const index = anchor ? boundaries().indexOf(anchor.messageID) : -1
     if (!anchor || index === -1) {
+      scroll.stickyScroll = true
       scroll.scrollTo(scroll.scrollHeight)
       setAwayFromBottom(false)
       return
@@ -560,6 +563,27 @@ export function Session(props: {
       })
     restore()
   }
+
+  createEffect(
+    on(
+      () => config.session?.tool_calls ?? "show",
+      (mode) => {
+        if (!restored || !scroll || scroll.isDestroyed) {
+          setToolCalls(mode)
+          return
+        }
+        // Capture identity before replacing the row list: pinned offsets belong
+        // to the old projection. This also works when session tabs are disabled.
+        const anchor = readScrollAnchor()
+        clearMessageNavigation()
+        setToolCalls(mode)
+        setHiddenRows(undefined)
+        setVisibleRowsEnd(undefined)
+        restoreScrollPosition(anchor)
+      },
+      { defer: true },
+    ),
+  )
 
   createEffect(() => {
     const current = prompt()
@@ -2627,51 +2651,10 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText; mes
 
 function ToolPart(props: { part: SessionMessageAssistantTool; images?: boolean }) {
   const ctx = use()
-  const renderer = useRenderer()
-  const theme = useTheme()
   return (
-    <Show
-      when={ctx.config.session?.tool_calls === "minimal"}
-      fallback={<ToolPartContent part={props.part} images={props.images} />}
-    >
-      {(_) => {
-        const [expanded, setExpanded] = createSignal(false)
-        const [hover, setHover] = createSignal(false)
-        const failed = () => props.part.state.status === "error"
-        const summary = createMemo(() => {
-          const input = props.part.state.input
-          const label = minimalToolSummary(props.part.name, typeof input === "string" ? {} : input)
-          const error = props.part.state.status === "error" ? ` — failed: ${props.part.state.error.message}` : ""
-          return `${label}${error}`.replace(/\s+/g, " ")
-        })
-        return (
-          <>
-            <InlineToolRow
-              id={`minimal-tool:${props.part.name}:${props.part.id}`}
-              singleLine
-              icon={failed() ? "✗" : expanded() ? "▾" : "▸"}
-              complete
-              pending={props.part.name}
-              spinner={props.part.state.status === "streaming" || props.part.state.status === "running"}
-              failed={failed()}
-              color={hover() ? theme.text.default : theme.text.subdued}
-              errorColor={theme.text.feedback.error.default}
-              onMouseOver={() => setHover(true)}
-              onMouseOut={() => setHover(false)}
-              onMouseUp={() => {
-                if (renderer.getSelection()?.getSelectedText()) return
-                setExpanded((value) => !value)
-              }}
-            >
-              {summary()}
-            </InlineToolRow>
-            <Show when={expanded()}>
-              <ToolPartContent part={props.part} images={props.images} />
-            </Show>
-          </>
-        )
-      }}
-    </Show>
+    <ToolPresentation part={props.part} sessionID={ctx.sessionID}>
+      <ToolPartContent part={props.part} images={props.images} />
+    </ToolPresentation>
   )
 }
 
@@ -2836,6 +2819,7 @@ type ToolProps = {
 }
 function GenericTool(props: ToolProps) {
   const theme = useTheme()
+  const details = useToolDetails()
   const output = createMemo(() => props.output?.trim() ?? "")
   const input = createMemo(() => Object.entries(props.input))
   const [expanded, setExpanded] = createSignal(false)
@@ -2844,17 +2828,19 @@ function GenericTool(props: ToolProps) {
 
   return (
     <>
-      <InlineTool
-        icon={props.part.state.status === "error" ? "✗" : "✓"}
-        complete={props.part.state.status === "completed"}
-        pending={props.tool}
-        spinner={loading()}
-        part={props.part}
-        onClick={expandable() ? () => setExpanded((value) => !value) : undefined}
-      >
-        {genericToolSummary(props.tool, props.input)}
-      </InlineTool>
-      <Show when={expanded()}>
+      <Show when={!details()}>
+        <InlineTool
+          icon={props.part.state.status === "error" ? "✗" : "✓"}
+          complete={props.part.state.status === "completed"}
+          pending={props.tool}
+          spinner={loading()}
+          part={props.part}
+          onClick={expandable() ? () => setExpanded((value) => !value) : undefined}
+        >
+          {genericToolSummary(props.tool, props.input)}
+        </InlineTool>
+      </Show>
+      <Show when={details() || expanded()}>
         <box paddingLeft={3 + INLINE_TOOL_ICON_WIDTH}>
           <For each={input()}>
             {([key, value]) => (
@@ -2891,16 +2877,6 @@ export function genericToolSummary(tool: string, input: Record<string, unknown>)
   return `${tool}${args ? ` ${args}` : ""}`
 }
 
-export function minimalToolSummary(tool: string, input: Record<string, unknown>) {
-  const patch = stringValue(input.patchText)
-  const primary = patch
-    ? [...patch.matchAll(/\*\*\* (?:Add|Update|Delete) File: ([^\r\n]+)/g)].map((match) => match[1].trim()).join(", ")
-    : ["description", "path", "filePath", "command", "pattern", "url", "query"]
-        .map((key) => stringValue(input[key]))
-        .find((value) => value?.trim())
-  return `${tool}${primary ? ` ${primary}` : ""}`.replace(/\s+/g, " ")
-}
-
 function useToolPermission(part: () => SessionMessageAssistantTool | undefined) {
   const ctx = use()
   const data = useData()
@@ -2931,21 +2907,12 @@ function InlineTool(props: {
   const [hover, setHover] = createSignal(false)
   const [errorExpanded, setErrorExpanded] = createSignal(false)
   const permission = useToolPermission(() => props.part)
-
-  const error = createMemo(() =>
-    !props.running && props.part.state.status === "error" ? props.part.state.error.message : undefined,
-  )
-
-  const denied = createMemo(
-    () =>
-      error()?.includes("QuestionRejectedError") ||
-      error()?.includes("rejected permission") ||
-      error()?.includes("specified a rule") ||
-      error()?.includes("user dismissed"),
-  )
-
-  const failed = createMemo(() => Boolean(error() && !denied()))
-  const clickable = createMemo(() => Boolean(props.onClick || failed()))
+  const details = useToolDetails()
+  const status = useToolStatus(() => props.part)
+  const error = () => (props.running ? undefined : status().error)
+  const denied = () => status().denied
+  const failed = () => !props.running && status().failed
+  const clickable = createMemo(() => Boolean(props.onClick || (!details() && failed() && error())))
   const fg = createMemo(() => {
     if (props.color) return props.color
     if (permission()) return theme.text.feedback.warning.default
@@ -2961,9 +2928,9 @@ function InlineTool(props: {
       color={fg()}
       errorColor={theme.text.feedback.error.default}
       failed={failed()}
-      denied={Boolean(denied())}
+      denied={denied()}
       error={error()}
-      errorExpanded={errorExpanded()}
+      errorExpanded={!details() && errorExpanded()}
       complete={props.complete}
       pending={props.pending}
       failure={props.failure}
@@ -2973,7 +2940,7 @@ function InlineTool(props: {
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
         if (renderer.getSelection()?.getSelectedText()) return
-        if (failed()) {
+        if (failed() && error() && !details()) {
           setErrorExpanded((value) => !value)
           return
         }
@@ -2986,8 +2953,6 @@ function InlineTool(props: {
 }
 
 export function InlineToolRow(props: {
-  id?: string
-  singleLine?: boolean
   icon: string
   iconColor?: RGBA
   color?: RGBA
@@ -3007,36 +2972,8 @@ export function InlineToolRow(props: {
   onMouseUp?: () => void
 }) {
   return (
-    <box
-      id={props.id}
-      paddingLeft={3}
-      onMouseOver={props.onMouseOver}
-      onMouseOut={props.onMouseOut}
-      onMouseUp={props.onMouseUp}
-    >
+    <box paddingLeft={3} onMouseOver={props.onMouseOver} onMouseOut={props.onMouseOut} onMouseUp={props.onMouseUp}>
       <Switch>
-        <Match when={props.singleLine}>
-          <box flexDirection="row" height={1}>
-            <box width={INLINE_TOOL_ICON_WIDTH} flexShrink={0}>
-              <Show
-                when={props.spinner}
-                fallback={<text fg={props.failed ? props.errorColor : props.color}>{props.icon}</text>}
-              >
-                <Spinner color={props.color} />
-              </Show>
-            </box>
-            <text
-              flexGrow={1}
-              minWidth={0}
-              height={1}
-              wrapMode="none"
-              truncate
-              fg={props.failed ? props.errorColor : props.color}
-            >
-              {props.children}
-            </text>
-          </box>
-        </Match>
         <Match when={props.spinner}>
           <Show when={props.status} fallback={<Spinner color={props.color} children={props.children} />}>
             {(status) => (
@@ -3146,8 +3083,10 @@ function BlockToolContent(props: BlockToolProps & { borderColor: RGBA }) {
   const ctx = use()
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
+  const details = useToolDetails()
   const error = createMemo(
-    () => props.error ?? (props.part?.state.status === "error" ? props.part.state.error.message : undefined),
+    () =>
+      props.error ?? (!details() && props.part?.state.status === "error" ? props.part.state.error.message : undefined),
   )
   const permission = useToolPermission(() => props.part)
   return (
@@ -3160,9 +3099,10 @@ function BlockToolContent(props: BlockToolProps & { borderColor: RGBA }) {
       backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
       customBorderChars={SplitBorder.customBorderChars}
       borderColor={props.borderColor}
-      onMouseOver={() => props.onClick && setHover(true)}
+      onMouseOver={() => !details() && props.onClick && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
+        if (details()) return
         if (renderer.getSelection()?.getSelectedText()) return
         props.onClick?.()
       }}
@@ -3253,6 +3193,8 @@ function ShellDisplay(props: {
   const ctx = use()
   const client = useClient()
   const data = useData()
+  const details = useToolDetails()
+  const status = useToolStatus(() => props.part)
   const pathFormatter = usePathFormatter()
   // A Session can move while its shell is still running in the original Location.
   const location = data.shell.get(props.shellID ?? "")?.location ?? data.session.get(ctx.sessionID)?.location
@@ -3262,9 +3204,12 @@ function ShellDisplay(props: {
     const id = props.shellID
     return Boolean(id && data.shell.get(id))
   })
-  const isRunning = createMemo(() => props.status === "running" || backgroundRunning())
+  const isRunning = createMemo(() =>
+    props.part ? status().running : props.status === "running" || backgroundRunning(),
+  )
   const workdir = createMemo(() => pathFormatter.format(props.workdir))
-  const [expanded, setExpanded] = createSignal(false)
+  const [open, setExpanded] = createSignal(false)
+  const expanded = () => details() || open()
   const [backgroundOutput, setBackgroundOutput] = createSignal("")
   const [outputTruncated, setOutputTruncated] = createSignal(false)
   let loading = false
@@ -3314,13 +3259,14 @@ function ShellDisplay(props: {
   }
   createEffect(() => {
     const running = backgroundRunning()
+    const visible = expanded()
     if (!running) {
-      if (wasRunning) void loadBackgroundOutput(true)
+      if (wasRunning || visible) void loadBackgroundOutput(true)
       wasRunning = false
       return
     }
     wasRunning = true
-    if (props.background && !expanded()) return
+    if (props.background && !visible) return
     void loadBackgroundOutput()
     const interval = setInterval(() => void loadBackgroundOutput(), 1_000)
     onCleanup(() => clearInterval(interval))
@@ -3348,11 +3294,7 @@ function ShellDisplay(props: {
   const limitedInput = createMemo(() => limited().slice(0, input().length))
   const limitedOutput = createMemo(() => limited().slice(Math.min(limited().length, input().length + 2)))
   const expandable = createMemo(() => Boolean(props.shellID) || collapsed().overflow)
-  const toggle = () => {
-    const next = !expanded()
-    setExpanded(next)
-    if (next) void loadBackgroundOutput(!backgroundRunning())
-  }
+  const toggle = () => setExpanded((value) => !value)
 
   return (
     <BlockTool part={props.part} error={props.error} onClick={expandable() ? toggle : undefined}>
@@ -3513,14 +3455,11 @@ function WebSearch(props: ToolProps) {
 
 function Subagent(props: ToolProps) {
   const { navigate } = useRoute()
-  const data = useData()
+  const status = useToolStatus(() => props.part)
   const sessionID = createMemo(() => stringValue(props.metadata.sessionID) ?? stringValue(props.metadata.sessionId))
   const description = createMemo(() => stringValue(props.input.description))
   const continuation = createMemo(() => Boolean(stringValue(props.input.sessionID)))
-  const isRunning = createMemo(() => {
-    const id = sessionID()
-    return props.part.state.status === "running" || Boolean(id && data.session.status(id) === "running")
-  })
+  const isRunning = () => status().running
 
   return (
     <InlineTool
@@ -3628,25 +3567,29 @@ function ExecuteCallView(props: { call: Accessor<ExecuteCall> }) {
 function Execute(props: ToolProps) {
   const ctx = use()
   const theme = useTheme()
-  const isLoading = createMemo(() => props.part.state.status === "streaming" || props.part.state.status === "running")
+  const details = useToolDetails()
+  const status = useToolStatus(() => props.part)
+  const isLoading = () => status().running
   const calls = createMemo(() => executeCalls(props.metadata.toolCalls))
   const output = createMemo(() => stripAnsi(props.output?.trim() ?? ""))
-  const hasRuntimeError = createMemo(() => props.metadata.error === true || props.part.state.status === "error")
+  const hasRuntimeError = () => status().failed
   const outputPreview = createMemo(() => collapseToolOutput(output(), 4, 4 * Math.max(20, ctx.width - 6)).output)
   const showOutput = createMemo(() => output() && hasRuntimeError())
 
   return (
     <>
-      <InlineTool
-        icon={hasRuntimeError() ? "✗" : props.part.state.status === "completed" ? "✓" : "│"}
-        color={hasRuntimeError() ? theme.text.feedback.error.default : undefined}
-        spinner={isLoading()}
-        pending="execute"
-        complete={true}
-        part={props.part}
-      >
-        execute
-      </InlineTool>
+      <Show when={!details()}>
+        <InlineTool
+          icon={hasRuntimeError() ? "✗" : props.part.state.status === "completed" ? "✓" : "│"}
+          color={hasRuntimeError() ? theme.text.feedback.error.default : undefined}
+          spinner={isLoading()}
+          pending="execute"
+          complete={true}
+          part={props.part}
+        >
+          execute
+        </InlineTool>
+      </Show>
       <Index each={calls()}>{(call) => <ExecuteCallView call={call} />}</Index>
       <Show when={showOutput()}>
         <box paddingLeft={3}>
@@ -3948,7 +3891,12 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined
 }
 
-function formatSessionTranscript(session: SessionInfo, messages: SessionMessageInfo[], thinking: boolean, tools = true) {
+function formatSessionTranscript(
+  session: SessionInfo,
+  messages: SessionMessageInfo[],
+  thinking: boolean,
+  tools = true,
+) {
   const body = messages.flatMap((message) => {
     if (message.type === "user") return [`## User\n\n${message.text}`]
     if (message.type === "shell")

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -424,6 +424,22 @@ export function sessionRowID(row: SessionRow, boundaryID?: string) {
   if (row.type === "part") return `session-part:${row.ref.messageID}:${row.ref.partID}`
 }
 
+export function survivingScrollAnchor(
+  anchor: { messageID: string; screenY: number } | undefined,
+  boundaries: (string | undefined)[],
+  messages: readonly SessionMessageInfo[],
+) {
+  if (!anchor) return
+  const visible = new Set(boundaries.filter((id) => id !== undefined))
+  if (visible.has(anchor.messageID)) return anchor
+  const index = messages.findIndex((message) => message.id === anchor.messageID)
+  if (index === -1) return
+  const message =
+    messages.slice(0, index).findLast((message) => visible.has(message.id)) ??
+    messages.slice(index + 1).find((message) => visible.has(message.id))
+  if (message) return { messageID: message.id, screenY: 0 }
+}
+
 function rowBoundaryMessageID(row: SessionRow, messages: Map<string, SessionMessageInfo>) {
   if (row.type === "message") {
     const message = messages.get(row.messageID)

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -340,6 +340,13 @@ export function reduceSessionRows(messages: SessionMessageInfo[], inputs = new S
   }, [])
 }
 
+export function isToolRow(row: SessionRow, message: (id: string) => SessionMessageInfo | undefined) {
+  if (row.type === "group") return row.kind === "exploration"
+  if (row.type !== "part") return false
+  const item = message(row.ref.messageID)
+  return item?.type === "assistant" && resolvePart(item, row.ref.partID)?.type === "tool"
+}
+
 export function cacheReuseDrop(previous: CacheUsage | undefined, current: CacheUsage) {
   if (previous === undefined) return
   if (

--- a/packages/tui/src/routes/session/tool-presentation.tsx
+++ b/packages/tui/src/routes/session/tool-presentation.tsx
@@ -1,0 +1,153 @@
+import { createContext, createEffect, createMemo, createSignal, on, Show, useContext, type Accessor } from "solid-js"
+import { useRenderer, type JSX } from "@opentui/solid"
+import { TextAttributes, type RGBA } from "@opentui/core"
+import type { SessionMessageAssistantTool } from "@opencode/client"
+import { useConfig } from "../../config"
+import { useData } from "../../context/data"
+import { useLocal } from "../../context/local"
+import { useTheme } from "../../context/theme"
+import { Spinner } from "../../component/spinner"
+import { canonicalToolName, toolDisplayMetadata, toolPresentationStatus } from "../../util/tool-display"
+
+const detailsContext = createContext<Accessor<boolean>>(() => false)
+
+export function useToolDetails() {
+  return useContext(detailsContext)
+}
+
+// A tool result can finish while its background work continues. All layouts use
+// the same live status instead of treating the result status as work status.
+export function useToolStatus(part: Accessor<SessionMessageAssistantTool | undefined>) {
+  const data = useData()
+  return createMemo(() => {
+    const value = part()
+    const metadata = value ? toolDisplayMetadata(value.state) : {}
+    const name = value ? canonicalToolName(value.name) : undefined
+    const sessionID = metadata.sessionID ?? metadata.sessionId
+    const backgroundRunning =
+      (name === "shell" && typeof metadata.shellID === "string" && Boolean(data.shell.get(metadata.shellID))) ||
+      (name === "subagent" && typeof sessionID === "string" && data.session.status(sessionID) === "running")
+    return toolPresentationStatus(value, backgroundRunning)
+  })
+}
+
+export function ToolPresentation(props: {
+  part: SessionMessageAssistantTool
+  sessionID: string
+  children: JSX.Element
+}) {
+  const config = useConfig()
+  const data = useData()
+  const local = useLocal()
+  const theme = useTheme()
+  const renderer = useRenderer()
+  const minimal = () => config.data.session?.tool_calls === "minimal"
+  const [expanded, setExpanded] = createSignal(false)
+  createEffect(on(minimal, () => setExpanded(false), { defer: true }))
+  const [hover, setHover] = createSignal(false)
+  const status = useToolStatus(() => props.part)
+  const permission = () => {
+    if (local.permission.mode === "auto") return false
+    const source = data.session.permission.list(props.sessionID)?.[0]?.source
+    return source?.type === "tool" && source.id === props.part.id
+  }
+  const color = () => {
+    if (permission()) return theme.text.feedback.warning.default
+    if (status().failed) return theme.text.feedback.error.default
+    return hover() ? theme.text.default : theme.text.subdued
+  }
+  const summary = createMemo(() => {
+    const input = props.part.state.input
+    const label = minimalToolSummary(props.part.name, typeof input === "string" ? {} : input)
+    const suffix = status().denied
+      ? " — dismissed"
+      : status().failed
+        ? " — failed"
+        : status().background
+          ? " — background"
+          : ""
+    return label + suffix
+  })
+
+  return (
+    <detailsContext.Provider value={minimal}>
+      <Show when={minimal()}>
+        <ToolSummaryRow
+          id={`minimal-tool:${props.part.name}:${props.part.id}`}
+          summary={summary()}
+          status={status()}
+          expanded={expanded()}
+          color={color()}
+          onMouseOver={() => setHover(true)}
+          onMouseOut={() => setHover(false)}
+          onMouseUp={() => {
+            if (renderer.getSelection()?.getSelectedText()) return
+            setExpanded((value) => !value)
+          }}
+        />
+      </Show>
+      <Show when={!minimal() || expanded()}>
+        {props.children}
+        <Show when={minimal() && status().error}>
+          <text paddingLeft={3} fg={status().denied ? theme.text.subdued : theme.text.feedback.error.default}>
+            {status().error}
+          </text>
+        </Show>
+      </Show>
+    </detailsContext.Provider>
+  )
+}
+
+export function ToolSummaryRow(props: {
+  id?: string
+  summary: string
+  status: ReturnType<typeof toolPresentationStatus>
+  expanded?: boolean
+  color?: RGBA
+  onMouseOver?: () => void
+  onMouseOut?: () => void
+  onMouseUp?: () => void
+}) {
+  return (
+    <box
+      id={props.id}
+      paddingLeft={3}
+      flexDirection="row"
+      height={1}
+      onMouseOver={props.onMouseOver}
+      onMouseOut={props.onMouseOut}
+      onMouseUp={props.onMouseUp}
+    >
+      <box width={2} flexShrink={0}>
+        <Show
+          when={props.status.running}
+          fallback={<text fg={props.color}>{props.status.failed ? "✗" : props.expanded ? "▾" : "▸"}</text>}
+        >
+          <Spinner color={props.color} />
+        </Show>
+      </box>
+      <text
+        flexGrow={1}
+        minWidth={0}
+        height={1}
+        wrapMode="none"
+        truncate
+        fg={props.color}
+        attributes={props.status.denied ? TextAttributes.STRIKETHROUGH : undefined}
+      >
+        {props.summary}
+      </text>
+    </box>
+  )
+}
+
+export function minimalToolSummary(tool: string, input: Record<string, unknown>) {
+  const patch = input.patchText
+  const primary =
+    typeof patch === "string" && patch
+      ? [...patch.matchAll(/\*\*\* (?:Add|Update|Delete) File: ([^\r\n]+)/g)].map((match) => match[1].trim()).join(", ")
+      : ["description", "path", "filePath", "command", "pattern", "url", "query"]
+          .map((key) => input[key])
+          .find((value): value is string => typeof value === "string" && Boolean(value.trim()))
+  return `${tool}${primary ? ` ${primary}` : ""}`.replace(/\s+/g, " ")
+}

--- a/packages/tui/src/util/tool-display.ts
+++ b/packages/tui/src/util/tool-display.ts
@@ -5,6 +5,23 @@ export function canonicalToolName(name: string) {
   return name
 }
 
+export function toolPresentationStatus(part: SessionMessageAssistantTool | undefined, backgroundRunning = false) {
+  const metadata = part ? toolDisplayMetadata(part.state) : {}
+  const running = backgroundRunning || part?.state.status === "running" || part?.state.status === "streaming"
+  const error = !running && part?.state.status === "error" ? part.state.error.message : undefined
+  const denied = Boolean(
+    error &&
+      ["QuestionRejectedError", "rejected permission", "specified a rule", "user dismissed"].some((text) =>
+        error.includes(text),
+      ),
+  )
+  const failed =
+    !running &&
+    !denied &&
+    Boolean(error || (part && canonicalToolName(part.name) === "execute" && metadata.error === true))
+  return { running, error, denied, failed, background: backgroundRunning && part?.state.status !== "running" }
+}
+
 export function finiteNumber(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return
   return value

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -5,6 +5,7 @@ import {
   InlineToolRow,
   executeCallSummary,
   genericToolSummary,
+  minimalToolSummary,
   isBackgroundSubagent,
   parseApplyPatchFiles,
   parseDiagnostics,
@@ -123,6 +124,42 @@ async function renderFrame(component: () => JSX.Element, options: { width: numbe
 }
 
 describe("TUI inline tool wrapping", () => {
+  test("minimal summaries describe targets without expanding input bodies", () => {
+    expect(minimalToolSummary("write", { path: "src/index.ts", content: "SECRET_BODY" })).toBe("write src/index.ts")
+    expect(
+      minimalToolSummary("patch", {
+        patchText:
+          "*** Begin Patch\n*** Add File: a.ts\n+SECRET_BODY\n*** Update File: b.ts\n@@\n-old\n+new\n*** End Patch",
+      }),
+    ).toBe("patch a.ts, b.ts")
+    expect(minimalToolSummary("shell", { command: "echo first\necho second" })).toBe("shell echo first echo second")
+    expect(minimalToolSummary("custom.lookup", { query: "two\nwords" })).toBe("custom.lookup two words")
+    expect(minimalToolSummary("execute", { code: "SECRET_BODY" })).toBe("execute")
+    expect(minimalToolSummary("custom.lookup", {})).toBe("custom.lookup")
+  })
+
+  test.each([24, 70, 112])("minimal tool rows stay one line at %s columns", async (width) => {
+    const frame = await renderFrame(
+      () => (
+        <box width={width}>
+          <InlineToolRow singleLine icon="▸" complete pending="shell">
+            {minimalToolSummary("shell", { command: `echo first\necho ${"long-argument-".repeat(30)}` })}
+          </InlineToolRow>
+          <InlineToolRow singleLine icon="✗" complete failed pending="read" error="Hidden error details">
+            {`read ${"long/path/".repeat(30)} — failed`}
+          </InlineToolRow>
+          <text>AFTER_TOOLS</text>
+        </box>
+      ),
+      { width, height: 10 },
+    )
+    expect(frame.split("\n")).toHaveLength(3)
+    expect(frame).toContain("▸ shell")
+    expect(frame).toContain("✗ read")
+    expect(frame).not.toContain("Hidden error details")
+    expect(frame.split("\n")[2]).toBe("AFTER_TOOLS")
+  })
+
   test("falls back for unknown tool names", () => {
     expect(toolDisplay("shell")).toBe("shell")
     expect(toolDisplay("subagent")).toBe("subagent")

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { For } from "solid-js"
+import { minimalToolSummary, ToolSummaryRow } from "../../../src/routes/session/tool-presentation"
+import { toolPresentationStatus } from "../../../src/util/tool-display"
 import { testRender, type JSX } from "@opentui/solid"
 import {
   InlineToolRow,
   executeCallSummary,
   genericToolSummary,
-  minimalToolSummary,
   isBackgroundSubagent,
   parseApplyPatchFiles,
   parseDiagnostics,
@@ -138,16 +139,18 @@ describe("TUI inline tool wrapping", () => {
     expect(minimalToolSummary("custom.lookup", {})).toBe("custom.lookup")
   })
 
-  test.each([24, 70, 112])("minimal tool rows stay one line at %s columns", async (width) => {
+  test.each([24, 112])("minimal tool rows stay one line at %s columns", async (width) => {
     const frame = await renderFrame(
       () => (
         <box width={width}>
-          <InlineToolRow singleLine icon="▸" complete pending="shell">
-            {minimalToolSummary("shell", { command: `echo first\necho ${"long-argument-".repeat(30)}` })}
-          </InlineToolRow>
-          <InlineToolRow singleLine icon="✗" complete failed pending="read" error="Hidden error details">
-            {`read ${"long/path/".repeat(30)} — failed`}
-          </InlineToolRow>
+          <ToolSummaryRow
+            status={toolPresentationStatus(undefined)}
+            summary={minimalToolSummary("shell", { command: `echo first\necho ${"long-argument-".repeat(30)}` })}
+          />
+          <ToolSummaryRow
+            status={{ ...toolPresentationStatus(undefined), failed: true, error: "Hidden error details" }}
+            summary={`read ${"long/path/".repeat(30)} — failed`}
+          />
           <text>AFTER_TOOLS</text>
         </box>
       ),

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import type { SessionMessageAssistant, SessionMessageInfo } from "@opencode/client"
-import { createMemo, createRoot, createSignal } from "solid-js"
+import { createMemo, createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
 import {
   cacheReuseDrop,
@@ -8,6 +8,7 @@ import {
   messageBoundaryIDs,
   reduceSessionRows,
   sessionRowID,
+  survivingScrollAnchor,
   turnDuration,
   turnTokensPerSecond,
 } from "../../../src/routes/session/rows"
@@ -564,7 +565,7 @@ test("hides grouped and individual tools without removing text, reasoning, or er
   const message = assistant("assistant", [
     { type: "text", text: "Checking files" },
     { type: "reasoning", text: "Reasoning", time: { created: 1 } },
-    ...["read", "glob", "grep", "shell", "patch", "subagent", "question", "custom.lookup"].map((name) => ({
+    ...["read", "glob", "grep", "shell"].map((name) => ({
       type: "tool" as const,
       id: name,
       name,
@@ -580,7 +581,7 @@ test("hides grouped and individual tools without removing text, reasoning, or er
   ]
   const rows = reduceSessionRows(messages)
   const lookup = (id: string) => messages.find((message) => message.id === id)
-  expect(rows.filter((row) => isToolRow(row, lookup))).toHaveLength(6)
+  expect(rows.filter((row) => isToolRow(row, lookup))).toHaveLength(2)
   expect(rows.filter((row) => !isToolRow(row, lookup))).toEqual([
     { type: "message", messageID: "user" },
     { type: "part", ref: { messageID: "assistant", partID: "text:0" } },
@@ -588,41 +589,22 @@ test("hides grouped and individual tools without removing text, reasoning, or er
     { type: "part", ref: { messageID: "assistant", partID: "text:1" } },
     { type: "assistant-footer", messageID: "assistant" },
   ])
-  expect(message.content).toHaveLength(11)
 })
 
 function pending() {
   return { status: "streaming" as const, input: "" }
 }
 
-test("restores hidden history and keeps newly streamed tools hidden", () => {
-  createRoot((dispose) => {
-    try {
-      const [hidden, setHidden] = createSignal(false)
-      const [messages, setMessages] = createStore([
-        assistant("assistant", [{ type: "tool", id: "shell", name: "shell", state: pending(), time: { created: 1 } }]),
-      ])
-      const rows = createMemo(() => reduceSessionRows(messages))
-      const visible = createMemo(() =>
-        hidden() ? rows().filter((row) => !isToolRow(row, (id) => messages.find((item) => item.id === id))) : rows(),
-      )
-      expect(visible()).toHaveLength(1)
-      setHidden(true)
-      expect(visible()).toHaveLength(0)
-      setMessages(0, "content", 1, {
-        type: "tool",
-        id: "read",
-        name: "read",
-        state: pending(),
-        time: { created: 2 },
-      })
-      expect(visible()).toHaveLength(0)
-      setMessages(0, "content", 2, { type: "text", text: "Done" })
-      expect(visible()).toEqual([{ type: "part", ref: { messageID: "assistant", partID: "text:0" } }])
-      setHidden(false)
-      expect(visible()).toHaveLength(3)
-    } finally {
-      dispose()
-    }
-  })
+test("restores surviving anchors and falls back when a tool-only boundary is hidden", () => {
+  const messages: SessionMessageInfo[] = [
+    { type: "user", id: "user", text: "Check", time: { created: 0 } },
+    assistant("tools", []),
+    assistant("answer", [{ type: "text", text: "Done" }]),
+  ]
+  const anchor = { messageID: "tools", screenY: -3 }
+  expect(survivingScrollAnchor(anchor, ["user", "tools", "answer"], messages)).toEqual(anchor)
+  expect(survivingScrollAnchor(anchor, ["user", "answer"], messages)).toEqual({ messageID: "user", screenY: 0 })
+  expect(survivingScrollAnchor(anchor, ["answer"], messages)).toEqual({ messageID: "answer", screenY: 0 })
+  expect(survivingScrollAnchor(anchor, [], messages)).toBeUndefined()
+  expect(survivingScrollAnchor(undefined, ["answer"], messages)).toBeUndefined()
 })

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "bun:test"
 import type { SessionMessageAssistant, SessionMessageInfo } from "@opencode/client"
-import { createMemo, createRoot } from "solid-js"
+import { createMemo, createRoot, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import {
   cacheReuseDrop,
+  isToolRow,
   messageBoundaryIDs,
   reduceSessionRows,
   sessionRowID,
@@ -559,6 +560,69 @@ function assistant(id: string, content: SessionMessageAssistant["content"]): Ses
   }
 }
 
+test("hides grouped and individual tools without removing text, reasoning, or errors", () => {
+  const message = assistant("assistant", [
+    { type: "text", text: "Checking files" },
+    { type: "reasoning", text: "Reasoning", time: { created: 1 } },
+    ...["read", "glob", "grep", "shell", "patch", "subagent", "question", "custom.lookup"].map((name) => ({
+      type: "tool" as const,
+      id: name,
+      name,
+      state: pending(),
+      time: { created: 1 },
+    })),
+    { type: "text", text: "Finished" },
+  ])
+  message.error = { type: "provider.transport", message: "Disconnected" }
+  const messages: SessionMessageInfo[] = [
+    { type: "user", id: "user", text: "Check files", time: { created: 0 } },
+    message,
+  ]
+  const rows = reduceSessionRows(messages)
+  const lookup = (id: string) => messages.find((message) => message.id === id)
+  expect(rows.filter((row) => isToolRow(row, lookup))).toHaveLength(6)
+  expect(rows.filter((row) => !isToolRow(row, lookup))).toEqual([
+    { type: "message", messageID: "user" },
+    { type: "part", ref: { messageID: "assistant", partID: "text:0" } },
+    { type: "group", kind: "reasoning", refs: [{ messageID: "assistant", partID: "reasoning:0" }], completed: true },
+    { type: "part", ref: { messageID: "assistant", partID: "text:1" } },
+    { type: "assistant-footer", messageID: "assistant" },
+  ])
+  expect(message.content).toHaveLength(11)
+})
+
 function pending() {
   return { status: "streaming" as const, input: "" }
 }
+
+test("restores hidden history and keeps newly streamed tools hidden", () => {
+  createRoot((dispose) => {
+    try {
+      const [hidden, setHidden] = createSignal(false)
+      const [messages, setMessages] = createStore([
+        assistant("assistant", [{ type: "tool", id: "shell", name: "shell", state: pending(), time: { created: 1 } }]),
+      ])
+      const rows = createMemo(() => reduceSessionRows(messages))
+      const visible = createMemo(() =>
+        hidden() ? rows().filter((row) => !isToolRow(row, (id) => messages.find((item) => item.id === id))) : rows(),
+      )
+      expect(visible()).toHaveLength(1)
+      setHidden(true)
+      expect(visible()).toHaveLength(0)
+      setMessages(0, "content", 1, {
+        type: "tool",
+        id: "read",
+        name: "read",
+        state: pending(),
+        time: { created: 2 },
+      })
+      expect(visible()).toHaveLength(0)
+      setMessages(0, "content", 2, { type: "text", text: "Done" })
+      expect(visible()).toEqual([{ type: "part", ref: { messageID: "assistant", partID: "text:0" } }])
+      setHidden(false)
+      expect(visible()).toHaveLength(3)
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -100,9 +100,7 @@ test("names tool grouping explicitly in settings", () => {
 test("validates tool call visibility and keeps calls visible by default", () => {
   for (const tool_calls of ["hide", "minimal", "show"] as const) {
     expect(decodeInfo({ session: { tool_calls } })).toEqual({ session: { tool_calls } })
-    expect(resolve({ session: { tool_calls } }, { terminalSuspend: true }).session.tool_calls).toBe(tool_calls)
   }
-  expect(() => decodeInfo({ session: { tool_calls: false } })).toThrow()
   expect(() => decodeInfo({ session: { tool_calls: "collapsed" } })).toThrow()
   expect(settings.find((setting) => setting.path.join(".") === "session.tool_calls")).toMatchObject({
     title: "Tool calls",

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -97,6 +97,21 @@ test("names tool grouping explicitly in settings", () => {
   })
 })
 
+test("validates tool call visibility and keeps calls visible by default", () => {
+  for (const tool_calls of ["hide", "minimal", "show"] as const) {
+    expect(decodeInfo({ session: { tool_calls } })).toEqual({ session: { tool_calls } })
+    expect(resolve({ session: { tool_calls } }, { terminalSuspend: true }).session.tool_calls).toBe(tool_calls)
+  }
+  expect(() => decodeInfo({ session: { tool_calls: false } })).toThrow()
+  expect(() => decodeInfo({ session: { tool_calls: "collapsed" } })).toThrow()
+  expect(settings.find((setting) => setting.path.join(".") === "session.tool_calls")).toMatchObject({
+    title: "Tool calls",
+    category: "Session",
+    default: "show",
+    values: ["hide", "minimal", "show"],
+  })
+})
+
 test("validates terminal copy behavior", () => {
   expect(decodeInfo({ terminal: { copy: "manual" } })).toEqual({ terminal: { copy: "manual" } })
   expect(decodeInfo({ terminal: { copy: "select" } })).toEqual({ terminal: { copy: "select" } })

--- a/packages/tui/test/fixture/app.ts
+++ b/packages/tui/test/fixture/app.ts
@@ -12,6 +12,7 @@ export async function createAppFixture(
     height?: number
     state?: string
     config?: Config.Info
+    configService?: TuiInput["config"]
     args?: TuiInput["args"]
     fetch?: FetchHandler
   } = {},
@@ -32,7 +33,10 @@ export async function createAppFixture(
     run({
       app: { name: "test", version: "test", channel: "test" },
       server: { endpoint: { url: server.url.toString() } },
-      config: { get: async () => input.config ?? { animations: false }, update: async () => ({}) },
+      config: input.configService ?? {
+        get: async () => input.config ?? { animations: false },
+        update: async () => ({}),
+      },
       packages: { prepare: async () => ({ directory: "" }) },
       terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
       args: input.args ?? {},

--- a/packages/tui/test/session-tool-modes.test.tsx
+++ b/packages/tui/test/session-tool-modes.test.tsx
@@ -1,0 +1,305 @@
+import { expect, test } from "bun:test"
+import { InputRenderable, type Renderable, ScrollBoxRenderable } from "@opentui/core"
+import type { SessionMessageAssistantTool, SessionMessageInfo } from "@opencode/client"
+import type { Config } from "../src/config"
+import { createAppFixture } from "./fixture/app"
+import { tmpdir } from "./fixture/fixture"
+import { directory, json } from "./fixture/tui-client"
+
+const session = {
+  id: "ses_tool_modes",
+  title: "Tool presentation",
+  projectID: "project",
+  location: { directory },
+  cost: 0,
+  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  time: { created: 0, updated: 0 },
+}
+
+test.each(["generic", "execute", "dismissed"] as const)(
+  "minimal %s exposes details with one disclosure",
+  async (kind) => {
+    await using state = await tmpdir()
+    const part: SessionMessageAssistantTool = {
+      type: "tool",
+      id: "tool",
+      name: kind === "generic" || kind === "dismissed" ? "custom.lookup" : kind,
+      state:
+        kind === "dismissed"
+          ? {
+              status: "error",
+              input: { query: "fixture" },
+              error: { type: "provider.transport", message: "user dismissed: ERROR_DETAILS" },
+            }
+          : {
+              status: "completed",
+              input: { query: "fixture", command: "echo result" },
+              content: [{ type: "text", text: "OUTPUT_DETAILS" }],
+              metadata: kind === "execute" ? { error: true } : {},
+            },
+      time: { created: 1, completed: 2 },
+    }
+    await using app = await createAppFixture({
+      state: state.path,
+      config: { animations: false, tabs: { enabled: false }, session: { sidebar: "hide", tool_calls: "minimal" } },
+      args: { sessionID: session.id },
+      fetch: fetchMessages([assistant("msg_tool", part)]),
+    })
+    const initial = await app.waitForFrame((frame) => frame.includes(kind === "dismissed" ? "— dismissed" : part.name))
+    expect(initial).not.toContain("OUTPUT_DETAILS")
+    expect(initial).not.toContain("ERROR_DETAILS")
+    if (kind === "execute") expect(initial).toContain("✗ execute echo result — failed")
+    if (kind === "dismissed") expect(initial).not.toContain("— failed")
+    await app.waitForVisualIdle()
+    const row = app.renderer.root.findDescendantById(`minimal-tool:${part.name}:tool`)
+    if (!row) throw new Error("Minimal summary not found")
+    expect(row.height).toBe(1)
+    await app.mockMouse.click(row.x + 1, row.y)
+    const expanded = await app.waitForFrame((frame) =>
+      frame.includes(kind === "dismissed" ? "ERROR_DETAILS" : "OUTPUT_DETAILS"),
+    )
+    if (kind === "generic") {
+      expect(expanded.match(/custom\.lookup/g)).toHaveLength(1)
+      expect(expanded).toContain("query:")
+    }
+    await app.mockMouse.click(row.x + 1, row.y)
+    await app.waitForFrame((frame) => !frame.includes("OUTPUT_DETAILS") && !frame.includes("ERROR_DETAILS"))
+  },
+)
+
+test.each(["show", "minimal"] as const)("%s shell disclosure loads finished output from storage", async (mode) => {
+  await using state = await tmpdir()
+  const output = `STORED_OUTPUT_START\n${"output line\n".repeat(12)}STORED_OUTPUT_END`
+  const reads: number[] = []
+  const messages = fetchMessages([
+    assistant("msg_stored_shell", {
+      type: "tool",
+      id: "stored",
+      name: "shell",
+      time: { created: 1, completed: 2 },
+      state: {
+        status: "completed",
+        input: { command: "echo stored" },
+        content: [{ type: "text", text: "MODEL_OUTPUT_PREVIEW" }],
+        metadata: { shellID: "sh_stored" },
+      },
+    }),
+  ])
+  await using app = await createAppFixture({
+    state: state.path,
+    config: { animations: false, tabs: { enabled: false }, session: { sidebar: "hide", tool_calls: mode } },
+    args: { sessionID: session.id },
+    fetch: (url) => {
+      if (url.pathname !== "/api/shell/sh_stored/output") return messages(url)
+      const cursor = Number(url.searchParams.get("cursor") ?? 0)
+      reads.push(cursor)
+      const end = cursor === 0 ? output.indexOf("\n") + 1 : output.length
+      return json({
+        location: { directory },
+        data: { output: output.slice(cursor, end), cursor: end, size: output.length, truncated: false },
+      })
+    },
+  })
+  await app.waitForFrame((frame) => frame.includes("echo stored"))
+  await app.waitForVisualIdle()
+  expect(reads).toHaveLength(0)
+  for (const expanded of [true, false, true]) {
+    const row = app
+      .captureCharFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("echo stored"))
+    expect(row).toBeGreaterThanOrEqual(0)
+    await app.mockMouse.click(4, row)
+    const frame = await app.waitForFrame((frame) => frame.includes("STORED_OUTPUT_END") === expanded)
+    expect(frame).not.toContain("MODEL_OUTPUT_PREVIEW")
+    if (expanded) expect(frame).toContain("STORED_OUTPUT_START")
+  }
+  expect(reads.slice(0, 2)).toEqual([0, output.indexOf("\n") + 1])
+})
+
+test("minimal shell reflects background activity after its tool result completes", async () => {
+  await using state = await tmpdir()
+  const shell = {
+    id: "sh_background",
+    command: "sleep 10",
+    status: "running",
+    cwd: directory,
+    shell: "/bin/sh",
+    file: `${directory}/output`,
+    metadata: { sessionID: session.id },
+    time: { started: 1 },
+  }
+  const messages = fetchMessages([
+    assistant("msg_background", {
+      type: "tool",
+      id: "background",
+      name: "shell",
+      time: { created: 1, completed: 2 },
+      state: {
+        status: "completed",
+        input: { command: "sleep 10" },
+        content: [{ type: "text", text: "Started" }],
+        metadata: { shellID: shell.id },
+      },
+    }),
+  ])
+  await using app = await createAppFixture({
+    state: state.path,
+    config: { animations: false, tabs: { enabled: false }, session: { sidebar: "hide", tool_calls: "minimal" } },
+    args: { sessionID: session.id },
+    fetch: (url) => (url.pathname === "/api/shell" ? json({ location: { directory }, data: [shell] }) : messages(url)),
+  })
+  await app.waitForFrame((frame) => frame.includes("⋯ shell sleep 10 — background"))
+  app.events.emit({
+    id: "evt_background_done",
+    created: 3,
+    type: "shell.exited",
+    location: { directory },
+    data: { id: shell.id, status: "exited", exit: 0 },
+  })
+  await app.waitForFrame((frame) => frame.includes("▸ shell sleep 10") && !frame.includes("— background"))
+})
+
+test("minimal subagents follow the child session after their tool result completes", async () => {
+  await using state = await tmpdir()
+  await using app = await createAppFixture({
+    state: state.path,
+    config: { animations: false, tabs: { enabled: false }, session: { sidebar: "hide", tool_calls: "minimal" } },
+    args: { sessionID: session.id },
+    fetch: fetchMessages([
+      assistant("msg_subagent", {
+        type: "tool",
+        id: "subagent",
+        name: "subagent",
+        time: { created: 1, completed: 2 },
+        state: {
+          status: "completed",
+          input: { description: "Inspect fixtures" },
+          content: [{ type: "text", text: "Started" }],
+          metadata: { sessionID: "ses_child" },
+        },
+      }),
+    ]),
+  })
+  await app.waitForFrame((frame) => frame.includes("▸ subagent Inspect fixtures"))
+  app.events.emit({
+    id: "evt_child_started",
+    created: 3,
+    type: "session.execution.started",
+    durable: { aggregateID: "ses_child", seq: 1, version: 1 },
+    data: { sessionID: "ses_child" },
+  })
+  await app.waitForFrame((frame) => frame.includes("⋯ subagent Inspect fixtures — background"))
+  app.events.emit({
+    id: "evt_child_done",
+    created: 4,
+    type: "session.execution.succeeded",
+    durable: { aggregateID: "ses_child", seq: 2, version: 1 },
+    data: { sessionID: "ses_child" },
+  })
+  await app.waitForFrame((frame) => frame.includes("▸ subagent Inspect fixtures") && !frame.includes("— background"))
+})
+
+test.each([false, true])("mode changes preserve pinned history anchors (tabs: %s)", async (tabs) => {
+  await using state = await tmpdir()
+  const config: Config.Info = {
+    animations: false,
+    tabs: { enabled: tabs },
+    session: { sidebar: "hide", tool_calls: "show" },
+  }
+  const messages = Array.from({ length: 120 }, (_, index): SessionMessageInfo[] => [
+    { type: "user", id: `msg_user_${index}`, text: `History message ${index}`, time: { created: index * 2 } },
+    assistant(`msg_tool_${index}`, {
+      type: "tool",
+      id: `tool_${index}`,
+      name: "custom.lookup",
+      state: { status: "completed", input: { query: `lookup ${index}` }, content: [{ type: "text", text: "Result" }] },
+      time: { created: index * 2 + 1, completed: index * 2 + 2 },
+    }),
+  ]).flat()
+  await using app = await createAppFixture({
+    state: state.path,
+    configService: {
+      get: async () => structuredClone(config),
+      update: async (update) => {
+        update(config)
+        return structuredClone(config)
+      },
+    },
+    args: { sessionID: session.id },
+    fetch: fetchMessages(messages),
+  })
+  await app.waitForFrame((frame) => frame.includes("History message 119"))
+  await app.waitForVisualIdle()
+  const findScroll = (root: Renderable): ScrollBoxRenderable | undefined =>
+    root instanceof ScrollBoxRenderable && root.getRenderable("msg_user_119")
+      ? root
+      : root.getChildren().map(findScroll).find(Boolean)
+  const scroll = findScroll(app.renderer.root)
+  if (!scroll) throw new Error("Transcript not found")
+  scroll.stickyScroll = false
+  scroll.scrollTo(Math.max(0, scroll.scrollHeight - scroll.viewport.height - 30))
+  await app.waitForVisualIdle()
+  const anchor = scroll
+    .getChildren()
+    .find(
+      (row) =>
+        row.id.startsWith("msg_user_") &&
+        row.y >= scroll.viewport.y &&
+        row.y < scroll.viewport.y + scroll.viewport.height,
+    )
+  if (!anchor) throw new Error("Visible user message not found")
+  scroll.scrollTo(scroll.scrollTop + anchor.y - scroll.viewport.y)
+  await app.waitForVisualIdle()
+  const before = anchor.y - scroll.viewport.y
+  for (const mode of ["hide", "minimal", "show"]) {
+    app.mockInput.pressKey("p", { ctrl: true })
+    await app.waitFor(() => app.renderer.currentFocusedEditor instanceof InputRenderable)
+    await app.mockInput.typeText("Open settings")
+    await app.waitForVisualIdle()
+    app.mockInput.pressEnter()
+    await app.waitForFrame((frame) => frame.includes("Settings"))
+    await app.mockInput.typeText("Tool calls")
+    await app.waitForVisualIdle()
+    await app.waitForFrame((frame) => frame.includes("Tool calls") && !frame.includes("Tool grouping"))
+    app.mockInput.pressEnter()
+    await app.waitFor(() => config.session?.tool_calls === mode)
+    app.mockInput.pressKey("ESCAPE")
+    await app.waitForFrame(
+      (frame) =>
+        !frame.includes("Settings") &&
+        (mode === "hide"
+          ? !frame.includes("custom.lookup")
+          : frame.includes(mode === "minimal" ? "▸ custom.lookup" : "✓ custom.lookup")),
+    )
+    await app.renderOnce()
+    await app.waitFor(() => scroll.getRenderable(anchor.id)?.y === scroll.viewport.y + before)
+    await app.waitForVisualIdle()
+    const restored = scroll.getRenderable(anchor.id)
+    if (!restored) throw new Error(`Anchor missing after switching to ${mode}`)
+    expect(restored.y - scroll.viewport.y).toBe(before)
+  }
+})
+
+function assistant(id: string, part: SessionMessageAssistantTool): SessionMessageInfo {
+  return {
+    id,
+    type: "assistant",
+    agent: "build",
+    model: { providerID: "demo", id: "demo-model" },
+    content: [part],
+    finish: "tool-calls",
+    time: { created: part.time.created, completed: part.time.completed },
+  }
+}
+
+function fetchMessages(messages: SessionMessageInfo[]) {
+  return (url: URL) => {
+    if (url.pathname === "/api/session") return json({ data: [session], cursor: {} })
+    if (url.pathname === `/api/session/${session.id}`) return json({ data: session })
+    if (url.pathname === `/api/session/${session.id}/message`) return json({ data: messages.toReversed(), cursor: {} })
+    if (url.pathname === `/api/session/${session.id}/inbox` || url.pathname === `/api/session/${session.id}/permission`)
+      return json({ data: [] })
+    return undefined
+  }
+}

--- a/services/www/src/docs/content/cli/config.mdx
+++ b/services/www/src/docs/content/cli/config.mdx
@@ -164,6 +164,37 @@ In `/diff`, press `d` to change the scope or choose a comparison branch from **B
 
 Your base choice for each branch and last selected scope survive closing and reopening the viewer, but reset when the TUI exits. These selections do not change `cli.json`.
 
+## Tool calls
+
+Choose **Session > Tool calls > hide** in settings to hide all tool calls from the full-screen transcript:
+
+```json title="cli.json"
+{
+  "session": {
+    "tool_calls": "hide"
+  }
+}
+```
+
+Choose `minimal` to keep every tool call on one line with its details collapsed:
+
+```json title="cli.json"
+{
+  "session": {
+    "tool_calls": "minimal"
+  }
+}
+```
+
+Long summaries truncate instead of wrapping. Click a row to expand its details, then click again to collapse them.
+Minimal mode shows each read and search separately, even when tool grouping is enabled.
+
+The default is `show`. The `hide` option hides individual tool calls, grouped reads and searches, and tool output.
+It applies to existing history and new calls without restarting the TUI.
+
+Tools still run normally. Permission prompts, questions, assistant messages, and session errors remain visible.
+Set `tool_calls` to `show` to restore the tool calls. This setting does not change Mini output.
+
 ## Tabs
 
 Choose **Tabs > Indicators** in settings, or set `tabs.indicators` in `cli.json`:


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Verbose tool output can make assistant responses harder to scan. Adds **Settings → Session → Tool calls** with three modes:

- `show`: current behavior and the default.
- `minimal`: one collapsed line per tool, with truncated summaries. Click to expand or collapse details.
- `hide`: removes tool rows and output from the transcript.

Minimal mode shows grouped reads and searches individually. Hidden mode filters rows before rendering to avoid empty rows. Mode changes preserve the reading position. Permission prompts and questions remain usable. This changes full-screen TUI presentation only.

### How did you verify your code works?

- Full TUI suite on Bun 1.4.2: 1,365 passed, 4 skipped, 0 failed. Includes regressions for status feedback, one-click details, stored shell output, and history anchors.
- TUI typecheck and all 35 pre-push typecheck tasks passed.
- Documentation typecheck, generated check, build, and link validation passed.
- Isolated OpenCode Drive checks passed for expansion, running and failed tools, 40/70/112-column layouts, restart persistence, mode switching, permissions, and questions.

To verify, open a session with tool calls and switch modes under **Settings → Session → Tool calls**. In minimal mode, click a summary to expand and collapse its details. Switch modes while scrolled into history to check the reading position.

### Screenshots / recordings

Default

<img width="2000" height="1840" alt="Tool calls shown with the default presentation" src="https://github.com/user-attachments/assets/ebbf8227-08ce-4350-8396-2b9ab9c067ab" />

Minimal

<img width="2000" height="1840" alt="Tool calls shown as collapsed one-line summaries" src="https://github.com/user-attachments/assets/cee4594c-c116-4eaa-ad82-2316020587f0" />

Hide

<img width="2000" height="1840" alt="Tool calls hidden while assistant text remains visible" src="https://github.com/user-attachments/assets/1cb88e5c-67b7-47aa-aa1c-29987cb61e90" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
