### PR TITLE
fix(cli): handle browser opener errors

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -28,6 +28,11 @@ function getNetworkIPs() {
   return results
 }
 
+export async function openBrowser(url: string, opener: typeof open = open) {
+  const subprocess = await opener(url)
+  subprocess.on("error", () => {})
+}
+
 export const WebCommand = effectCmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
@@ -72,11 +77,11 @@ export const WebCommand = effectCmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl).catch(() => {})
+      openBrowser(localhostUrl).catch(() => {})
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      openBrowser(displayUrl).catch(() => {})
     }
 
     yield* Effect.never

--- a/packages/opencode/test/cli/web.test.ts
+++ b/packages/opencode/test/cli/web.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { ChildProcess } from "node:child_process"
+
+import { openBrowser } from "../../src/cli/cmd/web"
+
+describe("web browser", () => {
+  test("handles errors from the browser subprocess", async () => {
+    const subprocess = new ChildProcess()
+
+    await openBrowser("http://localhost:4096", async () => subprocess)
+
+    expect(() => subprocess.emit("error", new Error("Executable not found"))).not.toThrow()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Addresses #31815. Alternative to #36875.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`open()` returns a child process before a missing Linux opener emits its `error` event. The existing promise `.catch()` therefore does not consume Bun's `xdg-open` ENOENT event.

This keeps browser opening fire-and-forget but attaches an `error` listener to the returned child process. Unlike a Linux-specific PATH preflight, it lets the `open` package retain responsibility for selecting platform-specific openers and also handles launch errors that occur after spawning.

### How did you verify your code works?

- `bun test test/cli/web.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `git diff --check`

Dependency installation used `--ignore-scripts` because this environment lacks `node-gyp` for the unrelated `tree-sitter-powershell` preinstall.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR