### PR TITLE
docs: correct v2 formatter documentation

### DIFF
--- a/services/www/src/docs/content/config.mdx
+++ b/services/www/src/docs/content/config.mdx
@@ -231,8 +231,7 @@ Ignore files and directories that should not trigger filesystem updates.
 
 ### Formatter
 
-Define formatter settings for compatibility and future use. V2 accepts this
-field, but it does not run formatters yet.
+Configure automatic formatting after file writes, edits, and patches.
 
 ```jsonc
 {
@@ -245,7 +244,7 @@ field, but it does not run formatters yet.
 }
 ```
 
-See the [formatters guide](/formatters) for accepted fields and current limitations.
+See the [formatters guide](/formatters) for configuration and command behavior.
 
 ### LSP
 

--- a/services/www/src/docs/content/formatters.mdx
+++ b/services/www/src/docs/content/formatters.mdx
@@ -2,13 +2,8 @@
 title: "Formatters"
 ---
 
-OpenCode V2 accepts formatter configuration, but it does not yet include a
-formatter runtime. File writes and edits are not automatically formatted.
-
-<Callout type="warning">
-  V2 currently has no built-in formatters. The built-in formatter list and automatic post-edit formatting documented for
-  V1 do not apply to V2.
-</Callout>
+OpenCode V2 automatically formats files after writes, edits, and patches when
+formatting is enabled in configuration.
 
 ## Configuration
 
@@ -30,20 +25,17 @@ The `formatter` field accepts a boolean or an object keyed by formatter name:
 }
 ```
 
-This example is valid V2 configuration, but V2 does not currently execute the
-command.
-
 Each named formatter entry supports these optional fields:
 
-| Field         | Type                     | Current V2 behavior                                                                   |
-| ------------- | ------------------------ | ------------------------------------------------------------------------------------- |
-| `disabled`    | `boolean`                | Accepted, but there is no runtime formatter to enable or disable.                     |
-| `command`     | `string[]`               | Accepted as an argument array, but not executed.                                      |
-| `environment` | `Record<string, string>` | Accepts string environment variable names and values, but they are not applied.       |
-| `extensions`  | `string[]`               | Accepted without extension-specific validation, but files are not matched against it. |
+| Field         | Type                     | Behavior                                                        |
+| ------------- | ------------------------ | --------------------------------------------------------------- |
+| `disabled`    | `boolean`                | Disables this formatter when `true`.                             |
+| `command`     | `string[]`               | Command and arguments to run instead of the built-in command.    |
+| `environment` | `Record<string, string>` | Environment variables passed to the formatter process.          |
+| `extensions`  | `string[]`               | Filename extensions to format, such as `.ts` and `.tsx`.         |
 
-All entry fields are optional. The schema therefore also accepts an empty entry
-such as `"prettier": {}`.
+All entry fields are optional. An empty entry, `{}`, uses the named built-in formatter's
+settings. For a custom formatter, provide `command` and `extensions`.
 
 ## Enable and disable
 
@@ -57,7 +49,7 @@ The schema accepts all of the following forms:
 ```
 
 ```jsonc
-// Reserved for enabling all built-ins once a V2 runtime provides them.
+// Enable built-ins whose requirements are met.
 {
   "formatter": true,
 }
@@ -76,17 +68,16 @@ The schema accepts all of the following forms:
 }
 ```
 
-At present, omitted, `false`, `true`, and object forms have the same runtime
-result: V2 runs no formatter. `disabled` is retained as configuration data but
-does not control an executable formatter.
+Formatting is disabled when `formatter` is omitted from all applicable configs
+or set to `false`. `true` enables built-ins; an object enables built-ins with
+the named overrides.
 
 ## Commands and placeholders
 
-`command` is an array of strings, not a shell command string. `$FILE` is the V1
-file-path placeholder and is often retained in migrated configuration. V2 does
-not currently substitute `$FILE` or define another formatter placeholder.
+`command` is an array of strings, not a shell command string. OpenCode replaces
+the first `$FILE` occurrence in each argument with the file path. Commands run
+from the session's working directory.
 
-Likewise, V2 does not currently use `extensions` to select commands, merge
-`environment` into a child process, discover formatter executables or project
-configuration, or run multiple matching formatters. These behaviors will only
-be available after a V2 formatter runtime is implemented.
+OpenCode uses `extensions` to select formatters and adds `environment` values
+to the inherited process environment. It skips unavailable built-ins and tries
+matching formatters in order until one exits successfully.


### PR DESCRIPTION
### Issue for this PR

Documentation-only correction.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The V2 formatter and configuration pages still say formatting is unimplemented, but #39564 added automatic formatting after file writes and edits.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Compared the documentation with the implementation, built-in definitions,
configuration plugin, and write/edit/patch integrations.

Passed in services/www: bun typecheck, bun run check:generated,
and bun run build. The build includes link validation.

### Screenshots / recordings

<img width="1396" height="2184" alt="formatters" src="https://github.com/user-attachments/assets/6df67f97-b9e8-4537-b860-7ecb5b06618c" />

<img width="1285" height="650" alt="screenshot_2026-09-10_16-01-42" src="https://github.com/user-attachments/assets/24cb0ccf-2d99-4556-91f8-731abec75938" />


_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
