### PR TITLE
fix(core): preserve unicode replay chunks

### DIFF
--- a/packages/core/src/pty/protocol.ts
+++ b/packages/core/src/pty/protocol.ts
@@ -22,7 +22,19 @@ export function metaFrame(cursor: number) {
 
 export function chunks(data: string) {
   const out: string[] = []
-  for (let i = 0; i < data.length; i += REPLAY_CHUNK) out.push(data.slice(i, i + REPLAY_CHUNK))
+  for (let i = 0; i < data.length; ) {
+    const boundary = Math.min(i + REPLAY_CHUNK, data.length)
+    const end =
+      boundary < data.length &&
+      data.charCodeAt(boundary - 1) >= 0xd800 &&
+      data.charCodeAt(boundary - 1) <= 0xdbff &&
+      data.charCodeAt(boundary) >= 0xdc00 &&
+      data.charCodeAt(boundary) <= 0xdfff
+        ? boundary - 1
+        : boundary
+    out.push(data.slice(i, end))
+    i = end
+  }
   return out
 }
 

--- a/packages/core/test/pty/protocol.test.ts
+++ b/packages/core/test/pty/protocol.test.ts
@@ -24,4 +24,14 @@ describe("pty protocol", () => {
     expect(frames[0].length).toBe(PtyProtocol.REPLAY_CHUNK)
     expect(frames.join("")).toBe(big)
   })
+
+  test("does not split surrogate pairs between replay frames", () => {
+    const replay = "x".repeat(PtyProtocol.REPLAY_CHUNK - 1) + "😀"
+    const frames = PtyProtocol.chunks(replay)
+    const decoder = new TextDecoder()
+    const encoder = new TextEncoder()
+
+    expect(frames).toEqual(["x".repeat(PtyProtocol.REPLAY_CHUNK - 1), "😀"])
+    expect(frames.map((frame) => decoder.decode(encoder.encode(frame))).join("")).toBe(replay)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48303

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps PTY replay chunk boundaries from splitting UTF-16 surrogate pairs. When a boundary falls between the two code units of a non-BMP character, it moves back one code unit so independent WebSocket frame encoding preserves the character.

### How did you verify your code works?

Added a protocol regression test that UTF-8 encodes and decodes each replay chunk independently, then verifies the reconstructed output. Ran `bun test test/pty/protocol.test.ts` from `packages/core`: 4 tests passed.

### Screenshots / recordings

Not applicable; this is a non-UI protocol fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR