### PR TITLE
fix(mcp): silence Ajv unknown format warnings from MCP tool schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -626,6 +626,8 @@
         "@zip.js/zip.js": "2.7.62",
         "ai": "catalog:",
         "ai-gateway-provider": "3.2.0",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
         "bonjour-service": "1.3.0",
         "chokidar": "4.0.3",
         "cross-spawn": "catalog:",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -112,6 +112,8 @@
     "@zip.js/zip.js": "2.7.62",
     "ai": "catalog:",
     "ai-gateway-provider": "3.2.0",
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
     "bonjour-service": "1.3.0",
     "chokidar": "4.0.3",
     "cross-spawn": "catalog:",

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -34,6 +34,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { McpCatalog } from "./catalog"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
 import { McpBrowser } from "./browser"
+import { McpSchema } from "./schema"
 
 const DEFAULT_TIMEOUT = 30_000
 const CLIENT_OPTIONS = {
@@ -47,6 +48,7 @@ const CLIENT_OPTIONS = {
     // https://github.com/anomalyco/opencode/issues/28567
     // tasks: {},
   },
+  jsonSchemaValidator: McpSchema.createJsonSchemaValidator(),
 } satisfies ClientOptions
 
 export const Resource = Schema.Struct({

--- a/packages/opencode/src/mcp/schema.ts
+++ b/packages/opencode/src/mcp/schema.ts
@@ -1,0 +1,22 @@
+import Ajv from "ajv"
+import addFormats from "ajv-formats"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+
+// Ajv ignores formats it does not know (uint32/uint64 from Rust schemars, for
+// example) but logs a warning for each one while compiling a schema. MCP tool
+// output schemas are third-party input, so keep the SDK's validation behavior
+// and only silence the logger.
+// https://github.com/anomalyco/opencode/issues/31002
+export function createJsonSchemaValidator() {
+  const ajv = new Ajv({
+    strict: false,
+    validateFormats: true,
+    validateSchema: false,
+    allErrors: true,
+    logger: false,
+  })
+  addFormats(ajv)
+  return new AjvJsonSchemaValidator(ajv)
+}
+
+export * as McpSchema from "./schema"

--- a/packages/opencode/test/mcp/schema.test.ts
+++ b/packages/opencode/test/mcp/schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { McpSchema } from "@/mcp/schema"
+
+describe("McpSchema.createJsonSchemaValidator", () => {
+  test("ignores non-standard formats without logging", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      const validate = McpSchema.createJsonSchemaValidator().getValidator({
+        type: "object",
+        properties: { pid: { type: "integer", format: "uint64" } },
+        required: ["pid"],
+      })
+      expect(warn).not.toHaveBeenCalled()
+      expect(validate({ pid: 7 }).valid).toBe(true)
+      expect(validate({ pid: "7" }).valid).toBe(false)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test("still validates known formats", () => {
+    const validate = McpSchema.createJsonSchemaValidator().getValidator({
+      type: "object",
+      properties: { id: { type: "string", format: "uuid" } },
+      required: ["id"],
+    })
+    expect(validate({ id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8" }).valid).toBe(true)
+    expect(validate({ id: "not-a-uuid" }).valid).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31002

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP servers built with Rust/schemars emit non-standard `format` values (`uint32`, `uint64`, ...) in tool output schemas. The MCP SDK eagerly compiles every `outputSchema` with Ajv when tools are listed, and Ajv's default logger warns per unknown format through `console.warn`. That bypasses `--log-level` and fills the TUI on startup (81 warning lines with cua-driver 0.26.0).

This passes a `jsonSchemaValidator` through the SDK's documented `ClientOptions` seam with the same Ajv configuration, but logger disabled. Unknown formats are still ignored silently; known formats (`uuid`, `date-time`, ...) and type validation are unchanged.

### How did you verify your code works?

- Against cua-driver 0.26.0's 34 output schemas, `opencode mcp list` goes from 81 warning lines to 0.
- `test/mcp/schema.test.ts` covers both sides: compiling a `uint64` schema logs nothing, and an invalid `uuid` is still rejected.
- `bun test --timeout 30000 test/mcp/` (63 tests), `bun typecheck`, prettier, and oxlint pass locally.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
