### PR TITLE
fix(desktop): render \(...\)/\[...\] and $/$$ multiline math

### DIFF
--- a/packages/ui/src/context/marked-parser.test.ts
+++ b/packages/ui/src/context/marked-parser.test.ts
@@ -14,6 +14,68 @@ test("renders inline and block math", async () => {
   expect(await parser.parse("$$\nx^2\n$$\n")).toContain('<span class="katex-display">')
 })
 
+test("renders \\(...\\) and \\[...\\] delimiters", async () => {
+  const inline = await parser.parse("\\( x^2 + y^2 \\)")
+  expect(inline).toContain('<span class="katex">')
+  expect(inline).not.toContain("katex-display")
+
+  const display = await parser.parse("\\[x^2 + y^2\\]")
+  expect(display).toContain('<span class="katex-display">')
+})
+
+test("renders single-dollar and single-line double-dollar math", async () => {
+  expect(await parser.parse("$x^2$")).toContain('<span class="katex">')
+  expect(await parser.parse("$$x^2$$")).toContain('<span class="katex-display">')
+  expect(await parser.parse("text $x^2$ text")).toContain('<span class="katex">')
+})
+
+test("renders multiline display math with environments", async () => {
+  const kmap = [
+    "\\[",
+    "\\begin{array}{c|cccc}",
+    "AB\\backslash CD & 00 & 01 & 11 & 10\\\\",
+    "\\hline",
+    "00 & 1 & 1 & 1 & 1\\\\",
+    "\\end{array}",
+    "\\]",
+  ].join("\n")
+  const kmapHtml = await parser.parse(kmap)
+  expect(kmapHtml).toContain('<span class="katex-display">')
+  expect(kmapHtml).not.toContain("katex-error")
+
+  for (const env of ["aligned", "matrix", "cases"]) {
+    const body =
+      env === "aligned"
+        ? "a &= 1\\\\\nb &= 2"
+        : env === "matrix"
+          ? "1 & 2\\\\\n3 & 4"
+          : "x & y"
+    const html = await parser.parse(`\\[\n\\begin{${env}}\n${body}\n\\end{${env}}\n\\]`)
+    expect(html).toContain('<span class="katex-display">')
+  }
+
+  expect(await parser.parse("\\(x^2 +\ny^2\\)")).toContain('<span class="katex">')
+  expect(await parser.parse("$$\nx^2\ny^2\n$$")).toContain('<span class="katex-display">')
+})
+
+test("does not render math inside code or from escaped/currency dollars", async () => {
+  expect(await parser.parse("`\\(x^2\\)`")).not.toContain("katex")
+  expect(await parser.parse("```\n\\[x^2\\]\n```\n")).not.toContain("katex")
+  expect(await parser.parse("```\n$x^2$\n```\n")).not.toContain("katex")
+
+  expect(await parser.parse("price is $5 and $10")).not.toContain("katex")
+  expect(await parser.parse("I paid $5 for coffee")).not.toContain("katex")
+  expect(await parser.parse("\\$x\\$")).not.toContain("katex")
+})
+
+test("leaves incomplete math as text without throwing", async () => {
+  for (const partial of ["\\(x^2", "\\[x^2", "$x^2", "$$x^2", "\\[\n\\begin{array}{c}\n1\\\\\n2"]) {
+    const html = await parser.parse(partial)
+    expect(html).not.toContain("katex")
+    expect(typeof html).toBe("string")
+  }
+})
+
 test("uses the configured code highlighter", async () => {
   expect(await parser.parse("```ts\nconst value = 1\n```\n")).toBe('<pre data-language="ts">const value = 1</pre>\n')
 })

--- a/packages/ui/src/context/marked-parser.tsx
+++ b/packages/ui/src/context/marked-parser.tsx
@@ -17,11 +17,78 @@ export function createMarkdownParser(highlight: (code: string, language: string)
   )
 }
 
