### PR TITLE
fix(tui): strip NUL characters before clipboard writes

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -51,7 +51,8 @@ export function createClipboardAdapter(clipboard: CoreClipboardService): OwnedCl
       throw new Error(`Unexpected clipboard MIME type: ${result.representation.mimeType}`)
     },
     async write(text) {
-      const result = await clipboard.writeText(text, {
+      // OpenTUI rejects NUL before any destination; host clipboard text cannot contain it.
+      const result = await clipboard.writeText(text.replaceAll("\0", ""), {
         destination: "all-available",
         selection: "clipboard",
       })

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -102,6 +102,19 @@ test("uses all available routes but skips the process host remotely", async () =
   expect(writes).toEqual({ host: 0, terminal: 1 })
 })
 
+test("removes NUL characters before writing", async () => {
+  const writes: string[] = []
+  const clipboard = createClipboardAdapter(
+    coreClipboard({
+      onWrite: (text) => writes.push(text),
+    }),
+  )
+
+  expect(await clipboard.write("before\0after")).toBeUndefined()
+  expect(await clipboard.write("clean")).toBeUndefined()
+  expect(writes).toEqual(["beforeafter", "clean"])
+})
+
 test("rejects only when no clipboard route accepted the write", async () => {
   const writes: [string, ClipboardWriteOptions][] = []
   const failure = new Error("native clipboard failed")


### PR DESCRIPTION
Fixes #44198

OpenTUI rejects clipboard text containing NUL before any host or terminal write, so `/copy` fails for sessions whose shell output includes NUL bytes. This drops NULs at the shared TUI `write()` boundary so the rest of the transcript can copy. `/export` is unchanged.

This is the v2 equivalent of the OpenTUI clipboard-adapter approach in #44197. It does not use the old spawn/OSC 52 clipboard from #44230 (`dev`).