### PR TITLE
feat(desktop): experimental app sidebar with new chat, projects, recents

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -258,7 +258,7 @@ export function AppSidebar() {
         <aside
           data-component="app-sidebar"
           data-collapsed="true"
-          class="hidden shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base/70 py-2 backdrop-blur-xl lg:flex"
+          class="hidden shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base py-2 lg:flex"
           classList={{ "w-14": !trafficLights(), "w-[84px]": trafficLights() }}
           style={trafficLights() ? { "padding-top": "36px" } : undefined}
         >
@@ -308,7 +308,7 @@ export function AppSidebar() {
     >
       <aside
         data-component="app-sidebar"
-        class="hidden w-64 shrink-0 flex-col bg-v2-background-bg-base/70 backdrop-blur-xl lg:flex"
+        class="hidden w-64 shrink-0 flex-col bg-v2-background-bg-base lg:flex"
         aria-label={language.t("sidebar.nav.projectsAndSessions")}
       >
         <div class="flex h-9 shrink-0 items-center justify-end px-2">
@@ -466,7 +466,7 @@ export function AppSidebar() {
             </Show>
           </section>
         </div>
-        <div class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-base/60 p-2">
+        <div class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-base p-2">
           <SidebarNavButton onClick={openMe}>
             <Mark class="h-4 w-auto shrink-0" />
             <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">Me</span>

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -482,7 +482,7 @@ function MeDialog(props: { onHome: () => void; onSettings: () => void }) {
   const language = useLanguage()
   const close = () => dialog.close()
   return (
-    <div class="flex w-64 flex-col gap-1 rounded-[12px] bg-v2-background-bg-base p-2 shadow-[var(--v2-elevation-floating)]">
+    <div class="pointer-events-auto flex w-64 flex-col gap-1 rounded-[12px] bg-v2-background-bg-base p-2 shadow-[var(--v2-elevation-floating)]">
       <div class="px-2 py-1 text-v2-text-text-muted [font-weight:530]">Me</div>
       <SidebarNavButton
         onClick={() => {

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1,8 +1,9 @@
 import type { Session } from "@opencode-ai/sdk/v2/client"
 import { useLocation, useNavigate } from "@solidjs/router"
 import { useQuery } from "@tanstack/solid-query"
-import { createMemo, For, Show, startTransition, type Accessor, type ParentProps } from "solid-js"
+import { createEffect, createMemo, For, Show, startTransition, type Accessor, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
+import { Logo, Mark } from "@opencode-ai/ui/logo"
 import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
 import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
@@ -191,6 +192,24 @@ export function AppSidebar() {
     openProjectNewSession(target.conn, target.directory)
   }
 
+  const goHome = () => {
+    if (location.pathname !== "/") navigate("/")
+  }
+
+  let started = false
+  createEffect(() => {
+    if (started || !tabs.ready() || location.pathname !== "/") return
+    if (tabs.store.length > 0) {
+      started = true
+      const last = tabs.store[tabs.store.length - 1]
+      if (last) tabs.select(last)
+      return
+    }
+    if (!newChatTarget()) return
+    started = true
+    openNewChat()
+  })
+
   const selectProject = (conn: ServerConnection.Any, directory: string) => {
     const key = ServerConnection.key(conn)
     if (global.servers.health[key]?.healthy === false) return
@@ -213,6 +232,17 @@ export function AppSidebar() {
           data-collapsed="true"
           class="hidden w-14 shrink-0 flex-col items-center gap-1 border-r border-v2-border-border-base py-2 lg:flex"
         >
+          <TooltipV2 placement="right" value={language.t("home.title")}>
+            <button
+              type="button"
+              data-action="sidebar-home"
+              class="flex size-9 shrink-0 items-center justify-center rounded-[6px] transition-[background-color] duration-[120ms] ease-in-out hover:bg-v2-background-bg-layer-01"
+              aria-label={language.t("home.title")}
+              onClick={goHome}
+            >
+              <Mark class="h-5 w-auto" />
+            </button>
+          </TooltipV2>
           <TooltipV2 placement="right" value={language.t("command.session.new")}>
             <IconButtonV2
               variant="ghost-muted"
@@ -251,18 +281,16 @@ export function AppSidebar() {
         class="hidden w-64 shrink-0 flex-col border-r border-v2-border-border-base lg:flex"
         aria-label={language.t("sidebar.nav.projectsAndSessions")}
       >
-        <div class="flex shrink-0 items-center gap-1 p-2">
-          <ButtonV2
-            data-action="sidebar-new-chat"
-            variant="neutral"
-            size="normal"
-            icon="edit"
-            class="h-8 flex-1 justify-start px-2.5 [font-weight:530]"
-            disabled={!newChatTarget()}
-            onClick={openNewChat}
+        <div class="flex shrink-0 items-center justify-between p-2 pb-1">
+          <button
+            type="button"
+            data-action="sidebar-home"
+            onClick={goHome}
+            class="flex min-w-0 items-center rounded-[6px] px-1.5 py-1 focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none"
+            aria-label={language.t("home.title")}
           >
-            {language.t("command.session.new")}
-          </ButtonV2>
+            <Logo class="h-5 w-auto" />
+          </button>
           <TooltipV2 placement="bottom" value={language.t("sidebar.menu.toggle")}>
             <IconButtonV2
               variant="ghost-muted"
@@ -273,6 +301,19 @@ export function AppSidebar() {
             />
           </TooltipV2>
         </div>
+        <div class="shrink-0 px-2 pb-1">
+          <ButtonV2
+            data-action="sidebar-new-chat"
+            variant="neutral"
+            size="normal"
+            icon="edit"
+            class="h-8 w-full justify-start px-2.5 [font-weight:530]"
+            disabled={!newChatTarget()}
+            onClick={openNewChat}
+          >
+            {language.t("command.session.new")}
+          </ButtonV2>
+        </div>
         <div class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-2 pb-2">
           <section class="flex min-w-0 flex-col gap-1" aria-label={language.t("home.projects")}>
             <div class="flex h-7 min-w-0 shrink-0 items-center px-1.5">
@@ -282,8 +323,7 @@ export function AppSidebar() {
               when={projects().length > 0}
               fallback={
                 <div class="px-1.5 py-1 text-v2-text-text-faint [font-weight:440]">
-                  <div>{language.t("sidebar.empty.title")}</div>
-                  <div class="mt-0.5 text-v2-text-text-faint">{language.t("sidebar.empty.description")}</div>
+                  {language.t("sidebar.projects.empty")}
                 </div>
               }
             >
@@ -388,6 +428,12 @@ export function AppSidebar() {
           </section>
         </div>
         <div class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-base p-2">
+          <SidebarNavButton onClick={goHome}>
+            <Mark class="h-4 w-auto shrink-0" />
+            <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+              {language.t("home.title")}
+            </span>
+          </SidebarNavButton>
           <SidebarNavButton onClick={openSettings}>
             <IconV2 name="settings-gear" size="small" />
             <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -25,11 +25,12 @@ import { ServerConnection, useServer } from "@/context/server"
 import { sessionHasOpenTab, useTabs } from "@/context/tabs"
 import { shouldOpenSessionInBackground } from "@/pages/home-session-open"
 import {
-  buildHomeSessionRecords,
   HomeSessionStatusController,
+  type HomeSessionRecord,
   type OpenSessionOptions,
 } from "@/pages/home/home-sessions-controller"
 import {
+  compareSessionTime,
   displayName,
   getProjectAvatarSource,
   projectForSession,
@@ -119,11 +120,6 @@ export function AppSidebar() {
     refetchOnReconnect: true,
   }))
 
-  const projectDirs = createMemo(() => {
-    const selected = selectedProject()
-    if (selected) return projectDirectories(selected)
-    return projects().flatMap(projectDirectories)
-  })
   const projectByID = createMemo(
     () => new Map(projects().flatMap((project) => (project.id ? [[project.id, project] as const] : []))),
   )
@@ -136,14 +132,25 @@ export function AppSidebar() {
       Date.now(),
     )
   })
-  const records = createMemo(() =>
-    buildHomeSessionRecords({
-      sessions: indexedSessions,
-      projectDirectories: projectDirs,
-      projects,
-      projectByID,
-    }).slice(0, SIDEBAR_SESSION_LIMIT),
-  )
+  // Show every recent session across projects (like Codex recents), not just
+  // sessions inside a known project directory. Sessions without a resolved
+  // project fall back to their directory for avatar/title purposes.
+  const records = createMemo((): HomeSessionRecord[] => {
+    const seen = new Map<string, Session>()
+    for (const session of indexedSessions()) seen.set(session.id, session)
+    return [...seen.values()]
+      .sort(compareSessionTime)
+      .slice(0, SIDEBAR_SESSION_LIMIT)
+      .map((session) => {
+        const project = projectForSession(session, projects(), projectByID())
+        const fallback = { worktree: session.directory }
+        return {
+          session,
+          project: project ?? { ...fallback, expanded: false },
+          projectName: displayName(project ?? fallback),
+        }
+      })
+  })
 
   const activeSessionId = createMemo(() => sidebarSessionIdFromPath(location.pathname))
   const serverKey = createMemo(() => {
@@ -252,7 +259,7 @@ export function AppSidebar() {
           data-component="app-sidebar"
           data-collapsed="true"
           class="hidden shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base/70 py-2 backdrop-blur-xl lg:flex"
-          classList={{ "w-14": !trafficLights(), "w-24": trafficLights() }}
+          classList={{ "w-14": !trafficLights(), "w-[84px]": trafficLights() }}
           style={trafficLights() ? { "padding-top": "36px" } : undefined}
         >
           <TooltipV2 placement="right" value={language.t("home.title")}>
@@ -490,7 +497,8 @@ function MeDialog(props: { onHome: () => void; onSettings: () => void }) {
       </SidebarNavButton>
       <SidebarNavButton
         onClick={() => {
-          close()
+          // dialog.show() replaces the whole stack, so no manual close needed
+          // (avoids racing the close animation).
           props.onSettings()
         }}
       >

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1,0 +1,516 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { useLocation, useNavigate } from "@solidjs/router"
+import { useQuery } from "@tanstack/solid-query"
+import { createMemo, For, Show, startTransition, type Accessor, type ParentProps } from "solid-js"
+import { createStore } from "solid-js/store"
+import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
+import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { ProjectAvatar } from "@opencode-ai/ui/v2/project-avatar-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import { useSettingsCommand } from "@/components/settings-dialog"
+import { useGlobal } from "@/context/global"
+import {
+  loadHomeSessionIndex,
+  retainHomeSessions,
+  type HomeSessionEvents,
+} from "@/context/global-sync/home-session-index"
+import { getProjectAvatarVariant, useLayout, type HomeProjectSelection, type LocalProject } from "@/context/layout"
+import { useLanguage } from "@/context/language"
+import { useNotification } from "@/context/notification"
+import { ServerConnection, useServer } from "@/context/server"
+import { sessionHasOpenTab, useTabs } from "@/context/tabs"
+import { shouldOpenSessionInBackground } from "@/pages/home-session-open"
+import {
+  buildHomeSessionRecords,
+  HomeSessionStatusController,
+  type OpenSessionOptions,
+} from "@/pages/home/home-sessions-controller"
+import {
+  displayName,
+  getProjectAvatarSource,
+  projectForSession,
+  toggleHomeProjectSelection,
+} from "@/pages/layout/helpers"
+import { SessionTabAvatarView } from "@/pages/layout/session-tab-avatar"
+import { sessionTitle } from "@/utils/session-title"
+import { sidebarSessionIdFromPath } from "@/utils/sidebar-route"
+import { pathKey } from "@/utils/path-key"
+import { Persist, persisted } from "@/utils/persist"
+
+const SIDEBAR_SESSION_LIMIT = 40
+
+function isBackgroundOpen(event: MouseEvent) {
+  return shouldOpenSessionInBackground({
+    button: event.button,
+    mac: typeof navigator === "object" && /(Mac|iPod|iPhone|iPad)/.test(navigator.platform),
+    meta: event.metaKey,
+    ctrl: event.ctrlKey,
+    shift: event.shiftKey,
+    alt: event.altKey,
+  })
+}
+
+function projectDirectories(project: LocalProject) {
+  return [project.worktree, ...(project.sandboxes ?? [])]
+}
+
+export function AppSidebar() {
+  const tabs = useTabs()
+  const layout = useLayout()
+  const global = useGlobal()
+  const server = useServer()
+  const language = useLanguage()
+  const notification = useNotification()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const openSettings = useSettingsCommand()
+  const [state, setState] = persisted(Persist.window("app.sidebar"), createStore({ collapsed: false }))
+
+  const selection = layout.home.selection
+  const focusedConn = createMemo(
+    () => global.servers.list().find((conn) => ServerConnection.key(conn) === selection().server) ?? server.current,
+  )
+  const focusedCtx = createMemo(() => {
+    const conn = focusedConn()
+    if (!conn) return undefined
+    return global.ensureServerCtx(conn)
+  })
+  const projects = createMemo(() => focusedCtx()?.projects.list() ?? layout.projects.list())
+  const selectedProject = createMemo(() => projects().find((project) => project.worktree === selection().directory))
+  const servers = global.servers.list
+  const multiServer = createMemo(() => servers().length > 1)
+
+  const homeSessions = () => focusedCtx()?.sync.homeSessions
+  const sessionEventLoad = useQuery(() => ({
+    queryKey: homeSessions()?.eventsKey ?? ["app-sidebar", "session-events"],
+    queryFn: async (): Promise<HomeSessionEvents> => ({ sequence: 0, entries: [] }),
+    initialData: { sequence: 0, entries: [] } satisfies HomeSessionEvents,
+    enabled: false,
+  }))
+  const sessionLoad = useQuery(() => ({
+    queryKey: homeSessions()?.indexKey ?? ["app-sidebar", "session-index"],
+    enabled: !!focusedCtx(),
+    queryFn: async ({ signal }) => {
+      const ctx = focusedCtx()
+      const cache = homeSessions()
+      if (!ctx || !cache) return { sessions: [], eventSequence: 0 }
+      const eventSequence = cache.eventSequence()
+      const index = await loadHomeSessionIndex(
+        (input, options) => ctx.sdk.client.v2.session.list(input, options),
+        eventSequence,
+        signal,
+      )
+      cache.complete(eventSequence)
+      return index
+    },
+    retry: false,
+    staleTime: 30_000,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+  }))
+
+  const projectDirs = createMemo(() => {
+    const selected = selectedProject()
+    if (selected) return projectDirectories(selected)
+    return projects().flatMap(projectDirectories)
+  })
+  const projectByID = createMemo(
+    () => new Map(projects().flatMap((project) => (project.id ? [[project.id, project] as const] : []))),
+  )
+  const indexedSessions = createMemo(() => {
+    const cache = homeSessions()
+    if (!cache) return []
+    return retainHomeSessions(
+      cache.sessions(sessionLoad.data, sessionEventLoad.data),
+      SIDEBAR_SESSION_LIMIT,
+      Date.now(),
+    )
+  })
+  const records = createMemo(() =>
+    buildHomeSessionRecords({
+      sessions: indexedSessions,
+      projectDirectories: projectDirs,
+      projects,
+      projectByID,
+    }).slice(0, SIDEBAR_SESSION_LIMIT),
+  )
+
+  const activeSessionId = createMemo(() => sidebarSessionIdFromPath(location.pathname))
+  const serverKey = createMemo(() => {
+    const conn = focusedConn()
+    return conn ? ServerConnection.key(conn) : selection().server
+  })
+
+  const openSession = (session: Session, options?: OpenSessionOptions) => {
+    const directoryKey = pathKey(session.directory)
+    const project =
+      projects().find(
+        (item) =>
+          pathKey(item.worktree) === directoryKey ||
+          item.sandboxes?.some((sandbox) => pathKey(sandbox) === directoryKey),
+      ) ?? projectForSession(session, projects(), projectByID())
+    const conn = focusedConn()
+    const ctx = focusedCtx()
+    if (!conn || !ctx) return
+    const directory = project?.worktree ?? session.directory
+    ctx.projects.open(directory)
+    if (options?.background) {
+      tabs.addSessionTab({ server: ServerConnection.key(conn), sessionId: session.id })
+      return
+    }
+    ctx.projects.touch(directory)
+    void startTransition(() => {
+      const tab = tabs.addSessionTab({ server: ServerConnection.key(conn), sessionId: session.id })
+      tabs.select(tab)
+    })
+  }
+
+  const openProjectNewSession = (conn: ServerConnection.Any, directory: string) => {
+    const ctx = global.ensureServerCtx(conn)
+    ctx.projects.open(directory)
+    ctx.projects.touch(directory)
+    void tabs.newDraft({ server: ServerConnection.key(conn), directory })
+  }
+
+  const newChatTarget = createMemo(() => {
+    const conn = focusedConn()
+    if (!conn) return undefined
+    const list = projects()
+    const target =
+      selectedProject() ??
+      list.find((project) => project.worktree === focusedCtx()?.projects.last()) ??
+      list[0]
+    if (!target) return undefined
+    return { conn, directory: target.worktree }
+  })
+
+  const openNewChat = () => {
+    const target = newChatTarget()
+    if (!target) return
+    openProjectNewSession(target.conn, target.directory)
+  }
+
+  const selectProject = (conn: ServerConnection.Any, directory: string) => {
+    const key = ServerConnection.key(conn)
+    if (global.servers.health[key]?.healthy === false) return
+    if (!global.ensureServerCtx(conn).projects.list().some((project) => project.worktree === directory)) return
+    layout.home.setSelection(toggleHomeProjectSelection(selection(), key, directory))
+    if (location.pathname !== "/") navigate("/")
+  }
+
+  const unseenCount = (conn: ServerConnection.Any, project: LocalProject) => {
+    const state = notification.ensureServerState(ServerConnection.key(conn))
+    return projectDirectories(project).reduce((total, directory) => total + state.project.unseenCount(directory), 0)
+  }
+
+  return (
+    <Show
+      when={!state.collapsed}
+      fallback={
+        <aside
+          data-component="app-sidebar"
+          data-collapsed="true"
+          class="hidden w-14 shrink-0 flex-col items-center gap-1 border-r border-v2-border-border-base py-2 lg:flex"
+        >
+          <TooltipV2 placement="right" value={language.t("command.session.new")}>
+            <IconButtonV2
+              variant="ghost-muted"
+              size="large"
+              icon={<IconV2 name="edit" />}
+              aria-label={language.t("command.session.new")}
+              disabled={!newChatTarget()}
+              onClick={openNewChat}
+            />
+          </TooltipV2>
+          <TooltipV2 placement="right" value={language.t("sidebar.settings")}>
+            <IconButtonV2
+              variant="ghost-muted"
+              size="large"
+              icon={<IconV2 name="settings-gear" />}
+              aria-label={language.t("sidebar.settings")}
+              onClick={openSettings}
+            />
+          </TooltipV2>
+          <div class="mt-auto">
+            <TooltipV2 placement="right" value={language.t("sidebar.menu.toggle")}>
+              <IconButtonV2
+                variant="ghost-muted"
+                size="large"
+                icon={<IconV2 name="chevron-down" size="small" style={{ transform: "rotate(-90deg)" }} />}
+                aria-label={language.t("sidebar.menu.toggle")}
+                onClick={() => setState("collapsed", false)}
+              />
+            </TooltipV2>
+          </div>
+        </aside>
+      }
+    >
+      <aside
+        data-component="app-sidebar"
+        class="hidden w-64 shrink-0 flex-col border-r border-v2-border-border-base lg:flex"
+        aria-label={language.t("sidebar.nav.projectsAndSessions")}
+      >
+        <div class="flex shrink-0 items-center gap-1 p-2">
+          <ButtonV2
+            data-action="sidebar-new-chat"
+            variant="neutral"
+            size="normal"
+            icon="edit"
+            class="h-8 flex-1 justify-start px-2.5 [font-weight:530]"
+            disabled={!newChatTarget()}
+            onClick={openNewChat}
+          >
+            {language.t("command.session.new")}
+          </ButtonV2>
+          <TooltipV2 placement="bottom" value={language.t("sidebar.menu.toggle")}>
+            <IconButtonV2
+              variant="ghost-muted"
+              size="large"
+              icon={<IconV2 name="chevron-down" size="small" style={{ transform: "rotate(90deg)" }} />}
+              aria-label={language.t("sidebar.menu.toggle")}
+              onClick={() => setState("collapsed", true)}
+            />
+          </TooltipV2>
+        </div>
+        <div class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-2 pb-2">
+          <section class="flex min-w-0 flex-col gap-1" aria-label={language.t("home.projects")}>
+            <div class="flex h-7 min-w-0 shrink-0 items-center px-1.5">
+              <div class="text-v2-text-text-muted [font-weight:530]">{language.t("home.projects")}</div>
+            </div>
+            <Show
+              when={projects().length > 0}
+              fallback={
+                <div class="px-1.5 py-1 text-v2-text-text-faint [font-weight:440]">
+                  <div>{language.t("sidebar.empty.title")}</div>
+                  <div class="mt-0.5 text-v2-text-text-faint">{language.t("sidebar.empty.description")}</div>
+                </div>
+              }
+            >
+              <Show
+                when={!multiServer()}
+                fallback={
+                  <For each={servers()}>
+                    {(conn) => (
+                      <SidebarServerProjects
+                        conn={conn}
+                        projects={projects().filter(
+                          (project) =>
+                            global.ensureServerCtx(conn).projects.list().some((item) => item.worktree === project.worktree),
+                        )}
+                        selection={selection}
+                        language={language}
+                        unseenCount={unseenCount}
+                        onSelectProject={selectProject}
+                        onOpenProjectNewSession={openProjectNewSession}
+                      />
+                    )}
+                  </For>
+                }
+              >
+                <For each={projects()}>
+                  {(project) => (
+                    <SidebarProjectRow
+                      project={project}
+                      conn={focusedConn()}
+                      selected={selection().directory === project.worktree}
+                      language={language}
+                      unseenCount={unseenCount}
+                      onSelectProject={selectProject}
+                      onOpenProjectNewSession={openProjectNewSession}
+                    />
+                  )}
+                </For>
+              </Show>
+            </Show>
+          </section>
+          <section class="flex min-w-0 flex-col gap-1" aria-label={language.t("sidebar.project.recentSessions")}>
+            <div class="flex h-7 min-w-0 shrink-0 items-center px-1.5">
+              <div class="text-v2-text-text-muted [font-weight:530]">
+                {language.t("sidebar.project.recentSessions")}
+              </div>
+            </div>
+            <Show
+              when={records().length > 0}
+              fallback={
+                <div class="px-1.5 py-1 text-v2-text-text-faint [font-weight:440]">
+                  {language.t("home.sessions.empty")}
+                </div>
+              }
+            >
+              <For each={records()}>
+                {(record) => (
+                  <div class="group/session relative flex h-8 min-w-0 items-center rounded-[6px]">
+                    <button
+                      type="button"
+                      data-component="sidebar-session-row"
+                      class={`
+                        flex h-8 min-w-0 w-full shrink-0 cursor-default items-center gap-2 rounded-[6px] border-0
+                        bg-transparent px-1.5 text-left text-v2-text-text-muted [font-weight:440]
+                        transition-[background-color,color] duration-[120ms] ease-in-out
+                        hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base
+                        data-[selected]:bg-v2-background-bg-layer-03 data-[selected]:text-v2-text-text-base
+                        focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none
+                      `}
+                      data-selected={activeSessionId() === record.session.id ? "" : undefined}
+                      onMouseDown={(event) => {
+                        if (event.button === 1) event.preventDefault()
+                      }}
+                      onClick={(event) => openSession(record.session, { background: isBackgroundOpen(event) })}
+                      onAuxClick={(event) => {
+                        if (!isBackgroundOpen(event)) return
+                        event.preventDefault()
+                        openSession(record.session, { background: true })
+                      }}
+                    >
+                      <HomeSessionStatusController
+                        server={serverKey}
+                        record={record}
+                        isOpenTab={(entry) => sessionHasOpenTab(tabs.store, serverKey(), entry.session)}
+                        render={(status) => (
+                          <SessionTabAvatarView
+                            project={record.project}
+                            directory={record.session.directory}
+                            revealProjectOnHover={!selectedProject()}
+                            unread={status.unread()}
+                            loading={status.loading()}
+                          />
+                        )}
+                      />
+                      <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base [font-weight:440]">
+                        {sessionTitle(record.session.title) || record.session.id}
+                      </span>
+                    </button>
+                  </div>
+                )}
+              </For>
+            </Show>
+          </section>
+        </div>
+        <div class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-base p-2">
+          <SidebarNavButton onClick={openSettings}>
+            <IconV2 name="settings-gear" size="small" />
+            <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+              {language.t("sidebar.settings")}
+            </span>
+          </SidebarNavButton>
+        </div>
+      </aside>
+    </Show>
+  )
+}
+
+function SidebarServerProjects(props: {
+  conn: ServerConnection.Any
+  projects: LocalProject[]
+  selection: Accessor<HomeProjectSelection>
+  language: ReturnType<typeof useLanguage>
+  unseenCount: (conn: ServerConnection.Any, project: LocalProject) => number
+  onSelectProject: (conn: ServerConnection.Any, directory: string) => void
+  onOpenProjectNewSession: (conn: ServerConnection.Any, directory: string) => void
+}) {
+  if (props.projects.length === 0) return null
+  return (
+    <div class="flex min-w-0 flex-col gap-1">
+      <div class="px-1.5 pt-1 text-v2-text-text-faint [font-weight:530]">
+        {props.conn.displayName ?? props.conn.http.url}
+      </div>
+      <For each={props.projects}>
+        {(project) => (
+          <SidebarProjectRow
+            project={project}
+            conn={props.conn}
+            selected={
+              props.selection().server === ServerConnection.key(props.conn) &&
+              props.selection().directory === project.worktree
+            }
+            language={props.language}
+            unseenCount={props.unseenCount}
+            onSelectProject={props.onSelectProject}
+            onOpenProjectNewSession={props.onOpenProjectNewSession}
+          />
+        )}
+      </For>
+    </div>
+  )
+}
+
+function SidebarProjectRow(props: {
+  project: LocalProject
+  conn: ServerConnection.Any | undefined
+  selected: boolean
+  language: ReturnType<typeof useLanguage>
+  unseenCount: (conn: ServerConnection.Any, project: LocalProject) => number
+  onSelectProject: (conn: ServerConnection.Any, directory: string) => void
+  onOpenProjectNewSession: (conn: ServerConnection.Any, directory: string) => void
+}) {
+  const name = () => displayName(props.project)
+  const unseen = () => (props.conn ? props.unseenCount(props.conn, props.project) : 0)
+  return (
+    <div class="group/project relative flex h-7 min-w-0 items-center rounded-[6px]">
+      <button
+        type="button"
+        data-component="sidebar-project-row"
+        class={`
+          flex h-7 min-w-0 w-full shrink-0 cursor-default items-center gap-2 rounded-[6px] bg-transparent px-1.5
+          text-left text-v2-text-text-muted [font-weight:440]
+          transition-[background-color,color] duration-[120ms] ease-in-out
+          hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base
+          data-[selected]:bg-v2-background-bg-layer-03 data-[selected]:text-v2-text-text-base
+          focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none
+        `}
+        data-selected={props.selected ? "" : undefined}
+        aria-current={props.selected ? "page" : undefined}
+        onClick={() => {
+          if (props.conn) props.onSelectProject(props.conn, props.project.worktree)
+        }}
+      >
+        <ProjectAvatar
+          fallback={name()}
+          src={getProjectAvatarSource(props.project.id, props.project.icon)}
+          variant={getProjectAvatarVariant(props.project.icon?.color)}
+        />
+        <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{name()}</span>
+        <Show when={unseen() > 0}>
+          <span class="flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-v2-background-bg-layer-04 px-1 text-[10px] text-v2-text-text-base">
+            {unseen()}
+          </span>
+        </Show>
+      </button>
+      <Show when={props.conn}>
+        {(conn) => (
+          <div class="hover-reveal absolute right-1 top-1/2 hidden -translate-y-1/2 items-center group-hover/project:flex">
+            <TooltipV2 placement="bottom" value={props.language.t("command.session.new")}>
+              <IconButtonV2
+                data-action="sidebar-project-new-session"
+                variant="ghost-muted"
+                size="small"
+                icon={<IconV2 name="edit" />}
+                aria-label={props.language.t("command.session.new")}
+                onClick={() => props.onOpenProjectNewSession(conn(), props.project.worktree)}
+              />
+            </TooltipV2>
+          </div>
+        )}
+      </Show>
+    </div>
+  )
+}
+
+function SidebarNavButton(props: ParentProps<{ onClick: () => void }>) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      class={`
+        flex h-7 min-w-0 w-full shrink-0 cursor-default items-center gap-2 rounded-[6px] bg-transparent px-1.5
+        text-left text-v2-text-text-faint [font-weight:440]
+        transition-[background-color,color] duration-[120ms] ease-in-out
+        hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base
+        focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none
+      `}
+    >
+      {props.children}
+    </button>
+  )
+}

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -251,7 +251,8 @@ export function AppSidebar() {
         <aside
           data-component="app-sidebar"
           data-collapsed="true"
-          class="hidden w-14 shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base/70 py-2 backdrop-blur-xl lg:flex"
+          class="hidden shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base/70 py-2 backdrop-blur-xl lg:flex"
+          classList={{ "w-14": !trafficLights(), "w-24": trafficLights() }}
           style={trafficLights() ? { "padding-top": "36px" } : undefined}
         >
           <TooltipV2 placement="right" value={language.t("home.title")}>
@@ -303,10 +304,7 @@ export function AppSidebar() {
         class="hidden w-64 shrink-0 flex-col bg-v2-background-bg-base/70 backdrop-blur-xl lg:flex"
         aria-label={language.t("sidebar.nav.projectsAndSessions")}
       >
-        <div
-          class="flex h-9 shrink-0 items-center px-2"
-          style={trafficLights() ? { "padding-left": "84px" } : undefined}
-        >
+        <div class="flex h-9 shrink-0 items-center justify-end px-2">
           <TooltipV2 placement="bottom" value={language.t("sidebar.menu.toggle")}>
             <IconButtonV2
               variant="ghost-muted"

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -4,12 +4,13 @@ import { useQuery } from "@tanstack/solid-query"
 import { createEffect, createMemo, For, Show, startTransition, type Accessor, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Logo, Mark } from "@opencode-ai/ui/logo"
-import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
 import { ProjectAvatar } from "@opencode-ai/ui/v2/project-avatar-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { useSettingsCommand } from "@/components/settings-dialog"
+import { useCommand } from "@/context/command"
 import { useGlobal } from "@/context/global"
 import {
   loadHomeSessionIndex,
@@ -19,6 +20,7 @@ import {
 import { getProjectAvatarVariant, useLayout, type HomeProjectSelection, type LocalProject } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { useNotification } from "@/context/notification"
+import { usePlatform } from "@/context/platform"
 import { ServerConnection, useServer } from "@/context/server"
 import { sessionHasOpenTab, useTabs } from "@/context/tabs"
 import { shouldOpenSessionInBackground } from "@/pages/home-session-open"
@@ -63,10 +65,16 @@ export function AppSidebar() {
   const server = useServer()
   const language = useLanguage()
   const notification = useNotification()
+  const platform = usePlatform()
   const location = useLocation()
   const navigate = useNavigate()
+  const command = useCommand()
+  const dialog = useDialog()
   const openSettings = useSettingsCommand()
   const [state, setState] = persisted(Persist.window("app.sidebar"), createStore({ collapsed: false }))
+  // Native macOS traffic lights overlay the top-left when the titlebar is
+  // hidden, so clear them with extra top padding on desktop macOS.
+  const trafficLights = () => platform.platform === "desktop" && platform.os === "macos"
 
   const selection = layout.home.selection
   const focusedConn = createMemo(
@@ -196,6 +204,19 @@ export function AppSidebar() {
     if (location.pathname !== "/") navigate("/")
   }
 
+  const openSearch = () => {
+    goHome()
+    // The home route registers the focus command on mount; retry in case it
+    // is not registered yet. Unknown ids are a safe no-op.
+    const trigger = () => command.trigger("home.sessions.search.focus")
+    setTimeout(trigger, 120)
+    setTimeout(trigger, 600)
+  }
+
+  const openMe = () => {
+    void dialog.show(() => <MeDialog onHome={goHome} onSettings={openSettings} />)
+  }
+
   let started = false
   createEffect(() => {
     if (started || !tabs.ready() || location.pathname !== "/") return
@@ -230,7 +251,8 @@ export function AppSidebar() {
         <aside
           data-component="app-sidebar"
           data-collapsed="true"
-          class="hidden w-14 shrink-0 flex-col items-center gap-1 border-r border-v2-border-border-base py-2 lg:flex"
+          class="hidden w-14 shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base/70 py-2 backdrop-blur-xl lg:flex"
+          style={trafficLights() ? { "padding-top": "30px" } : undefined}
         >
           <TooltipV2 placement="right" value={language.t("home.title")}>
             <button
@@ -253,13 +275,13 @@ export function AppSidebar() {
               onClick={openNewChat}
             />
           </TooltipV2>
-          <TooltipV2 placement="right" value={language.t("sidebar.settings")}>
+          <TooltipV2 placement="right" value="Me">
             <IconButtonV2
               variant="ghost-muted"
               size="large"
               icon={<IconV2 name="settings-gear" />}
-              aria-label={language.t("sidebar.settings")}
-              onClick={openSettings}
+              aria-label="Me"
+              onClick={openMe}
             />
           </TooltipV2>
           <div class="mt-auto">
@@ -278,10 +300,13 @@ export function AppSidebar() {
     >
       <aside
         data-component="app-sidebar"
-        class="hidden w-64 shrink-0 flex-col border-r border-v2-border-border-base lg:flex"
+        class="hidden w-64 shrink-0 flex-col bg-v2-background-bg-base/70 backdrop-blur-xl lg:flex"
         aria-label={language.t("sidebar.nav.projectsAndSessions")}
       >
-        <div class="flex shrink-0 items-center justify-between p-2 pb-1">
+        <div
+          class="flex shrink-0 items-center justify-between p-2 pb-1"
+          style={trafficLights() ? { "padding-top": "30px" } : undefined}
+        >
           <button
             type="button"
             data-action="sidebar-home"
@@ -302,17 +327,12 @@ export function AppSidebar() {
           </TooltipV2>
         </div>
         <div class="shrink-0 px-2 pb-1">
-          <ButtonV2
-            data-action="sidebar-new-chat"
-            variant="neutral"
-            size="normal"
-            icon="edit"
-            class="h-8 w-full justify-start px-2.5 [font-weight:530]"
-            disabled={!newChatTarget()}
-            onClick={openNewChat}
-          >
-            {language.t("command.session.new")}
-          </ButtonV2>
+          <SidebarNavButton data-action="sidebar-new-chat" onClick={openNewChat} disabled={!newChatTarget()}>
+            <IconV2 name="edit" size="small" />
+            <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+              {language.t("command.session.new")}
+            </span>
+          </SidebarNavButton>
         </div>
         <div class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-2 pb-2">
           <section class="flex min-w-0 flex-col gap-1" aria-label={language.t("home.projects")}>
@@ -365,10 +385,20 @@ export function AppSidebar() {
             </Show>
           </section>
           <section class="flex min-w-0 flex-col gap-1" aria-label={language.t("sidebar.project.recentSessions")}>
-            <div class="flex h-7 min-w-0 shrink-0 items-center px-1.5">
+            <div class="flex h-7 min-w-0 shrink-0 items-center justify-between px-1.5">
               <div class="text-v2-text-text-muted [font-weight:530]">
                 {language.t("sidebar.project.recentSessions")}
               </div>
+              <TooltipV2 placement="bottom" value={language.t("home.sessions.search.placeholder")}>
+                <IconButtonV2
+                  data-action="sidebar-search-sessions"
+                  variant="ghost-muted"
+                  size="small"
+                  icon={<IconV2 name="magnifying-glass" />}
+                  aria-label={language.t("home.sessions.search.placeholder")}
+                  onClick={openSearch}
+                />
+              </TooltipV2>
             </div>
             <Show
               when={records().length > 0}
@@ -427,22 +457,47 @@ export function AppSidebar() {
             </Show>
           </section>
         </div>
-        <div class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-base p-2">
-          <SidebarNavButton onClick={goHome}>
+        <div class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-base/60 p-2">
+          <SidebarNavButton onClick={openMe}>
             <Mark class="h-4 w-auto shrink-0" />
-            <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-              {language.t("home.title")}
-            </span>
-          </SidebarNavButton>
-          <SidebarNavButton onClick={openSettings}>
-            <IconV2 name="settings-gear" size="small" />
-            <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-              {language.t("sidebar.settings")}
-            </span>
+            <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">Me</span>
           </SidebarNavButton>
         </div>
       </aside>
     </Show>
+  )
+}
+
+function MeDialog(props: { onHome: () => void; onSettings: () => void }) {
+  const dialog = useDialog()
+  const language = useLanguage()
+  const close = () => dialog.close()
+  return (
+    <div class="flex w-64 flex-col gap-1 rounded-[12px] bg-v2-background-bg-base p-2 shadow-[var(--v2-elevation-floating)]">
+      <div class="px-2 py-1 text-v2-text-text-muted [font-weight:530]">Me</div>
+      <SidebarNavButton
+        onClick={() => {
+          close()
+          props.onHome()
+        }}
+      >
+        <Mark class="h-4 w-auto shrink-0" />
+        <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+          {language.t("home.title")}
+        </span>
+      </SidebarNavButton>
+      <SidebarNavButton
+        onClick={() => {
+          close()
+          props.onSettings()
+        }}
+      >
+        <IconV2 name="settings-gear" size="small" />
+        <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+          {language.t("sidebar.settings")}
+        </span>
+      </SidebarNavButton>
+    </div>
   )
 }
 
@@ -543,16 +598,18 @@ function SidebarProjectRow(props: {
   )
 }
 
-function SidebarNavButton(props: ParentProps<{ onClick: () => void }>) {
+function SidebarNavButton(props: ParentProps<{ onClick: () => void; disabled?: boolean }>) {
   return (
     <button
       type="button"
       onClick={props.onClick}
+      disabled={props.disabled}
       class={`
         flex h-7 min-w-0 w-full shrink-0 cursor-default items-center gap-2 rounded-[6px] bg-transparent px-1.5
         text-left text-v2-text-text-faint [font-weight:440]
         transition-[background-color,color] duration-[120ms] ease-in-out
         hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base
+        disabled:opacity-40
         focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none
       `}
     >

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -252,7 +252,7 @@ export function AppSidebar() {
           data-component="app-sidebar"
           data-collapsed="true"
           class="hidden w-14 shrink-0 flex-col items-center gap-1 bg-v2-background-bg-base/70 py-2 backdrop-blur-xl lg:flex"
-          style={trafficLights() ? { "padding-top": "30px" } : undefined}
+          style={trafficLights() ? { "padding-top": "36px" } : undefined}
         >
           <TooltipV2 placement="right" value={language.t("home.title")}>
             <button
@@ -304,18 +304,9 @@ export function AppSidebar() {
         aria-label={language.t("sidebar.nav.projectsAndSessions")}
       >
         <div
-          class="flex shrink-0 items-center justify-between p-2 pb-1"
-          style={trafficLights() ? { "padding-top": "30px" } : undefined}
+          class="flex h-9 shrink-0 items-center px-2"
+          style={trafficLights() ? { "padding-left": "84px" } : undefined}
         >
-          <button
-            type="button"
-            data-action="sidebar-home"
-            onClick={goHome}
-            class="flex min-w-0 items-center rounded-[6px] px-1.5 py-1 focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none"
-            aria-label={language.t("home.title")}
-          >
-            <Logo class="h-5 w-auto" />
-          </button>
           <TooltipV2 placement="bottom" value={language.t("sidebar.menu.toggle")}>
             <IconButtonV2
               variant="ghost-muted"
@@ -325,6 +316,19 @@ export function AppSidebar() {
               onClick={() => setState("collapsed", true)}
             />
           </TooltipV2>
+        </div>
+        <div
+          class="flex shrink-0 items-center px-3 pb-3 pt-1"
+        >
+          <button
+            type="button"
+            data-action="sidebar-home"
+            onClick={goHome}
+            class="flex min-w-0 items-center rounded-[6px] px-1.5 py-2 focus-visible:bg-v2-background-bg-layer-01 focus-visible:outline-none"
+            aria-label={language.t("home.title")}
+          >
+            <Logo class="h-5 w-auto" />
+          </button>
         </div>
         <div class="shrink-0 px-2 pb-1">
           <SidebarNavButton data-action="sidebar-new-chat" onClick={openNewChat} disabled={!newChatTarget()}>

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -37,7 +37,6 @@ import { ServerConnection, useServer } from "@/context/server"
 import { tabKey, useTabs } from "@/context/tabs"
 import type { PromptSession } from "@/context/prompt"
 import "./titlebar.css"
-import { newTabTooltipKeybind } from "./command-tooltip-keybind"
 import { normalizeSessionInfo } from "@/utils/session"
 
 const legacyTitlebarHeight = 40
@@ -410,25 +409,6 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                   }}
                   onReorder={(keys) => tabsStoreActions.reorder(keys)}
                 />
-                <TooltipV2
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("command.session.new")}
-                      <KeybindV2 keys={newTabTooltipKeybind(command)} variant="neutral" />
-                    </>
-                  }
-                >
-                  <IconButtonV2
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
-                    class="shrink-0"
-                    icon={<IconV2 name="plus" />}
-                    onClick={openNewTab}
-                    aria-label={language.t("command.session.new")}
-                  />
-                </TooltipV2>
                 <div class="flex-1" />
                 <TitlebarV2Right state={v2RightState()} />
               </div>

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -367,32 +367,9 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                   "md:pl-4": !macTrafficLights(),
                 }}
               >
-                <ChannelIndicator debugTools={props.debugTools} />
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} variant="v2" />
                 </Show>
-                <TooltipV2
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("home.title")}
-                      <KeybindV2 keys={command.keybindParts("home.toggle")} variant="neutral" />
-                    </>
-                  }
-                  class="shrink-0"
-                >
-                  <IconButtonV2
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
-                    class="!w-9 shrink-0"
-                    icon={<IconV2 name="grid-plus" />}
-                    state={layout.route().type === "home" ? "pressed" : undefined}
-                    onClick={toggleHome}
-                    aria-label={language.t("home.title")}
-                    aria-pressed={layout.route().type === "home"}
-                  />
-                </TooltipV2>
 
                 <TitlebarTabStrip
                   tabs={tabsStore}
@@ -542,7 +519,6 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                     <div id="opencode-titlebar-left" class="flex items-center gap-3 min-w-0 px-2" />
                   </div>
                 </div>
-                <ChannelIndicator debugTools={props.debugTools} />
               </div>
             </div>
 
@@ -622,32 +598,5 @@ function TitlebarUpdateIconButton(props: { state: TitlebarUpdatePillState }) {
         </span>
       </button>
     </div>
-  )
-}
-
-function ChannelIndicator(props: { debugTools?: { visible: boolean; toggle: () => void } }) {
-  const channel = import.meta.env.VITE_OPENCODE_CHANNEL
-  if (channel === "dev" && props.debugTools) {
-    return (
-      <button
-        type="button"
-        class="bg-icon-interactive-base text-[#FFF] font-medium px-2 rounded-sm uppercase font-mono cursor-pointer"
-        onClick={props.debugTools.toggle}
-        aria-label="Toggle debug tools"
-        aria-pressed={props.debugTools.visible}
-      >
-        DEV
-      </button>
-    )
-  }
-
-  return (
-    <>
-      {["beta", "dev"].includes(channel) && (
-        <div class="bg-icon-interactive-base text-[#FFF] font-medium px-2 rounded-sm uppercase font-mono">
-          {channel.toUpperCase()}
-        </div>
-      )}
-    </>
   )
 }

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -860,6 +860,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ማሳወቂያዎችን አጽዳ",
   "sidebar.empty.title": "ምንም ክፍት ፕሮጀክቶች የሉም",
   "sidebar.empty.description": "ለመጀመር ፕሮጀክት ይክፈቱ",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "የልማት አፈጻጸም ምርመራዎች",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -827,6 +827,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "مسح الإشعارات",
   "sidebar.empty.title": "لا توجد مشاريع مفتوحة",
   "sidebar.empty.description": "افتح مشروعًا للبدء",
+  "sidebar.projects.empty": "No projects",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "سطح المكتب",
   "settings.section.server": "الخادم",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Bildirişləri təmizlə",
   "sidebar.empty.title": "Heç bir layihə açılmayıb",
   "sidebar.empty.description": "Başlamaq üçün bir layihə açın",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Tərtibatçı performans diaqnostikası",
   "debugBar.na": "yox",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -882,6 +882,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Изчистване на известията",
   "sidebar.empty.title": "Няма отворени проекти",
   "sidebar.empty.description": "Отворете проект, за да започнете",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Диагностика на ефективността на разработката",
   "debugBar.na": "няма",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -876,6 +876,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "বিজ্ঞপ্তিগুলি সাফ করুন",
   "sidebar.empty.title": "কোনো প্রকল্প খোলা নেই",
   "sidebar.empty.description": "শুরু করতে একটি প্রকল্প খুলুন",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "উন্নয়ন কর্মক্ষমতা ডায়গনিস্টিক",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "এনএভি",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -830,6 +830,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Limpar notificações",
   "sidebar.empty.title": "Nenhum projeto aberto",
   "sidebar.empty.description": "Abra um projeto para começar",
+  "sidebar.projects.empty": "No projects",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Desktop",
   "settings.section.server": "Servidor",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -891,6 +891,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Očisti obavijesti",
   "sidebar.empty.title": "Nema otvorenih projekata",
   "sidebar.empty.description": "Otvori projekat za početak",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Esborra les notificacions",
   "sidebar.empty.title": "No hi ha projectes oberts",
   "sidebar.empty.description": "Obriu un projecte per començar",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnòstic de rendiment del desenvolupament",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -882,6 +882,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Vymazat oznámení",
   "sidebar.empty.title": "Nejsou otevřeny žádné projekty",
   "sidebar.empty.description": "Chcete-li začít, otevřete projekt",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostika vývoje výkonnosti",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -768,6 +768,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Ryd notifikationer",
   "sidebar.empty.title": "Ingen åbne projekter",
   "sidebar.empty.description": "Åbn et projekt for at komme i gang",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Desktop",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -721,6 +721,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Benachrichtigungen löschen",
   "sidebar.empty.title": "Keine Projekte geöffnet",
   "sidebar.empty.description": "Öffnen Sie ein Projekt, um loszulegen",
+  "sidebar.projects.empty": "No projects",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Desktop",
   "settings.section.server": "Server",

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -890,6 +890,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ނޮޓިފިކޭޝަންތައް ސާފުކުރުން",
   "sidebar.empty.title": "އެއްވެސް މަޝްރޫއެއް ނުހުޅުވޭ",
   "sidebar.empty.description": "ފަށަން ޕްރޮޖެކްޓެއް ހުޅުވާށެވެ",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "ޑިވެލޮޕްމަންޓް ޕާފޯމަންސް ޑައިގްނޯސްޓިކްސް",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV އެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -891,6 +891,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "བརྡ་བསྐུལ་ཚུ་གསལ་བཟོ།",
   "sidebar.empty.title": "ལས་འགུལ་ཁ་ཕྱེ་མེད།",
   "sidebar.empty.description": "འགོ་བཙུགས་ནིའི་དོན་ལུ་ལས་འགུལ་ཅིག་ཁ་ཕྱེ།",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "གོང་འཕེལ་གྱི་ལས་དོན་བརྟག་དཔྱད།",
   "debugBar.na": "ན/ཨེ།",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -885,6 +885,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Διαγραφή ειδοποιήσεων",
   "sidebar.empty.title": "Δεν υπάρχουν ανοιχτά έργα",
   "sidebar.empty.description": "Ανοίξτε ένα έργο για να ξεκινήσετε",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Διαγνωστικά απόδοσης ανάπτυξης",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -854,6 +854,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Clear notifications",
   "sidebar.empty.title": "No projects open",
   "sidebar.empty.description": "Open a project to get started",
+  "sidebar.projects.empty": "No projects",
 
   "debugBar.ariaLabel": "Development performance diagnostics",
   "debugBar.na": "n/a",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -896,6 +896,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Borrar notificaciones",
   "sidebar.empty.title": "No hay proyectos abiertos",
   "sidebar.empty.description": "Abre un proyecto para empezar",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -872,6 +872,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Tühjenda märguanded",
   "sidebar.empty.title": "Avatud projekte pole",
   "sidebar.empty.description": "Alustamiseks avage projekt",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Arendustegevuse diagnostika",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -875,6 +875,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "پرامپت ها را پاک کنید",
   "sidebar.empty.title": "هیچ پروژه ای باز نشده است",
   "sidebar.empty.description": "برای شروع یک پروژه باز کنید",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "تشخیص عملکرد توسعه",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -776,6 +776,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Tyhjennä ilmoitukset",
   "sidebar.empty.title": "Ei avoimia projekteja",
   "sidebar.empty.description": "Aloita avaamalla projekti",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Kehityksen suorituskyvyn diagnostiikka",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -877,6 +877,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Rudda fráboðanir",
   "sidebar.empty.title": "Ongar verkætlanir lata upp",
   "sidebar.empty.description": "Opna eina verkætlan fyri at koma í gongd",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Menningar avriksdiagnostikk",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -835,6 +835,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Effacer les notifications",
   "sidebar.empty.title": "Aucun projet ouvert",
   "sidebar.empty.description": "Ouvrez un projet pour commencer",
+  "sidebar.projects.empty": "No projects",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Application de bureau",
   "settings.section.server": "Serveur",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "सूचनाएँ साफ़ करें",
   "sidebar.empty.title": "कोई प्रोजेक्ट खुला नहीं",
   "sidebar.empty.description": "आरंभ करने के लिए एक प्रोजेक्ट खोलें",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "विकास प्रदर्शन निदान",
   "debugBar.na": "एन/ए",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -885,6 +885,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Očistite obavijesti",
   "sidebar.empty.title": "Nema otvorenih projekata",
   "sidebar.empty.description": "Otvorite projekt da biste započeli",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Dijagnostika izvedbe razvoja",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Értesítések törlése",
   "sidebar.empty.title": "Nincs nyitott projekt",
   "sidebar.empty.description": "A kezdéshez nyisson meg egy projektet",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Fejlesztési teljesítmény diagnosztika",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -883,6 +883,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Մաքրել ծանուցումները",
   "sidebar.empty.title": "Ոչ մի նախագիծ բաց",
   "sidebar.empty.description": "Բացեք նախագիծ՝ սկսելու համար",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Զարգացման կատարողականի ախտորոշում",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -953,6 +953,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Hapus notifikasi",
   "sidebar.empty.title": "Tidak ada proyek terbuka",
   "sidebar.empty.description": "Buka proyek untuk memulai",
+  "sidebar.projects.empty": "No projects",
 
   "debugBar.ariaLabel": "Diagnostik kinerja pengembangan",
   "debugBar.na": "n/a",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Hreinsaðu tilkynningar",
   "sidebar.empty.title": "Engin verkefni opin",
   "sidebar.empty.description": "Opnaðu verkefni til að byrja",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Þróunarárangursgreiningar",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -796,6 +796,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Cancella notifiche",
   "sidebar.empty.title": "Nessun progetto aperto",
   "sidebar.empty.description": "Apri un progetto per iniziare",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostica delle prestazioni di sviluppo",
   "debugBar.na": "n/d",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -815,6 +815,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "通知をクリア",
   "sidebar.empty.title": "開いているプロジェクトはありません",
   "sidebar.empty.description": "プロジェクトを開いて始めましょう",
+  "sidebar.projects.empty": "No projects",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "デスクトップ",
   "settings.section.server": "サーバー",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -876,6 +876,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "შეტყობინებების გასუფთავება",
   "sidebar.empty.title": "პროექტები არ არის გახსნილი",
   "sidebar.empty.description": "გახსენით პროექტი დასაწყებად",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "განვითარების შესრულების დიაგნოსტიკა",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -873,6 +873,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ជម្រះការជូនដំណឹង",
   "sidebar.empty.title": "គ្មានគម្រោងបើកទេ។",
   "sidebar.empty.description": "បើកគម្រោងដើម្បីចាប់ផ្តើម",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "ការវិនិច្ឆ័យដំណើរការអភិវឌ្ឍន៍",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -1016,6 +1016,7 @@ export const dict = {
 
   "sidebar.empty.title": "열린 프로젝트 없음",
   "sidebar.empty.description": "프로젝트를 열어 시작하세요",
+  "sidebar.projects.empty": "No projects",
 
   "settings.general.section.advanced": "고급",
   "settings.general.row.shell.title": "터미널 셸",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -871,6 +871,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ລຶບການແຈ້ງເຕືອນ",
   "sidebar.empty.title": "ບໍ່ມີໂຄງການເປີດ",
   "sidebar.empty.description": "ເປີດໂຄງການເພື່ອເລີ່ມຕົ້ນ",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "ການວິນິດໄສປະສິດທິພາບການພັດທະນາ",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -890,6 +890,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Išvalyti pranešimus",
   "sidebar.empty.title": "Jokių atvirų projektų",
   "sidebar.empty.description": "Norėdami pradėti, atidarykite projektą",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Vystymosi veiklos diagnostika",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -882,6 +882,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Notīrīt paziņojumus",
   "sidebar.empty.title": "Nav atvērts neviens projekts",
   "sidebar.empty.description": "Atveriet projektu, lai sāktu",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Izstrādes veiktspējas diagnostika",
   "debugBar.na": "nav",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Исчистете ги известувањата",
   "sidebar.empty.title": "Нема отворени проекти",
   "sidebar.empty.description": "Отворете проект за да започнете",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Дијагностика на перформансите на развојот",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Мэдэгдлийг арилгах",
   "sidebar.empty.title": "Нээлттэй төсөл байхгүй",
   "sidebar.empty.description": "Эхлэхийн тулд төсөл нээнэ үү",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Хөгжлийн гүйцэтгэлийн оношлогоо",
   "debugBar.na": "үгүй",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -876,6 +876,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Kosongkan notifikasi",
   "sidebar.empty.title": "Tiada projek dibuka",
   "sidebar.empty.description": "Buka projek untuk bermula",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostik prestasi pembangunan",
   "debugBar.na": "tiada",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "အကြောင်းကြားချက်များကို ရှင်းလင်းပါ။",
   "sidebar.empty.title": "မည်သည့်ပရောဂျက်မှ ဖွင့်ထားခြင်းမရှိပါ။",
   "sidebar.empty.description": "စတင်ရန် ပရောဂျက်တစ်ခုကို ဖွင့်ပါ။",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "ဖွံ့ဖြိုးတိုးတက်မှု စွမ်းဆောင်ရည် အဖြေရှာခြင်း",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -877,6 +877,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "सूचनाहरू खाली गर्नुहोस्",
   "sidebar.empty.title": "कुनै पनि आयोजना खुलेका छैनन्",
   "sidebar.empty.description": "सुरु गर्न एउटा परियोजना खोल्नुहोस्",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "विकास प्रदर्शन निदान",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Meldingen wissen",
   "sidebar.empty.title": "Geen projecten geopend",
   "sidebar.empty.description": "Open een project om aan de slag te gaan",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostiek voor ontwikkelprestaties",
   "debugBar.na": "n.v.t.",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -1229,6 +1229,7 @@ export const dict = {
 
   "sidebar.empty.title": "Ingen åpne prosjekter",
   "sidebar.empty.description": "Åpne et prosjekt for å komme i gang",
+  "sidebar.projects.empty": "No projects",
 
   "settings.general.section.advanced": "Avansert",
   "settings.general.row.shell.title": "Terminalskall",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "نوٹیفکیشن صاف کرو",
   "sidebar.empty.title": "کوئی پروجیکٹ نئیں کھلیا",
   "sidebar.empty.description": "شروع کرن لئی کوئی پروجیکٹ کھولو",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "ترقی دی کارکردگی دی تشخیص",
   "debugBar.na": "لاگو نئیں",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -831,6 +831,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Wyczyść powiadomienia",
   "sidebar.empty.title": "Brak otwartych projektów",
   "sidebar.empty.description": "Otwórz projekt, aby rozpocząć",
+  "sidebar.projects.empty": "No projects",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Aplikacja komputerowa",
   "settings.section.server": "Serwer",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -881,6 +881,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Șterge notificările",
   "sidebar.empty.title": "Niciun proiect deschis",
   "sidebar.empty.description": "Deschide un proiect pentru a începe",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnosticare performanță dezvoltare",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -894,6 +894,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Очистить уведомления",
   "sidebar.empty.title": "Нет открытых проектов",
   "sidebar.empty.description": "Откройте проект, чтобы начать",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Приложение",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -874,6 +874,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "දැනුම්දීම් හිස් කරන්න",
   "sidebar.empty.title": "ව්‍යාපෘති විවෘත නැත",
   "sidebar.empty.description": "ආරම්භ කිරීමට ව්‍යාපෘතියක් විවෘත කරන්න",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "සංවර්ධන කාර්ය සාධන රෝග විනිශ්චය",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Vymazať oznámenia",
   "sidebar.empty.title": "Nie sú otvorené žiadne projekty",
   "sidebar.empty.description": "Otvorte projekt pre začiatok",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostika výkonu vývoja",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -881,6 +881,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Počisti obvestila",
   "sidebar.empty.title": "Ni odprtih projektov",
   "sidebar.empty.description": "Za začetek odprite projekt",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostika uspešnosti razvoja",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -879,6 +879,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Pastro njoftimet",
   "sidebar.empty.title": "Asnjë projekt i hapur",
   "sidebar.empty.description": "Hapni një projekt për të filluar",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Diagnostifikimi i performancës së zhvillimit",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Обришите обавештења",
   "sidebar.empty.title": "Нема отворених пројеката",
   "sidebar.empty.description": "Отворите пројекат да бисте започели",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Дијагностика перформанси развоја",
   "debugBar.na": "н/а",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -881,6 +881,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Rensa aviseringar",
   "sidebar.empty.title": "Inga projekt öppna",
   "sidebar.empty.description": "Öppna ett projekt för att komma igång",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Utvecklingsprestandadiagnostik",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Огоҳиҳоро тоза кунед",
   "sidebar.empty.title": "Ягон лоиҳа кушода нест",
   "sidebar.empty.description": "Барои оғоз кардани лоиҳа лоиҳа кушоед",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Ташхиси самаранокии рушд",
   "debugBar.na": "не",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -878,6 +878,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ล้างการแจ้งเตือน",
   "sidebar.empty.title": "ไม่มีโปรเจกต์ที่เปิดอยู่",
   "sidebar.empty.description": "เปิดโปรเจกต์เพื่อเริ่มต้น",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -877,6 +877,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Duýduryşlary arassalaň",
   "sidebar.empty.title": "Taslama açylmaýar",
   "sidebar.empty.description": "Başlamak üçin taslama açyň",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Ösüş öndürijiligini anyklaýyş",
   "debugBar.na": "n / a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -896,6 +896,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Bildirimleri temizle",
   "sidebar.empty.title": "Açık proje yok",
   "sidebar.empty.description": "Başlamak için bir proje açın",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Masaüstü",
 

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -966,6 +966,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Очистити сповіщення",
   "sidebar.empty.title": "Немає відкритих проєктів",
   "sidebar.empty.description": "Відкрийте проєкт, щоб почати",
+  "sidebar.projects.empty": "No projects",
 
   "debugBar.ariaLabel": "Діагностика продуктивності розробки",
   "debugBar.na": "н/д",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -887,6 +887,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "اطلاعات کو صاف کریں۔",
   "sidebar.empty.title": "کوئی پروجیکٹ نہیں کھلا۔",
   "sidebar.empty.description": "شروع کرنے کے لیے ایک پروجیکٹ کھولیں۔",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "ترقیاتی کارکردگی کی تشخیص",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Bildirishnomalarni tozalash",
   "sidebar.empty.title": "Hech qanday loyiha ochiq emas",
   "sidebar.empty.description": "Boshlash uchun loyihani oching",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Rivojlanish samaradorligi diagnostikasi",
   "debugBar.na": "yo'q",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -888,6 +888,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Xóa thông báo",
   "sidebar.empty.title": "Không có dự án nào mở",
   "sidebar.empty.description": "Mở một dự án để bắt đầu",
+  "sidebar.projects.empty": "No projects",
   "debugBar.ariaLabel": "Chẩn đoán hiệu suất phát triển",
   "debugBar.na": "không có",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -874,6 +874,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "清除通知",
   "sidebar.empty.title": "没有打开的项目",
   "sidebar.empty.description": "打开一个项目以开始使用",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -871,6 +871,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "清除通知",
   "sidebar.empty.title": "未開啟任何專案",
   "sidebar.empty.description": "開啟專案以開始使用",
+  "sidebar.projects.empty": "No projects",
 
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "桌面",

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -247,7 +247,7 @@ function directories(project: LocalProject) {
   return [project.worktree, ...(project.sandboxes ?? [])]
 }
 
-function buildHomeSessionRecords(input: {
+export function buildHomeSessionRecords(input: {
   sessions: () => Session[]
   projectDirectories: () => string[]
   projects: () => LocalProject[]

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -5,10 +5,12 @@ import { DebugBar } from "@/components/debug-bar"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
 import { usePlatform } from "@/context/platform"
+import { useTabs } from "@/context/tabs"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
+  const tabs = useTabs()
   const [state, setState] = createStore({ debugTools: true })
 
   createEffect(() => setV2Toast(true))
@@ -31,14 +33,18 @@ export default function NewLayout(props: ParentProps) {
         "padding-bottom": "env(safe-area-inset-bottom, 0px)",
       }}
     >
-      <Titlebar
-        update={update}
-        debugTools={
-          import.meta.env.DEV
-            ? { visible: state.debugTools, toggle: () => setState("debugTools", (value) => !value) }
-            : undefined
-        }
-      />
+      {/* Keep the titlebar mounted (tab keybinds/effects) but hide the empty
+          strip when there are no tabs to show. */}
+      <div classList={{ hidden: tabs.store.length === 0, contents: tabs.store.length > 0 }}>
+        <Titlebar
+          update={update}
+          debugTools={
+            import.meta.env.DEV
+              ? { visible: state.debugTools, toggle: () => setState("debugTools", (value) => !value) }
+              : undefined
+          }
+        />
+      </div>
       <div class="flex min-h-0 flex-1 items-stretch">
         <AppSidebar />
         <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,5 +1,6 @@
 import { createEffect, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
+import { AppSidebar } from "@/components/app-sidebar"
 import { DebugBar } from "@/components/debug-bar"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
@@ -38,9 +39,12 @@ export default function NewLayout(props: ParentProps) {
             : undefined
         }
       />
-      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
-        <Suspense>{props.children}</Suspense>
-      </main>
+      <div class="flex min-h-0 flex-1 items-stretch">
+        <AppSidebar />
+        <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
+          <Suspense>{props.children}</Suspense>
+        </main>
+      </div>
       {import.meta.env.DEV && state.debugTools && <DebugBar inline />}
       <TabsInfoPopup />
       <ToastRegion v2 />

--- a/packages/app/src/utils/sidebar-route.test.ts
+++ b/packages/app/src/utils/sidebar-route.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { sidebarSessionIdFromPath } from "./sidebar-route"
+
+test("extracts the session id from session routes", () => {
+  expect(sidebarSessionIdFromPath("/server/c2Vzc2lvbg/session/abc123")).toBe("abc123")
+  expect(sidebarSessionIdFromPath("/server/c2Vzc2lvbg/session/abc123/")).toBe("abc123")
+})
+
+test("returns undefined outside session routes", () => {
+  expect(sidebarSessionIdFromPath("/")).toBeUndefined()
+  expect(sidebarSessionIdFromPath("/new-session")).toBeUndefined()
+  expect(sidebarSessionIdFromPath("/new-session?draftId=abc")).toBeUndefined()
+  expect(sidebarSessionIdFromPath("/server/c2Vzc2lvbg/session/")).toBeUndefined()
+  expect(sidebarSessionIdFromPath("")).toBeUndefined()
+})

--- a/packages/app/src/utils/sidebar-route.ts
+++ b/packages/app/src/utils/sidebar-route.ts
@@ -1,0 +1,9 @@
+export function sidebarSessionIdFromPath(pathname: string): string | undefined {
+  const match = pathname.match(/\/session\/([^/?#]+)/)
+  if (!match?.[1]) return undefined
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return match[1]
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #38410

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Desktop app has no persistent sidebar: sessions live in the titlebar tab strip, projects and history only on the home page. This adds an experimental app sidebar to the new layout with new chat, projects list, recent conversations across projects, and a Me menu (Home + Settings). It reuses the home page data layer (session index, project lists) and row components, so no new data plumbing or dependencies.

Included: wordmark header, collapsible icon rail, session search shortcut into home search, unselected-project recents, startup restores the last tab or opens a new chat, macOS traffic-light clearance, and removal of the now-redundant titlebar new-tab/home/channel buttons (keybinds still work).

I built this for personal use and verified it end to end locally; marking experimental so maintainers can decide whether the direction fits.

### How did you verify your code works?

- New unit test for the sidebar route helper; full app unit suite passes except one pre-existing environment locale failure (fails on clean tree too)
- Typecheck clean, oxlint clean
- Desktop `electron-vite build` succeeds and the sidebar is in the bundle; ran the packaged app and exercised new chat, project switching, recents, search shortcut, Me menu, and collapse

### Screenshots / recordings

Verified visually in a local desktop build (sidebar with logo header, projects, recents, Me footer; collapsed icon rail). Happy to attach screenshots on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

