### PR TITLE
fix(tui): validate frecency entries

### DIFF
--- a/packages/tui/src/prompt/frecency.tsx
+++ b/packages/tui/src/prompt/frecency.tsx
@@ -15,12 +15,12 @@ export function parseFrecency(text: string) {
     .filter(Boolean)
     .map((line) => {
       try {
-        return JSON.parse(line) as FrecencyEntry
+        return JSON.parse(line) as unknown
       } catch {
         return undefined
       }
     })
-    .filter((line): line is FrecencyEntry => line !== undefined)
+    .filter(isFrecencyEntry)
     .reduce<Record<string, FrecencyEntry>>((result, entry) => {
       result[entry.path] = entry
       return result
@@ -28,6 +28,13 @@ export function parseFrecency(text: string) {
   return Object.values(latest)
     .sort((a, b) => b.lastOpen - a.lastOpen)
     .slice(0, MAX_FRECENCY_ENTRIES)
+}
+
+function isFrecencyEntry(value: unknown): value is FrecencyEntry {
+  if (!value || typeof value !== "object") return false
+  if (!("path" in value) || typeof value.path !== "string" || !value.path) return false
+  if (!("frequency" in value) || typeof value.frequency !== "number" || !Number.isFinite(value.frequency)) return false
+  return "lastOpen" in value && typeof value.lastOpen === "number" && Number.isFinite(value.lastOpen)
 }
 
 function calculateFrecency(entry?: { frequency: number; lastOpen: number }) {

--- a/packages/tui/test/prompt/frecency.test.ts
+++ b/packages/tui/test/prompt/frecency.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { parseFrecency } from "../../src/prompt/frecency"
+
+describe("prompt frecency", () => {
+  test("skips malformed entries and retains valid neighbors", () => {
+    const first = { path: "/first.ts", frequency: 1, lastOpen: 1 }
+    const second = { path: "/second.ts", frequency: 2, lastOpen: 2 }
+    const input = [
+      JSON.stringify(first),
+      "null",
+      JSON.stringify({ path: "/missing-frequency.ts", lastOpen: 3 }),
+      JSON.stringify({ path: "/invalid-last-open.ts", frequency: 1, lastOpen: null }),
+      JSON.stringify(second),
+    ].join("\n")
+
+    expect(parseFrecency(input)).toEqual([second, first])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #48299

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Validates parsed frecency records before they are deduplicated and sorted. Malformed JSON values such as `null`, missing fields, empty paths, and non-finite counters are skipped, while valid neighboring entries continue to load.

### How did you verify your code works?

Added a focused parser regression test covering `null` and malformed object shapes between valid entries, then ran `bun test test/prompt/frecency.test.ts` from `packages/tui`.

### Screenshots / recordings

Not applicable; this is a non-UI parser fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR