### PR TITLE
fix(opencode): refresh brew tap before version check

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -130,6 +130,25 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
       return "opencode"
     })
 
+    const brewEnv = { HOMEBREW_NO_AUTO_UPDATE: "1" }
+    const refreshBrewTap = Effect.fnUntraced(function* () {
+      const tap = yield* run(["brew", "tap", "anomalyco/tap"], { env: brewEnv })
+      if (tap.code !== 0) return tap
+      const dir = (yield* text(["brew", "--repo", "anomalyco/tap"])).trim()
+      if (!dir) return { code: 1, stdout: "", stderr: "Tap repository not found." }
+      return yield* run(["git", "pull", "--ff-only"], { cwd: dir, env: brewEnv })
+    })
+
+    const latestGitHub = Effect.fnUntraced(function* () {
+      const response = yield* httpOk.execute(
+        HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
+          HttpClientRequest.acceptJson,
+        ),
+      )
+      const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
+      return data.tag_name.replace(/^v/, "")
+    })
+
     const upgradeFailure = (method: Method, result?: { code: number; stdout: string; stderr: string }) => {
       if (method === "choco") return "not running from an elevated command shell"
       if (result) return `Upgrade failed for ${method} (exit code ${result.code}).`
@@ -211,6 +230,8 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
         if (detectedMethod === "brew") {
           const formula = yield* getBrewFormula()
           if (formula.includes("/")) {
+            const refreshed = yield* refreshBrewTap()
+            if (refreshed.code !== 0) return yield* latestGitHub()
             const infoJson = yield* text(["brew", "info", "--json=v2", formula])
             const info = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(BrewInfoV2))(infoJson)
             return info.formulae[0].versions.stable
@@ -254,13 +275,7 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
           return data.version
         }
 
-        const response = yield* httpOk.execute(
-          HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
-            HttpClientRequest.acceptJson,
-          ),
-        )
-        const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
-        return data.tag_name.replace(/^v/, "")
+        return yield* latestGitHub()
       }, Effect.orDie),
       upgrade: Effect.fn("Installation.upgrade")(function* (m: Method, target: string) {
         let upgradeResult: { code: number; stdout: string; stderr: string } | undefined
@@ -279,24 +294,14 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
             break
           case "brew": {
             const formula = yield* getBrewFormula()
-            const env = { HOMEBREW_NO_AUTO_UPDATE: "1" }
             if (formula.includes("/")) {
-              const tap = yield* run(["brew", "tap", "anomalyco/tap"], { env })
-              if (tap.code !== 0) {
-                upgradeResult = tap
+              const refreshed = yield* refreshBrewTap()
+              if (refreshed.code !== 0) {
+                upgradeResult = refreshed
                 break
               }
-              const repo = yield* text(["brew", "--repo", "anomalyco/tap"])
-              const dir = repo.trim()
-              if (dir) {
-                const pull = yield* run(["git", "pull", "--ff-only"], { cwd: dir, env })
-                if (pull.code !== 0) {
-                  upgradeResult = pull
-                  break
-                }
-              }
             }
-            upgradeResult = yield* run(["brew", "upgrade", formula], { env })
+            upgradeResult = yield* run(["brew", "upgrade", formula], { env: brewEnv })
             break
           }
           case "choco":

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -18,12 +18,15 @@ function mockHttpClient(handler: (request: HttpClientRequest.HttpClientRequest) 
 }
 
 function mockSpawner(
-  handler: (cmd: string, args: readonly string[]) => string | { code: number; stdout?: string; stderr?: string } = () =>
-    "",
+  handler: (
+    cmd: string,
+    args: readonly string[],
+    options: ChildProcess.CommandOptions,
+  ) => string | { code: number; stdout?: string; stderr?: string } = () => "",
 ) {
   const spawner = ChildProcessSpawner.make((command) => {
     const std = ChildProcess.isStandardCommand(command) ? command : undefined
-    const result = handler(std?.command ?? "", std?.args ?? [])
+    const result = handler(std?.command ?? "", std?.args ?? [], std?.options ?? {})
     const output = typeof result === "string" ? { code: 0, stdout: result, stderr: "" } : result
     return Effect.succeed(
       ChildProcessSpawner.makeHandle({
@@ -53,7 +56,11 @@ function jsonResponse(body: unknown) {
 
 function testLayer(
   httpHandler: (request: HttpClientRequest.HttpClientRequest) => Response,
-  spawnHandler?: (cmd: string, args: readonly string[]) => string | { code: number; stdout?: string; stderr?: string },
+  spawnHandler?: (
+    cmd: string,
+    args: readonly string[],
+    options: ChildProcess.CommandOptions,
+  ) => string | { code: number; stdout?: string; stderr?: string },
 ) {
   const spawnerNode = makeGlobalNode({
     service: ChildProcessSpawner.ChildProcessSpawner,
@@ -161,22 +168,64 @@ describe("installation", () => {
       }),
     )
 
-    const brewInfoJson = JSON.stringify({
-      formulae: [{ versions: { stable: "2.1.0" } }],
-    })
+    let tapRefreshed = false
+    let tapRefreshCwd: string | undefined
+    let tapCommandAutoUpdate: string | undefined
+    let tapRefreshAutoUpdate: string | undefined
+    let tapRefreshFastForward = false
     testEffect(
       testLayer(
         () => jsonResponse({}), // HTTP not used for tap formula
-        (cmd, args) => {
+        (cmd, args, options) => {
           if (cmd === "brew" && args.includes("anomalyco/tap/opencode") && args.includes("--formula")) return "opencode"
-          if (cmd === "brew" && args.includes("--json=v2")) return brewInfoJson
+          if (cmd === "brew" && args[0] === "tap") {
+            tapCommandAutoUpdate = options.env?.HOMEBREW_NO_AUTO_UPDATE
+            return ""
+          }
+          if (cmd === "brew" && args.includes("--repo")) return "/tmp/anomalyco-tap\n"
+          if (cmd === "git" && args.includes("pull")) {
+            tapRefreshed = true
+            tapRefreshCwd = options.cwd
+            tapRefreshAutoUpdate = options.env?.HOMEBREW_NO_AUTO_UPDATE
+            tapRefreshFastForward = args.includes("--ff-only")
+            return ""
+          }
+          if (cmd === "brew" && args.includes("--json=v2")) {
+            return JSON.stringify({
+              formulae: [{ versions: { stable: tapRefreshed ? "2.1.0" : "2.0.0" } }],
+            })
+          }
           return ""
         },
       ),
-    ).effect("reads brew tap info JSON via CLI", () =>
+    ).effect("refreshes the brew tap before reading its info JSON", () =>
       Effect.gen(function* () {
         const result = yield* Installation.use.latest("brew")
         expect(result).toBe("2.1.0")
+        expect(tapRefreshed).toBe(true)
+        expect(tapRefreshCwd).toBe("/tmp/anomalyco-tap")
+        expect(tapCommandAutoUpdate).toBe("1")
+        expect(tapRefreshAutoUpdate).toBe("1")
+        expect(tapRefreshFastForward).toBe(true)
+      }),
+    )
+
+    let readStaleInfo = false
+    testEffect(
+      testLayer(
+        () => jsonResponse({ tag_name: "v2.2.0" }),
+        (cmd, args) => {
+          if (cmd === "brew" && args.includes("anomalyco/tap/opencode") && args.includes("--formula")) return "opencode"
+          if (cmd === "brew" && args[0] === "tap") return { code: 1, stderr: "offline" }
+          if (cmd === "brew" && args.includes("--json=v2")) readStaleInfo = true
+          return ""
+        },
+      ),
+    ).effect("falls back to GitHub instead of reading stale tap info when refresh fails", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.use.latest("brew")
+        expect(result).toBe("2.2.0")
+        expect(readStaleInfo).toBe(false)
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #48322

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Refreshes `anomalyco/tap` before reading its formula version. This prevents stale Homebrew metadata from making `opencode upgrade` return early. A failed targeted refresh falls back to the GitHub release version instead of stale tap info.

### How did you verify your code works?

- `bun test test/installation/installation.test.ts`
- `bun typecheck`
- repository pre-push typecheck (30 packages)

### Screenshots / recordings

Not applicable; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR