### PR TITLE
fix(tui): avoid default theme flash during startup

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -288,7 +288,9 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
       yield* Effect.tryPromise(async () => {
         // Prewarm palette before ThemeProvider mounts so `system` theme avoids a first-paint fallback flash.
         void renderer.getPalette({ size: 16 }).catch(() => undefined)
-        const mode = handoff?.mode ?? (await renderer.waitForThemeMode(1000)) ?? "dark"
+        // Don't block the first frame on terminal theme detection: use the mode already resolved by the
+        // renderer and let the theme context react to late `theme_mode` events.
+        const mode = handoff?.mode ?? renderer.themeMode ?? "dark"
         if (renderer.isDestroyed) return
 
         await render(() => {

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -320,7 +320,12 @@ const themeContext = createSimpleContext({
     themePerformance.set("Init", `${(performance.now() - initStarted).toFixed(2)} ms`)
     const current = createComponentTheme(valuesV2, mode)
 
-    createEffect(() => renderer.setBackgroundColor(valuesV2().background.default))
+    // Keep the terminal's own background until the configured theme resolves so `system` and custom
+    // themes never flash the built-in fallback palette first.
+    createEffect(() => {
+      if (!store.ready && !store.themes[store.active]) return
+      renderer.setBackgroundColor(valuesV2().background.default)
+    })
 
     const currentSyntax = createSyntaxStyleMemo(() => generateSyntax(valuesV2(), mode()))
     const service: Themes = {

--- a/packages/tui/test/cli/tui/theme-mode.test.tsx
+++ b/packages/tui/test/cli/tui/theme-mode.test.tsx
@@ -222,3 +222,46 @@ test.each(["dark", "light"] as const)(
     }
   },
 )
+
+test("keeps the terminal background until the configured theme resolves", async () => {
+  const discovery = Promise.withResolvers<Record<string, unknown>>()
+  const custom = {
+    version: 2,
+    dark: {
+      background: { default: "#123456" },
+      text: { default: "#eeeeee" },
+    },
+  } as const
+  let themes: ReturnType<typeof useThemes> | undefined
+
+  function Probe() {
+    const value = useThemes()
+    themes = value
+    return <text>{value.selected}</text>
+  }
+
+  const app = await testRender(
+    () => (
+      <ConfigProvider config={createTuiResolvedConfig({ theme: { name: "custom", mode: "dark" } })}>
+        <ThemeProvider mode="dark" source={{ discover: () => discovery.promise }}>
+          <Probe />
+        </ThemeProvider>
+      </ConfigProvider>
+    ),
+    { width: 20, height: 2 },
+  )
+  app.renderer.start()
+
+  try {
+    await app.flush()
+    const cells = () => app.captureSpans().lines.flatMap((line) => line.spans)
+    expect(cells().every((span) => span.bg.toInts()[3] === 0)).toBeTrue()
+
+    discovery.resolve({ custom })
+    await wait(() => themes?.ready === true)
+    await app.flush()
+    expect(cells().some((span) => span.bg.equals(RGBA.fromHex("#123456")))).toBeTrue()
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
Render the first frame without waiting for terminal theme-mode detection and keep the terminal's own background until the configured theme resolves, so `system` and custom themes no longer show a blank or fallback-painted frame while loading.

### Issue for this PR

Fixes #42742 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

With `system` or custom themes, startup showed a blank frame for up to ~1s and then a flash of the default `opencode` background.

Two causes:

- `app.tsx` awaited `renderer.waitForThemeMode(1000)` before mounting the UI. If the terminal/multiplexer doesn't answer OSC 10/11, it waits the full timeout (opentui only listens for those replies for 250ms anyway).
- While the theme was still resolving, `ThemeProvider` painted the fallback `opencode` background while the UI was hidden behind the `ready` gate.

Fix: don't block on theme-mode detection (use `renderer.themeMode` plus the existing reactive `theme_mode` handler), and don't set the renderer background until the active theme actually resolves.

### How did you verify your code works?

- Regression test in `packages/tui/test/cli/tui/theme-mode.test.tsx` (fails without the guard).
- `bun typecheck` passes; `packages/tui` suite: 1352 pass, 0 fail.

### Screenshots / recordings

Single recording, first the current build and then this branch:

https://github.com/user-attachments/assets/0e21ca67-f606-44bd-bb86-c55842cfcb6d

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