-const inlineMathRegex = /^\\\(((?:\\.|[^\\\n])*?)\\\)/
-const blockMathRegex = /^\$\$\n([\s\S]+?)\n\$\$(?:\n|$)/
-
 const katexExtension: MarkedExtension = {
   extensions: [
+    {
+      name: "blockKatexDisplayDollar",
+      level: "block",
+      tokenizer(src) {
+        const result = tryBlockDisplay(src, "$$")
+        if (!result) return
+        return {
+          type: "blockKatexDisplayDollar",
+          raw: result.raw,
+          text: result.text,
+          displayMode: true,
+        }
+      },
+      renderer: renderKatexToken,
+    },
+    {
+      name: "blockKatexDisplayBracket",
+      level: "block",
+      tokenizer(src) {
+        const result = tryBlockDisplay(src, "\\[")
+        if (!result) return
+        return {
+          type: "blockKatexDisplayBracket",
+          raw: result.raw,
+          text: result.text,
+          displayMode: true,
+        }
+      },
+      renderer: renderKatexToken,
+    },
+    {
+      name: "inlineKatexDisplayDollar",
+      level: "inline",
+      start(src) {
+        const index = src.indexOf("$$")
+        if (index === -1) return
+        return index
+      },
+      tokenizer(src) {
+        const result = tryDisplayDollar(src)
+        if (!result) return
+        return {
+          type: "inlineKatexDisplayDollar",
+          raw: result.raw,
+          text: result.text,
+          displayMode: true,
+        }
+      },
+      renderer: renderKatexToken,
+    },
+    {
+      name: "inlineKatexDisplayBracket",
+      level: "inline",
+      start(src) {
+        const index = src.indexOf("\\[")
+        if (index === -1) return
+        return index
+      },
+      tokenizer(src) {
+        const result = tryBracket(src)
+        if (!result) return
+        return {
+          type: "inlineKatexDisplayBracket",
+          raw: result.raw,
+          text: result.text,
+          displayMode: true,
+        }
+      },
+      renderer: renderKatexToken,
+    },
     {
       name: "inlineKatex",
       level: "inline",
@@ -31,33 +98,125 @@ const katexExtension: MarkedExtension = {
         return index
       },
       tokenizer(src) {
-        const match = src.match(inlineMathRegex)
-        if (!match) return
+        const result = tryParen(src)
+        if (!result) return
         return {
           type: "inlineKatex",
-          raw: match[0],
-          text: match[1].trim(),
+          raw: result.raw,
+          text: result.text,
           displayMode: false,
         }
       },
       renderer: renderKatexToken,
     },
     {
-      name: "blockKatex",
-      level: "block",
+      name: "inlineKatexDollar",
+      level: "inline",
+      start(src) {
+        const index = src.indexOf("$")
+        if (index === -1) return
+        return index
+      },
       tokenizer(src) {
-        const match = src.match(blockMathRegex)
-        if (!match) return
+        const result = tryDollarSingle(src)
+        if (!result) return
         return {
-          type: "blockKatex",
-          raw: match[0],
-          text: match[1].trim(),
-          displayMode: true,
+          type: "inlineKatexDollar",
+          raw: result.raw,
+          text: result.text,
+          displayMode: false,
         }
       },
       renderer: renderKatexToken,
     },
   ],
+}
+
+function isEscaped(src: string, index: number): boolean {
+  let backslashes = 0
+  for (let i = index - 1; i >= 0 && src[i] === "\\"; i--) backslashes++
+  return backslashes % 2 === 1
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r"
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= "0" && char <= "9"
+}
+
+function tryParen(src: string): { raw: string; text: string } | undefined {
+  if (src[0] !== "\\" || src[1] !== "(") return
+  for (let i = 2; i < src.length - 1; i++) {
+    if (src[i] !== "\\" || src[i + 1] !== ")") continue
+    if (isEscaped(src, i)) continue
+    const text = src.slice(2, i).trim()
+    if (!text) return
+    return { raw: src.slice(0, i + 2), text }
+  }
+  return
+}
+
+function tryBracket(src: string): { raw: string; text: string } | undefined {
+  if (src[0] !== "\\" || src[1] !== "[") return
+  for (let i = 2; i < src.length - 1; i++) {
+    if (src[i] !== "\\" || src[i + 1] !== "]") continue
+    if (isEscaped(src, i)) continue
+    const text = src.slice(2, i).trim()
+    if (!text) return
+    return { raw: src.slice(0, i + 2), text }
+  }
+  return
+}
+
+function tryDisplayDollar(src: string): { raw: string; text: string } | undefined {
+  if (src[0] !== "$" || src[1] !== "$") return
+  for (let i = 2; i < src.length - 1; i++) {
+    if (src[i] !== "$" || src[i + 1] !== "$") continue
+    if (isEscaped(src, i)) continue
+    const text = src.slice(2, i).trim()
+    if (!text) return
+    return { raw: src.slice(0, i + 2), text }
+  }
+  return
+}
+
+function tryDollarSingle(src: string): { raw: string; text: string } | undefined {
+  if (src[0] !== "$") return
+  // Let $$ display handling take precedence.
+  if (src[1] === "$") return
+  // Opening $ must not be followed by whitespace (avoids currency like "$ 5").
+  if (isWhitespace(src[1])) return
+  if (src[1] === undefined) return
+  for (let i = 1; i < src.length; i++) {
+    if (src[i] !== "$") continue
+    if (isEscaped(src, i)) continue
+    // Skip $ that is part of $$ (display math takes precedence).
+    if (src[i - 1] === "$" || src[i + 1] === "$") continue
+    // Closing $ must not be preceded by whitespace (avoids "$5 and $" currency ranges).
+    if (isWhitespace(src[i - 1])) continue
+    const text = src.slice(1, i)
+    if (!text || !text.trim()) continue
+    // Content must not contain another $ (keeps "$5, blah $x$" from merging).
+    if (text.includes("$")) return
+    // Closing $ followed by a digit is likely currency ("$5,$6"), not math.
+    if (isDigit(src[i + 1])) continue
+    return { raw: src.slice(0, i + 1), text: text.trim() }
+  }
+  return
+}
+
+function tryBlockDisplay(src: string, opening: "$$" | "\\["): { raw: string; text: string } | undefined {
+  const match = src.match(/^ {0,3}(\$\$|\\\[)/)
+  if (!match) return
+  const leading = match[0].length - match[1].length
+  const rest = src.slice(leading)
+  if (opening === "$$" && !rest.startsWith("$$")) return
+  if (opening === "\\[" && !rest.startsWith("\\[")) return
+  const result = opening === "$$" ? tryDisplayDollar(rest) : tryBracket(rest)
+  if (!result) return
+  return { raw: src.slice(0, leading + result.raw.length), text: result.text }
 }
 
 function renderKatexToken(token: Tokens.Generic) {


### PR DESCRIPTION
### Issue for this PR

Closes #39170

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Desktop math shows raw LaTeX for valid delimiters. In `packages/ui/src/context/marked-parser.tsx` the inline regex was single-line only (multiline `\(...\)` failed), the block regex only matched `$$` on its own lines, and `\[...\]` had no tokenizer at all, so marked ate `\[`/`\]` as escapes. Single-line `$$x$$` and `$x$` were unsupported too.

I replaced the two regexes with marked block+inline tokenizer extensions: block and inline `$$...$$` / `\[...\]` (display), inline `\(...\)` / `$...$`, with multiline content and an unescaped-closing scan. `$` keeps guards so currency (`$5 and $10`), escaped `\$`, and code blocks/spans stay literal; incomplete delimiters match nothing and KaTeX runs with `throwOnError: false`, so streaming partial math can't crash rendering.

### How did you verify your code works?

- `bun test` in `packages/ui` (32 pass) and `packages/session-ui` (83 pass), including new cases in `marked-parser.test.ts` for delimiters, multiline array/aligned/matrix/cases (K-map example), code/escape/currency safety, and incomplete math
- typecheck clean in both packages
- desktop `electron-vite build` succeeds; confirmed the fix is in the built `markdown.worker` bundle and installed the packaged app to verify the K-map renders

### Screenshots / recordings

K-map `\[ \begin{array}...\end{array} \]` now renders as a display table instead of literal source; inline `\(...\)`, `$...$`, `$$...$$` render as KaTeX. (Screenshot from local build verified by reporter.)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
