### PR TITLE
fix(session): answer queued prompts after a stopped turn

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1316,7 +1316,23 @@ const layer = Layer.effect(
               }
             }
 
-            if (result === "stop") return "break" as const
+            if (result === "stop") {
+              // A stop (denied tool or errored turn) ends only the turn of the
+              // user message this iteration answered. Prompts submitted while
+              // the run is active persist their user message immediately and
+              // every waiter of the run resolves with its final message, so
+              // breaking out here hands those queued prompts the stopped
+              // turn's message — often a tool call with no text at all. Keep
+              // looping while a newer user message is already waiting; the
+              // exit check at the top of the loop terminates the run once the
+              // newest user message has been answered.
+              const msgsNow = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
+                Effect.provideService(Database.Service, database),
+              )
+              const newestUser = MessageV2.latest(msgsNow).user
+              if (newestUser && newestUser.id !== lastUser.id) return "continue" as const
+              return "break" as const
+            }
             if (result === "compact") {
               yield* compaction.create({
                 sessionID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1218,6 +1218,25 @@ const layer = Layer.effect(
             })
             .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
 
+          // Turns can end below without the loop's natural exit check firing:
+          // stop (denied tool or errored turn), structured output, or a
+          // content-filtered / structured-output-less finish. Prompts queued
+          // while the run is active persist their user message immediately and
+          // every waiter of the run resolves with its final message, so an
+          // unconditional break hands those queued prompts the ended turn's
+          // message — often a tool call or filtered turn with no usable text.
+          // Keep looping while a newer user message is already waiting; the
+          // exit check at the top of the loop terminates the run once the
+          // newest user message has been answered. The ended turn itself is
+          // never retried — the model gets no extra turn for a denial.
+          const newerUserWaiting = Effect.gen(function* () {
+            const msgsNow = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
+              Effect.provideService(Database.Service, database),
+            )
+            const newestUser = MessageV2.latest(msgsNow).user
+            return newestUser !== undefined && newestUser.id !== lastUser.id
+          })
+
           const outcome: "break" | "continue" = yield* Effect.gen(function* () {
             const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
             const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
@@ -1289,6 +1308,12 @@ const layer = Layer.effect(
               handle.message.structured = structured
               handle.message.finish = handle.message.finish ?? "stop"
               yield* sessions.updateMessage(handle.message)
+              if (yield* newerUserWaiting) {
+                // Clear the captured output so it cannot leak into the next
+                // turn's check above.
+                structured = undefined
+                return "continue" as const
+              }
               return "break" as const
             }
 
@@ -1304,6 +1329,7 @@ const layer = Layer.effect(
                 }).toObject()
                 yield* sessions.updateMessage(handle.message)
                 yield* events.publish(Session.Event.Error, { sessionID, error: handle.message.error })
+                if (yield* newerUserWaiting) return "continue" as const
                 return "break" as const
               }
               if (format.type === "json_schema") {
@@ -1312,25 +1338,13 @@ const layer = Layer.effect(
                   retries: 0,
                 }).toObject()
                 yield* sessions.updateMessage(handle.message)
+                if (yield* newerUserWaiting) return "continue" as const
                 return "break" as const
               }
             }
 
             if (result === "stop") {
-              // A stop (denied tool or errored turn) ends only the turn of the
-              // user message this iteration answered. Prompts submitted while
-              // the run is active persist their user message immediately and
-              // every waiter of the run resolves with its final message, so
-              // breaking out here hands those queued prompts the stopped
-              // turn's message — often a tool call with no text at all. Keep
-              // looping while a newer user message is already waiting; the
-              // exit check at the top of the loop terminates the run once the
-              // newest user message has been answered.
-              const msgsNow = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
-                Effect.provideService(Database.Service, database),
-              )
-              const newestUser = MessageV2.latest(msgsNow).user
-              if (newestUser && newestUser.id !== lastUser.id) return "continue" as const
+              if (yield* newerUserWaiting) return "continue" as const
               return "break" as const
             }
             if (result === "compact") {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1496,6 +1496,78 @@ it.instance("prompt submitted during an active run is included in the next LLM i
   }),
 )
 
