### PR TITLE
fix(ai): make xAI Responses websockets work and enable them

### DIFF
--- a/packages/ai/src/protocols/open-responses-channel.ts
+++ b/packages/ai/src/protocols/open-responses-channel.ts
@@ -26,10 +26,6 @@ export interface Options {
   readonly enabled?: (url: string) => boolean
   readonly url?: (url: string) => string
   readonly headers?: (headers: Headers.Headers) => Headers.Headers
-  /**
-   * Shapes the fields sent next to `previous_response_id` on an incremental step, or returns undefined to send
-   * that step in full. The provider keeps omitted fields from the response it continues.
-   */
   readonly continuation?: OpenResponsesContinuation.Shape
 }
 

--- a/packages/ai/src/protocols/open-responses-channel.ts
+++ b/packages/ai/src/protocols/open-responses-channel.ts
@@ -18,7 +18,6 @@ const WebSocketResponseCreate = Schema.StructWithRest(Schema.Struct({ type: Sche
 ])
 const decodeMessage = ProviderShared.validateWith(Schema.decodeUnknownEffect(WebSocketResponseCreate))
 const encodeMessage = Schema.encodeSync(Schema.fromJsonString(WebSocketResponseCreate))
-const decodeEvent = Schema.decodeUnknownEffect(OpenResponses.protocol.stream.event)
 
 export interface Options {
   readonly id: string
@@ -27,6 +26,11 @@ export interface Options {
   readonly enabled?: (url: string) => boolean
   readonly url?: (url: string) => string
   readonly headers?: (headers: Headers.Headers) => Headers.Headers
+  /**
+   * Shapes the fields sent next to `previous_response_id` on an incremental step, or returns undefined to send
+   * that step in full. The provider keeps omitted fields from the response it continues.
+   */
+  readonly continuation?: OpenResponsesContinuation.Shape
 }
 
 export interface Prepared {
@@ -60,7 +64,7 @@ const driver = (options: Options, body: string): WebSocketChannelDriver => {
       }),
     observe: (_create, frame) =>
       Effect.gen(function* () {
-        const event = yield* decodeEvent(frame).pipe(
+        const event = yield* OpenResponses.decodeChannelEvent(frame).pipe(
           Effect.mapError((cause) =>
             ProviderShared.eventError(options.id, `Invalid ${options.name} WebSocket event`, frame, cause),
           ),
@@ -163,6 +167,7 @@ export const transport = <Body>(options: Options): Transport<Body, Prepared, str
                     request: create.request,
                     message: create.message,
                     base,
+                    continuation: options.continuation,
                   }),
                 }
               })

--- a/packages/ai/src/protocols/open-responses-continuation.ts
+++ b/packages/ai/src/protocols/open-responses-continuation.ts
@@ -6,7 +6,6 @@ import { OpenResponses } from "./open-responses.js"
 
 const PROTOCOL = "open-responses.websocket.v1"
 const VERSION = 1
-const decodeEvent = Schema.decodeUnknownEffect(OpenResponses.protocol.stream.event)
 
 interface CheckpointValue {
   readonly version: typeof VERSION
@@ -15,12 +14,16 @@ interface CheckpointValue {
   readonly output: ReadonlyArray<unknown>
 }
 
+/** Fields to send next to `previous_response_id`, or undefined to send the step in full. */
+export type Shape = (request: Readonly<Record<string, unknown>>) => Readonly<Record<string, unknown>> | undefined
+
 export interface DriverInput {
   readonly id: string
   readonly name: string
   readonly request: Readonly<Record<string, unknown>>
   readonly message: string
   readonly base: WebSocketChannelDriver
+  readonly continuation?: Shape
 }
 
 const checkpointValue = (checkpoint: ChannelCheckpoint | undefined): CheckpointValue | undefined => {
@@ -104,6 +107,13 @@ const incremental = (
 
 const code = (event: OpenResponses.Event) => event.code || event.error?.code || event.response?.error?.code || undefined
 
+// A classified failure (overflow, rate limit, quota, policy, auth) describes the request as a whole and keeps its
+// runner-owned recovery; anything else the provider refuses before creating a response is blamed on the continuation.
+const blamesContinuation = (reason: AIError["reason"]) => {
+  if (reason._tag === "InvalidRequest") return reason.classification === undefined
+  return reason._tag === "ProviderInternal" || reason._tag === "UnknownProvider"
+}
+
 const rejected = (
   observation: Extract<ChannelObservation, { readonly type: "provider-failure" }>,
   recovery: "retry-full" | "rotate-and-retry-full",
@@ -127,40 +137,42 @@ const rejected = (
 
 export const driver = (input: DriverInput): WebSocketChannelDriver => {
   const { previous_response_id: _previousResponseID, ...request } = input.request
+  const shape = input.continuation ?? ((fields: Readonly<Record<string, unknown>>) => fields)
   let output: OpenResponses.StreamItem[] = []
+  let created = false
   return {
     create: (checkpoint) =>
       Effect.sync(() => {
         output = []
+        created = false
         const previous = checkpointValue(checkpoint)
         const delta = previous ? incremental(request, previous) : undefined
-        if (!previous || !delta) return { message: ProviderShared.encodeJson(request), mode: "full" as const }
+        const fields = delta ? shape(request) : undefined
+        if (!previous || !delta || !fields)
+          return { message: ProviderShared.encodeJson(request), mode: "full" as const }
         return {
-          message: ProviderShared.encodeJson({ ...request, input: delta, previous_response_id: previous.responseID }),
+          message: ProviderShared.encodeJson({ ...fields, input: delta, previous_response_id: previous.responseID }),
           mode: "incremental" as const,
         }
       }),
     observe: (create, frame) =>
       Effect.gen(function* () {
-        const event = yield* decodeEvent(frame).pipe(
+        const event = yield* OpenResponses.decodeChannelEvent(frame).pipe(
           Effect.mapError((cause) =>
             ProviderShared.eventError(input.id, `Invalid ${input.name} WebSocket event`, frame, cause),
           ),
         )
         const observation = yield* input.base.observe(create, frame)
+        if (event.type === "response.created") created = true
         if (event.type === "response.output_item.done" && event.item) output.push(event.item)
         if (observation.type === "provider-failure") {
           const rejection = code(event)
           if (rejection === "previous_response_not_found") return rejected(observation, "retry-full")
           if (rejection === "websocket_connection_limit_reached") return rejected(observation, "rotate-and-retry-full")
-          // Only the continuation distinguishes an incremental send from a full one, so an unclassified
-          // invalid request there is retried full; Codex reports a stale previous_response_id that way, with
-          // no code. Classified failures such as context overflow keep their runner-owned recovery.
-          if (
-            create.mode === "incremental" &&
-            observation.error.reason._tag === "InvalidRequest" &&
-            observation.error.reason.classification === undefined
-          )
+          // Only the continuation distinguishes an incremental send from a full one, so a refusal before the
+          // provider creates a response is retried full. Codex reports a stale previous_response_id as an
+          // invalid_request_error with no code; xAI reports every rejection as an api_error.
+          if (create.mode === "incremental" && !created && blamesContinuation(observation.error.reason))
             return rejected(observation, "retry-full")
         }
         if (observation.type !== "completed") return observation
@@ -195,4 +207,4 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
   }
 }
 
-export const OpenResponsesContinuation = { driver } as const
+export * as OpenResponsesContinuation from "./open-responses-continuation.js"

--- a/packages/ai/src/protocols/open-responses-continuation.ts
+++ b/packages/ai/src/protocols/open-responses-continuation.ts
@@ -14,7 +14,10 @@ interface CheckpointValue {
   readonly output: ReadonlyArray<unknown>
 }
 
-/** Fields to send next to `previous_response_id`, or undefined to send the step in full. */
+/**
+ * Fields to send next to `previous_response_id` on an incremental step, or undefined to send the step in full.
+ * Whether omitted fields carry over from the continued response is provider behavior the route must know.
+ */
 export type Shape = (request: Readonly<Record<string, unknown>>) => Readonly<Record<string, unknown>> | undefined
 
 export interface DriverInput {
@@ -107,13 +110,6 @@ const incremental = (
 
 const code = (event: OpenResponses.Event) => event.code || event.error?.code || event.response?.error?.code || undefined
 
-// A classified failure (overflow, rate limit, quota, policy, auth) describes the request as a whole and keeps its
-// runner-owned recovery; anything else the provider refuses before creating a response is blamed on the continuation.
-const blamesContinuation = (reason: AIError["reason"]) => {
-  if (reason._tag === "InvalidRequest") return reason.classification === undefined
-  return reason._tag === "ProviderInternal" || reason._tag === "UnknownProvider"
-}
-
 const rejected = (
   observation: Extract<ChannelObservation, { readonly type: "provider-failure" }>,
   recovery: "retry-full" | "rotate-and-retry-full",
@@ -139,16 +135,15 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
   const { previous_response_id: _previousResponseID, ...request } = input.request
   const shape = input.continuation ?? ((fields: Readonly<Record<string, unknown>>) => fields)
   let output: OpenResponses.StreamItem[] = []
-  let created = false
   return {
     create: (checkpoint) =>
       Effect.sync(() => {
         output = []
-        created = false
         const previous = checkpointValue(checkpoint)
-        const delta = previous ? incremental(request, previous) : undefined
-        const fields = delta ? shape(request) : undefined
-        if (!previous || !delta || !fields)
+        // Ask the route first: diffing the whole history is wasted when it declines the continuation.
+        const fields = previous ? shape(request) : undefined
+        const delta = previous && fields ? incremental(request, previous) : undefined
+        if (!previous || !fields || !delta)
           return { message: ProviderShared.encodeJson(request), mode: "full" as const }
         return {
           message: ProviderShared.encodeJson({ ...fields, input: delta, previous_response_id: previous.responseID }),
@@ -163,16 +158,19 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
           ),
         )
         const observation = yield* input.base.observe(create, frame)
-        if (event.type === "response.created") created = true
         if (event.type === "response.output_item.done" && event.item) output.push(event.item)
         if (observation.type === "provider-failure") {
           const rejection = code(event)
           if (rejection === "previous_response_not_found") return rejected(observation, "retry-full")
           if (rejection === "websocket_connection_limit_reached") return rejected(observation, "rotate-and-retry-full")
-          // Only the continuation distinguishes an incremental send from a full one, so a refusal before the
-          // provider creates a response is retried full. Codex reports a stale previous_response_id as an
-          // invalid_request_error with no code; xAI reports every rejection as an api_error.
-          if (create.mode === "incremental" && !created && blamesContinuation(observation.error.reason))
+          // Only the continuation distinguishes an incremental send from a full one, so an unclassified
+          // invalid request there is retried full; Codex reports a stale previous_response_id that way, with
+          // no code. Classified failures such as context overflow keep their runner-owned recovery.
+          if (
+            create.mode === "incremental" &&
+            observation.error.reason._tag === "InvalidRequest" &&
+            observation.error.reason.classification === undefined
+          )
             return rejected(observation, "retry-full")
         }
         if (observation.type !== "completed") return observation

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -405,6 +405,24 @@ export const Event = Schema.StructWithRest(
 export type Event = Schema.Schema.Type<typeof Event>
 export type NormalizedEvent = Event & { readonly item?: OutputItem | null }
 
+const decodeEventValue = Schema.decodeUnknownEffect(Event)
+const decodeFrame = Schema.decodeUnknownEffect(ProviderShared.Json)
+
+/**
+ * Decodes one WebSocket frame. xAI answers a rejected `response.create` with `{ "error": { "message", "type" } }` and no
+ * event type; that envelope reads as an error event so the failure classifies instead of failing decoding.
+ */
+export const decodeChannelEvent = (frame: string) =>
+  decodeFrame(frame).pipe(
+    Effect.flatMap((value) =>
+      decodeEventValue(
+        ProviderShared.isRecord(value) && value.type === undefined && ProviderShared.isRecord(value.error)
+          ? { ...value, type: "error" }
+          : value,
+      ),
+    ),
+  )
+
 export interface ProviderAdapter {
   readonly id: string
   readonly name: string

--- a/packages/ai/src/providers/xai.ts
+++ b/packages/ai/src/providers/xai.ts
@@ -4,7 +4,6 @@ import { Endpoint } from "../route/endpoint.js"
 import { HttpOptions, ProviderID, type ModelID } from "../schema/index.js"
 import { OpenAIChat } from "../protocols/openai-chat.js"
 import { OpenResponsesChannel } from "../protocols/open-responses-channel.js"
-import type { OpenResponsesContinuation } from "../protocols/open-responses-continuation.js"
 import { XAIResponses } from "../protocols/xai-responses.js"
 import { XAIImages } from "../protocols/xai-images.js"
 import type { OpenAIOptionsInput } from "./openai-options.js"
@@ -31,12 +30,6 @@ export type { XAIImageOptions } from "../protocols/xai-images.js"
 
 const RESPONSES_WEBSOCKET_ROTATE_AFTER_MS = 24 * 60 * 1000
 
-// xAI continues a chain only from stored responses: with `store: false` (the route default) `previous_response_id`
-// fails with "Response with id=… not found", so those steps are sent in full over the reused connection. It also
-// rejects `instructions` next to `previous_response_id` and keeps the instructions of the response it continues.
-const continuation: OpenResponsesContinuation.Shape = ({ instructions: _instructions, ...request }) =>
-  request.store === false ? undefined : request
-
 const responsesRoute = Route.make({
   compact: { endpoint: XAIResponses.compact },
   id: "openai-responses",
@@ -48,7 +41,10 @@ const responsesRoute = Route.make({
     id: "openai-responses",
     name: "xAI Responses",
     rotateAfterMs: RESPONSES_WEBSOCKET_ROTATE_AFTER_MS,
-    continuation,
+    // xAI continues a chain only from stored responses: with `store: false` (the route default) `previous_response_id`
+    // fails with "Response with id=… not found", so those steps are sent in full over the reused connection. It also
+    // rejects `instructions` next to `previous_response_id` and keeps the instructions of the response it continues.
+    continuation: ({ instructions: _instructions, ...request }) => (request.store === false ? undefined : request),
   }),
   defaults: { providerOptions: { store: false, include: ["reasoning.encrypted_content"] } },
 })

--- a/packages/ai/src/providers/xai.ts
+++ b/packages/ai/src/providers/xai.ts
@@ -4,6 +4,7 @@ import { Endpoint } from "../route/endpoint.js"
 import { HttpOptions, ProviderID, type ModelID } from "../schema/index.js"
 import { OpenAIChat } from "../protocols/openai-chat.js"
 import { OpenResponsesChannel } from "../protocols/open-responses-channel.js"
+import type { OpenResponsesContinuation } from "../protocols/open-responses-continuation.js"
 import { XAIResponses } from "../protocols/xai-responses.js"
 import { XAIImages } from "../protocols/xai-images.js"
 import type { OpenAIOptionsInput } from "./openai-options.js"
@@ -30,6 +31,12 @@ export type { XAIImageOptions } from "../protocols/xai-images.js"
 
 const RESPONSES_WEBSOCKET_ROTATE_AFTER_MS = 24 * 60 * 1000
 
+// xAI continues a chain only from stored responses: with `store: false` (the route default) `previous_response_id`
+// fails with "Response with id=… not found", so those steps are sent in full over the reused connection. It also
+// rejects `instructions` next to `previous_response_id` and keeps the instructions of the response it continues.
+const continuation: OpenResponsesContinuation.Shape = ({ instructions: _instructions, ...request }) =>
+  request.store === false ? undefined : request
+
 const responsesRoute = Route.make({
   compact: { endpoint: XAIResponses.compact },
   id: "openai-responses",
@@ -41,6 +48,7 @@ const responsesRoute = Route.make({
     id: "openai-responses",
     name: "xAI Responses",
     rotateAfterMs: RESPONSES_WEBSOCKET_ROTATE_AFTER_MS,
+    continuation,
   }),
   defaults: { providerOptions: { store: false, include: ["reasoning.encrypted_content"] } },
 })

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -90,7 +90,11 @@ const classifyingChannelDriver = (message: string): WebSocketChannelDriver => {
   }
 }
 
-const continuationDriver = (request: Readonly<Record<string, unknown>>, base = baseChannelDriver) => {
+const continuationDriver = (
+  request: Readonly<Record<string, unknown>>,
+  base = baseChannelDriver,
+  continuation?: OpenResponsesContinuation.Shape,
+) => {
   const message = ProviderShared.encodeJson(request)
   return OpenResponsesContinuation.driver({
     id: "openai-responses",
@@ -98,6 +102,7 @@ const continuationDriver = (request: Readonly<Record<string, unknown>>, base = b
     request,
     message,
     base: base(message),
+    continuation,
   })
 }
 
@@ -921,6 +926,111 @@ describe("OpenAI Responses route", () => {
         type: "provider-failure",
         error: { reason: { _tag: "InvalidRequest", classification: "context-overflow" } },
       })
+    }),
+  )
+
+  it.effect("retries an incremental send in full when the provider refuses it before creating a response", () =>
+    Effect.gen(function* () {
+      const firstRequest = {
+        type: "response.create",
+        model: "grok-4.6",
+        store: false,
+        input: [{ role: "user", content: [{ type: "input_text", text: "First" }] }],
+      }
+      const first = continuationDriver(firstRequest, classifyingChannelDriver)
+      const saved = checkpoint(
+        yield* first.observe(
+          yield* first.create(undefined),
+          ProviderShared.encodeJson({ type: "response.completed", response: { id: "resp_1" } }),
+        ),
+      )
+      const second = continuationDriver(
+        {
+          ...firstRequest,
+          input: [...firstRequest.input, { role: "user", content: [{ type: "input_text", text: "Second" }] }],
+        },
+        classifyingChannelDriver,
+      )
+      // xAI reports every rejection as an api_error, which classifies as a retryable provider failure.
+      const notFound = ProviderShared.encodeJson({
+        type: "error",
+        error: { type: "api_error", message: "gRPC error: Response with id=resp_1 not found" },
+      })
+      const incremental = yield* second.create(saved)
+      expect(incremental.mode).toBe("incremental")
+      expect(yield* second.observe(incremental, notFound)).toMatchObject({
+        type: "rejected",
+        recovery: "retry-full",
+        error: { reason: { _tag: "Transport", delivery: "rejected" } },
+      })
+
+      // Once the provider has created a response the continuation was accepted; a later error is its own failure.
+      const started = yield* second.create(saved)
+      yield* second.observe(
+        started,
+        ProviderShared.encodeJson({ type: "response.created", response: { id: "resp_2" } }),
+      )
+      expect(yield* second.observe(started, notFound)).toMatchObject({
+        type: "provider-failure",
+        error: { reason: { _tag: "ProviderInternal" } },
+      })
+
+      // A full send has no continuation to blame.
+      expect(yield* second.observe(yield* second.create(undefined), notFound)).toMatchObject({
+        type: "provider-failure",
+        error: { reason: { _tag: "ProviderInternal" } },
+      })
+
+      // A rate limit describes the request as a whole; resending it in full would only hit the limit again.
+      const limited = ProviderShared.encodeJson({
+        type: "error",
+        error: { type: "rate_limit_error", message: "Rate limit exceeded" },
+      })
+      expect(yield* second.observe(yield* second.create(saved), limited)).toMatchObject({
+        type: "provider-failure",
+        error: { reason: { _tag: "RateLimit" } },
+      })
+    }),
+  )
+
+  it.effect("shapes the incremental send with the route continuation", () =>
+    Effect.gen(function* () {
+      const firstRequest = {
+        type: "response.create",
+        model: "grok-4.6",
+        store: true,
+        instructions: "You are terse.",
+        input: [{ role: "user", content: [{ type: "input_text", text: "First" }] }],
+      }
+      const secondRequest = {
+        ...firstRequest,
+        input: [...firstRequest.input, { role: "user", content: [{ type: "input_text", text: "Second" }] }],
+      }
+      const saved = checkpoint(
+        yield* continuationDriver(firstRequest).observe(
+          yield* continuationDriver(firstRequest).create(undefined),
+          ProviderShared.encodeJson({ type: "response.completed", response: { id: "resp_1" } }),
+        ),
+      )
+
+      const trimmed = yield* continuationDriver(
+        secondRequest,
+        baseChannelDriver,
+        ({ instructions: _, ...rest }) => rest,
+      ).create(saved)
+      expect(trimmed.mode).toBe("incremental")
+      expect(JSON.parse(trimmed.message)).toEqual({
+        type: "response.create",
+        model: "grok-4.6",
+        store: true,
+        previous_response_id: "resp_1",
+        input: [{ role: "user", content: [{ type: "input_text", text: "Second" }] }],
+      })
+
+      // Declining the continuation sends the step in full and never sends a previous_response_id.
+      const declined = yield* continuationDriver(secondRequest, baseChannelDriver, () => undefined).create(saved)
+      expect(declined.mode).toBe("full")
+      expect(JSON.parse(declined.message)).toEqual(secondRequest)
     }),
   )
 

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -926,69 +926,16 @@ describe("OpenAI Responses route", () => {
         type: "provider-failure",
         error: { reason: { _tag: "InvalidRequest", classification: "context-overflow" } },
       })
-    }),
-  )
 
-  it.effect("retries an incremental send in full when the provider refuses it before creating a response", () =>
-    Effect.gen(function* () {
-      const firstRequest = {
-        type: "response.create",
-        model: "grok-4.6",
-        store: false,
-        input: [{ role: "user", content: [{ type: "input_text", text: "First" }] }],
-      }
-      const first = continuationDriver(firstRequest, classifyingChannelDriver)
-      const saved = checkpoint(
-        yield* first.observe(
-          yield* first.create(undefined),
-          ProviderShared.encodeJson({ type: "response.completed", response: { id: "resp_1" } }),
-        ),
-      )
-      const second = continuationDriver(
-        {
-          ...firstRequest,
-          input: [...firstRequest.input, { role: "user", content: [{ type: "input_text", text: "Second" }] }],
-        },
-        classifyingChannelDriver,
-      )
-      // xAI reports every rejection as an api_error, which classifies as a retryable provider failure.
-      const notFound = ProviderShared.encodeJson({
+      // A retryable failure stays one: the runner retries it, and the transport has already dropped the
+      // checkpoint, so that retry is a full send. xAI reports every rejection this way.
+      const internal = ProviderShared.encodeJson({
         type: "error",
         error: { type: "api_error", message: "gRPC error: Response with id=resp_1 not found" },
       })
-      const incremental = yield* second.create(saved)
-      expect(incremental.mode).toBe("incremental")
-      expect(yield* second.observe(incremental, notFound)).toMatchObject({
-        type: "rejected",
-        recovery: "retry-full",
-        error: { reason: { _tag: "Transport", delivery: "rejected" } },
-      })
-
-      // Once the provider has created a response the continuation was accepted; a later error is its own failure.
-      const started = yield* second.create(saved)
-      yield* second.observe(
-        started,
-        ProviderShared.encodeJson({ type: "response.created", response: { id: "resp_2" } }),
-      )
-      expect(yield* second.observe(started, notFound)).toMatchObject({
+      expect(yield* second.observe(yield* second.create(saved), internal)).toMatchObject({
         type: "provider-failure",
         error: { reason: { _tag: "ProviderInternal" } },
-      })
-
-      // A full send has no continuation to blame.
-      expect(yield* second.observe(yield* second.create(undefined), notFound)).toMatchObject({
-        type: "provider-failure",
-        error: { reason: { _tag: "ProviderInternal" } },
-      })
-
-      // A rate limit describes the request as a whole; resending it in full would only hit the limit again.
-      const limited = ProviderShared.encodeJson({
-        type: "error",
-        error: { type: "rate_limit_error", message: "Rate limit exceeded" },
-      })
-      expect(yield* second.observe(yield* second.create(saved), limited)).toMatchObject({
-        type: "provider-failure",
-        error: { reason: { _tag: "RateLimit" } },
       })
     }),
   )

--- a/packages/ai/test/provider/xai-responses.test.ts
+++ b/packages/ai/test/provider/xai-responses.test.ts
@@ -1,17 +1,47 @@
 import { describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Stream } from "effect"
 import { LLM, LLMEvent, Message } from "../../src/index.js"
 import { XAI } from "../../src/providers.js"
 import { OpenResponses } from "../../src/protocols/open-responses.js"
 import { OpenAIResponses } from "../../src/protocols/openai-responses.js"
+import * as ProviderShared from "../../src/protocols/shared.js"
 import { XAIResponses } from "../../src/protocols/xai-responses.js"
-import { LLMClient } from "../../src/route.js"
+import { LLMClient, WebSocketTransport, type ChannelCheckpoint, type WebSocketChannelDriver } from "../../src/route.js"
 import { compileRequest } from "../../src/route/client.js"
 import { it } from "../lib/effect.js"
 import { fixedResponse } from "../lib/http.js"
 import { sseEvents } from "../lib/sse.js"
 
 const model = XAI.configure({ apiKey: "test", baseURL: "https://api.x.ai/v1" }).responses("grok-4.6")
+
+/** Runs a request through the WebSocket transport and hands back its channel driver; the HTTP fallback answers. */
+const channelDriver = (request: ReturnType<typeof LLM.request>) =>
+  Effect.gen(function* () {
+    let driver: WebSocketChannelDriver | undefined
+    yield* LLMClient.generate(request, {
+      webSocket: {
+        execute: (exchange) =>
+          Effect.sync(() => {
+            driver = exchange.driver
+            return { frames: exchange.fallback(), complete: Effect.void }
+          }),
+      },
+    }).pipe(Effect.provide(fixedResponse(sseEvents({ type: "response.completed", response: { id: "http" } }))))
+    if (!driver) throw new Error("Expected a WebSocket channel driver")
+    return driver
+  })
+
+const completed = (driver: WebSocketChannelDriver, id: string) =>
+  Effect.gen(function* () {
+    const create = yield* driver.create(undefined)
+    yield* driver.observe(create, ProviderShared.encodeJson({ type: "response.created", response: { id } }))
+    const observation = yield* driver.observe(
+      create,
+      ProviderShared.encodeJson({ type: "response.completed", response: { id } }),
+    )
+    if (observation.type !== "completed" || !observation.checkpoint) throw new Error("Expected a checkpoint")
+    return observation.checkpoint
+  })
 
 describe("xAI Responses route", () => {
   it.effect("composes the Open Responses baseline with xAI extensions", () =>
@@ -159,6 +189,69 @@ describe("xAI Responses route", () => {
         items[1],
         { role: "user", content: [{ type: "input_text", text: JSON.stringify(items[2]) }] },
       ])
+    }),
+  )
+
+  it.effect("classifies xAI's untyped WebSocket error envelope", () =>
+    Effect.gen(function* () {
+      // xAI answers a rejected response.create with an error envelope that carries no event type.
+      const envelope = ProviderShared.encodeJson({
+        error: {
+          message:
+            'Request validation error: {"code":"400","error":"Argument not supported: instructions and previous_response_id together"}',
+          type: "api_error",
+        },
+      })
+      const webSocket = WebSocketTransport.makeDirect({
+        open: () =>
+          Effect.succeed({ sendText: () => Effect.void, messages: Stream.make(envelope), close: Effect.void }),
+      })
+      const error = yield* LLMClient.generate(LLM.request({ model, prompt: "Hello" }), { webSocket }).pipe(
+        Effect.provide(fixedResponse("", { status: 500 })),
+        Effect.flip,
+      )
+
+      expect(error.reason._tag).toBe("ProviderInternal")
+      expect(error.message).toContain("Argument not supported: instructions and previous_response_id together")
+      expect(error.reason.body).toBe(envelope)
+    }),
+  )
+
+  it.effect("continues stored responses without instructions and sends unstored steps in full", () =>
+    Effect.gen(function* () {
+      const step = (store: boolean, ...prompts: string[]) =>
+        LLM.request({
+          model,
+          system: "You are terse.",
+          messages: prompts.map((prompt) => Message.user(prompt)),
+          providerOptions: { store },
+        })
+      const send = (store: boolean, checkpoint: ChannelCheckpoint) =>
+        channelDriver(step(store, "First", "Second")).pipe(Effect.flatMap((driver) => driver.create(checkpoint)))
+
+      const stored = yield* send(true, yield* completed(yield* channelDriver(step(true, "First")), "resp_1"))
+      expect(stored.mode).toBe("incremental")
+      expect(JSON.parse(stored.message)).toEqual({
+        type: "response.create",
+        model: "grok-4.6",
+        store: true,
+        include: ["reasoning.encrypted_content"],
+        previous_response_id: "resp_1",
+        input: [{ role: "user", content: [{ type: "input_text", text: "Second" }] }],
+      })
+
+      // The connection cache only serves stored responses, so the default store: false never chains.
+      const unstored = yield* send(false, yield* completed(yield* channelDriver(step(false, "First")), "resp_1"))
+      expect(unstored.mode).toBe("full")
+      expect(JSON.parse(unstored.message)).toMatchObject({
+        instructions: "You are terse.",
+        store: false,
+        input: [
+          { role: "user", content: [{ type: "input_text", text: "First" }] },
+          { role: "user", content: [{ type: "input_text", text: "Second" }] },
+        ],
+      })
+      expect(JSON.parse(unstored.message).previous_response_id).toBeUndefined()
     }),
   )
 

--- a/packages/ai/test/provider/xai-responses.test.ts
+++ b/packages/ai/test/provider/xai-responses.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect } from "bun:test"
-import { Effect, Stream } from "effect"
+import { Effect, Layer, Stream } from "effect"
 import { LLM, LLMEvent, Message } from "../../src/index.js"
 import { XAI } from "../../src/providers.js"
 import { OpenResponses } from "../../src/protocols/open-responses.js"
 import { OpenAIResponses } from "../../src/protocols/openai-responses.js"
 import * as ProviderShared from "../../src/protocols/shared.js"
 import { XAIResponses } from "../../src/protocols/xai-responses.js"
-import { LLMClient, WebSocketTransport, type ChannelCheckpoint, type WebSocketChannelDriver } from "../../src/route.js"
+import {
+  LLMClient,
+  RequestExecutor,
+  WebSocketTransport,
+  type ChannelCheckpoint,
+  type WebSocketChannelDriver,
+} from "../../src/route.js"
 import { compileRequest } from "../../src/route/client.js"
 import { it } from "../lib/effect.js"
 import { fixedResponse } from "../lib/http.js"
@@ -207,7 +213,16 @@ describe("xAI Responses route", () => {
           Effect.succeed({ sendText: () => Effect.void, messages: Stream.make(envelope), close: Effect.void }),
       })
       const error = yield* LLMClient.generate(LLM.request({ model, prompt: "Hello" }), { webSocket }).pipe(
-        Effect.provide(fixedResponse("", { status: 500 })),
+        Effect.provide(
+          LLMClient.layer.pipe(
+            Layer.provide(
+              Layer.succeed(
+                RequestExecutor.Service,
+                RequestExecutor.Service.of({ execute: () => Effect.die("unexpected HTTP request") }),
+              ),
+            ),
+          ),
+        ),
         Effect.flip,
       )
 

--- a/packages/core/src/plugin/provider/xai.ts
+++ b/packages/core/src/plugin/provider/xai.ts
@@ -101,6 +101,7 @@ export const XAIPlugin = define({
       for (const model of provider.models.values()) {
         catalog.model.update(providerID, model.id, (draft) => {
           draft.capabilities.responsesWebsockets = true
+          draft.websocket = true
         })
       }
     })

--- a/packages/core/test/plugin/provider-xai.test.ts
+++ b/packages/core/test/plugin/provider-xai.test.ts
@@ -69,7 +69,7 @@ describe("XAIPlugin", () => {
     }),
   )
 
-  it.effect("keeps xAI Responses WebSockets opt-in", () =>
+  it.effect("enables xAI Responses WebSockets", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service
       const providerID = Provider.ID.make("xai")
@@ -84,7 +84,7 @@ describe("XAIPlugin", () => {
 
       const model = yield* catalog.model.get(providerID, Model.ID.make("grok-4.6"))
       expect(model?.capabilities.responsesWebsockets).toBe(true)
-      expect(model?.websocket).toBeUndefined()
+      expect(model?.websocket).toBe(true)
     }),
   )
 })

--- a/services/www/src/docs/content/providers.mdx
+++ b/services/www/src/docs/content/providers.mdx
@@ -110,10 +110,11 @@ role for other Foundry models. If a request fails because the token belongs to a
 
 ## WebSocket transport
 
-OpenAI and supported Azure Responses models keep one WebSocket connection open per session and send each step over it
-instead of opening a new HTTP request. While the request prefix is unchanged, consecutive steps only transmit what was
-added since the previous response, which cuts upload volume on long sessions. Provider compaction runs over the same
-connection.
+OpenAI, xAI, and supported Azure Responses models keep one WebSocket connection open per session and send each step
+over it instead of opening a new HTTP request. While the request prefix is unchanged, consecutive steps only transmit
+what was added since the previous response, which cuts upload volume on long sessions. OpenAI provider compaction runs
+over the same connection. xAI continues a chain only from stored responses, so with its default `store: false` each step
+is sent in full over the reused connection.
 
 The connection is transparent. When the provider closes the socket, the next step reconnects; when a connection cannot
 be opened at all, the session continues over HTTP. Plugins that register `http.request` or `http.response` hooks for a


### PR DESCRIPTION
## Summary
Re-enable the Responses WebSocket for xAI (disabled in #48231) after fixing the three things that made it fail, verified against the live xAI socket with an API key.

**What was broken.** Every xAI step after the first went incremental (`previous_response_id` + the new items), and xAI answered with `{"error":{"message":"…","type":"api_error"}}` — an envelope with no event `type`. `OpenResponses.Event` requires `type`, so the frame failed decoding, surfaced as `InvalidProviderOutput`, and the step failed hard. Probing the socket directly shows two distinct rejections behind that envelope:

1. `Argument not supported: instructions and previous_response_id together` — xAI refuses `instructions` on a continuation and keeps the instructions of the response it continues (verified: a `BANANA`-suffix instruction set on turn 1 still applies on turns 2–3 with the field dropped).
2. `gRPC error: Response with id=… not found` — with `store: false` (our route default) **no** continuation works today: docs-shaped body, `generate: false` warmup, grok-4.6/4.3/4.20/build all fail. xAI's docs say the per-connection cache serves `store: false`; the server does not. With `store: true` the chain works and xAI keeps one `response.id` for the whole connection.

## Changes
- **Decode xAI's untyped error envelope** (`OpenResponses.decodeChannelEvent`): a frame with `error` and no `type` reads as an `error` event, so it classifies through `providerFailure` like every other failure instead of failing decoding. Used by both WebSocket drivers.
- **No new blame rule.** xAI labels every rejection `api_error`, which classifies as `ProviderInternal` — already retryable, and because the transport drops the checkpoint and closes the channel after any error terminal, that retry is necessarily a full send on a fresh connection. An earlier revision widened the continuation-rejection rule to cover it; the simplify pass removed that as unnecessary (it would also have changed OpenAI/Azure behaviour for pre-creation 5xxs). The Codex rule (unclassified `InvalidRequest` on an incremental send → `retry-full`) is unchanged; a test pins that `api_error` stays a provider failure.
- **Per-route continuation shape** (`OpenResponsesChannel.Options.continuation`): shapes the fields sent next to `previous_response_id`, or declines so the step goes in full. xAI drops `instructions` and declines while `store === false`, so default sessions use the reused connection with full sends (zero wasted round trips) and `settings.store: true` sessions chain incrementally. When xAI's cache starts serving `store: false`, the gate is one line.
- **Enable**: the xAI plugin sets `websocket = true` alongside `responsesWebsockets`; docs updated.

## Evidence (live, api.x.ai, grok-4.6 / grok-4.3)
- Isolated server, default config: tools (glob/read/bash), interrupt mid-step, model switch A→B→A with recall, idle gaps, big reads — **17 sends on one connection (all `full`), 0 fallbacks, 0 WARN/ERROR, 0 rejections**, prompt-cache reads high across full sends.
- Idle: xAI closes an idle socket with 1006 (seen after ~9 min and after a 300 s gap); the next step reconnects transparently and recall is intact — 21 sends over 4 connections in the whole run, still 0 fallbacks / 0 warnings.
- Isolated server, `providers.xai.settings.store: true`: 1 full + **4 incremental** sends, tool step and recall clean.
- Rejection path through `SessionModelTransport` against the real socket with the shape removed: the incremental send returns the untyped envelope → classified `ProviderInternal` with the original message (the runner retries it); the next attempt goes out in full on a new connection and succeeds.
- Raw probes: the xAI socket stays open after an error frame (unlike Codex); `include`, `prompt_cache_key`, `max_output_tokens`, `tools`, `parallel_tool_calls`, `reasoning`, `tool_choice` are all accepted next to `previous_response_id`.

## Validation
- New tests: untyped envelope end-to-end through the real channel driver (`ProviderInternal`, body preserved); `api_error` on an incremental send stays a provider failure; continuation shape trims `instructions` / declines to full; xAI route chains stored responses without `instructions` and sends unstored steps in full; xAI plugin enables the policy.
- Simplify pass (three reviewers) applied: removed the widened blame rule and its `created` flag; the route shape is consulted before the history diff (1–5 ms per step saved on xAI's default path, measured); the `continuation` doc no longer generalises xAI's carry-over semantics (OpenAI drops omitted `instructions`); xAI's shape is inlined at the transport call.
- `bun test`: `@opencode/ai` 1,298 pass; `packages/core` 5,393 pass / 35 skip (one unrelated `pty` timeout while two servers booted concurrently — passes alone). Typecheck clean for ai, schema, core, client; no generated-client drift.

## Not in this PR
- xAI reports deterministic 400s on the socket as `api_error`, so a genuinely invalid *full* send is retried with backoff before failing (same class as its HTTP quirk). Our full sends are the same bodies that work over HTTP.
- `settings.store` is the AI-SDK-mapped spelling; `settings.providerOptions.store` is ignored for `@ai-sdk/xai` (pre-existing `AISDKNative.map` behaviour).