+it.instance("queued prompt gets a text reply when the active turn stops on a rejected question", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const question = yield* Question.Service
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+
+    yield* llm.tool("question", {
+      questions: [
+        {
+          question: "Pick one",
+          header: "Pick",
+          options: [
+            { label: "A", description: "first" },
+            { label: "B", description: "second" },
+          ],
+        },
+      ],
+    })
+    yield* llm.text("second reply")
+
+    const a = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "first" }],
+      })
+      .pipe(Effect.forkChild)
+
+    const requestID = yield* pollWithTimeout(
+      question.list().pipe(Effect.map((items) => items[0]?.id)),
+      "timed out waiting for pending question",
+    )
+
+    const id = MessageID.ascending()
+    const b = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        messageID: id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "second" }],
+      })
+      .pipe(Effect.forkChild)
+
+    yield* pollWithTimeout(
+      sessions
+        .messages({ sessionID: chat.id })
+        .pipe(Effect.map((msgs) => (msgs.some((msg) => msg.info.role === "user" && msg.info.id === id) ? true : undefined))),
+      "timed out waiting for second prompt to save",
+    )
+
+    yield* question.reject(requestID)
+
+    const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+    expect(Exit.isSuccess(ea)).toBe(true)
+    expect(Exit.isSuccess(eb)).toBe(true)
+    if (!Exit.isSuccess(eb)) throw new Error("queued prompt failed")
+    // The queued prompt must resolve with its own answered message, never the
+    // stopped turn's tool-only message (no text parts).
+    if (eb.value.info.role !== "assistant") throw new Error("expected assistant message")
+    expect(eb.value.info.parentID).toBe(id)
+    expect(eb.value.parts.some((part) => part.type === "text" && part.text === "second reply")).toBe(true)
+    expect(yield* llm.calls).toBe(2)
+  }),
+)
+
 it.instance("assertNotBusy fails with BusyError when loop running", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1568,6 +1568,69 @@ it.instance("queued prompt gets a text reply when the active turn stops on a rej
   }),
 )
 
+it.instance("queued prompt gets a text reply when the active turn ends on a content filter", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+
+    // Hold the first stream open before its content-filter finish so the
+    // second prompt can be persisted while the turn is still active.
+    let release: () => void = () => {}
+    const held = new Promise<void>((resolve) => (release = resolve))
+    yield* llm.push(reply().wait(held).text("partial response").contentFilter())
+    yield* llm.text("second reply")
+
+    const a = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "first" }],
+      })
+      .pipe(Effect.forkChild)
+
+    yield* llm.wait(1)
+
+    const id = MessageID.ascending()
+    const b = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        messageID: id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "second" }],
+      })
+      .pipe(Effect.forkChild)
+
+    yield* pollWithTimeout(
+      sessions
+        .messages({ sessionID: chat.id })
+        .pipe(Effect.map((msgs) => (msgs.some((msg) => msg.info.role === "user" && msg.info.id === id) ? true : undefined))),
+      "timed out waiting for second prompt to save",
+    )
+
+    release()
+
+    const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+    expect(Exit.isSuccess(ea)).toBe(true)
+    expect(Exit.isSuccess(eb)).toBe(true)
+    if (!Exit.isSuccess(eb)) throw new Error("queued prompt failed")
+    if (eb.value.info.role !== "assistant") throw new Error("expected assistant message")
+    // The queued prompt must resolve with its own answered message, never the
+    // content-filtered turn's message.
+    expect(eb.value.info.parentID).toBe(id)
+    expect(eb.value.parts.some((part) => part.type === "text" && part.text === "second reply")).toBe(true)
+    expect(yield* llm.calls).toBe(2)
+    // The filtered turn still recorded its error on disk.
+    const stored = yield* sessions.messages({ sessionID: chat.id })
+    expect(
+      stored.some((msg) => msg.info.role === "assistant" && msg.info.error?.name === "ContentFilterError"),
+    ).toBe(true)
+  }),
+)
+
 it.instance("assertNotBusy fails with BusyError when loop running", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

  Closes #48347

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  A prompt submitted while another turn is active waits on that run's `done` deferred, so the run's return value (`lastAssistant()`) is also that prompt's response. The loop guarantees
  "answer the newest user message before exiting" on its natural exit path (`lastAssistant.parentID === lastUser.id`), but the `"stop"` outcome (denied tool / errored turn) breaks
  immediately. If prompt B was queued while A's turn hung on a `question` tool and the question is then rejected, B's HTTP response is A's tool-only message — no text parts.

  Fix: on `"stop"`, keep looping when a newer user message is already persisted so it gets answered; otherwise break as before. A stop still ends the turn of the message that triggered it
  — the model gets no extra turn for a denial.

  Related: #44810 covers the cancel path (queued prompts dropped entirely) — different exit path, same invariant.

  ### How did you verify your code works?

  Added a regression test (`queued prompt gets a text reply when the active turn stops on a rejected question`) that drives the real `question` tool: prompt A hangs on a question, prompt B
  queues, the question is rejected, and B must resolve with its own reply (parentID + text part + second LLM call). It fails on `dev` and passes with this change. Full `test/session/`
  suite (422 tests) and `typecheck` pass.

  ### Screenshots / recordings

  N/A — server-side only.

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR