### PR TITLE
feat(core): parse JSON text results from MCP tools without an output schema

### DIFF
--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -99,8 +99,19 @@ export const layer = Layer.effect(
                           },
                     )
                     const text = content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n")
+                    const output = () => {
+                      if (result.structured !== undefined) return result.structured
+                      if (text === "") return null
+                      // Agents assume JSON returned as text is already an object, so parse it when the server declares no schema.
+                      if (tool.outputSchema === undefined && (text.startsWith("{") || text.startsWith("["))) {
+                        try {
+                          return JSON.parse(text)
+                        } catch {}
+                      }
+                      return text
+                    }
                     return {
-                      output: result.structured ?? (text === "" ? null : text),
+                      output: output(),
                       ...(content.length === 0 ? {} : { content }),
                     }
                   }).pipe(

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -325,6 +325,32 @@ const mcp = Layer.mock(Mcp.Service, {
         inputSchema: { type: "object", properties: {} },
       }),
       new Mcp.Tool({
+        server: Mcp.ServerName.make("demo"),
+        name: "issues",
+        description: "Returns JSON as text",
+        inputSchema: { type: "object", properties: {} },
+      }),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("demo"),
+        name: "count",
+        description: "Returns a number as text",
+        inputSchema: { type: "object", properties: {} },
+      }),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("demo"),
+        name: "typed",
+        description: "Declares a string output and returns JSON as text",
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: { type: "string" },
+      }),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("direct"),
+        name: "issues",
+        codemode: false,
+        description: "Returns JSON as text",
+        inputSchema: { type: "object", properties: {} },
+      }),
+      new Mcp.Tool({
         server: Mcp.ServerName.make("direct"),
         name: "lookup",
         codemode: false,
@@ -373,6 +399,20 @@ const mcp = Layer.mock(Mcp.Service, {
           tool: input.name,
           isError: false,
           content: [{ type: "text", text: "hello" }],
+        })
+      if (input.name === "issues" || input.name === "typed")
+        return new Mcp.ToolResult({
+          server: Mcp.ServerName.make(input.server),
+          tool: input.name,
+          isError: false,
+          content: [{ type: "text", text: '{"issues":[{"id":1}]}' }],
+        })
+      if (input.name === "count")
+        return new Mcp.ToolResult({
+          server: Mcp.ServerName.make(input.server),
+          tool: input.name,
+          isError: false,
+          content: [{ type: "text", text: "42" }],
         })
       return new Mcp.ToolResult({
         server: Mcp.ServerName.make(input.server),
@@ -1943,6 +1983,7 @@ it.effect("advertises MCP output schemas to Code Mode", () =>
 
     expect(toolSet.definitions.map((tool) => tool.name)).toEqual([
       "direct_fail",
+      "direct_issues",
       "direct_lookup",
       "direct_media",
       "execute",
@@ -2030,6 +2071,39 @@ it.effect("returns content-only MCP results through Code Mode", () =>
       output: { output: "hello", toolCalls: [{ tool: "demo.status", status: "completed" }] },
       content: [{ type: "text", text: "hello" }],
     })
+  }),
+)
+
+it.effect("parses JSON text results from MCP tools without an output schema", () =>
+  Effect.gen(function* () {
+    assertion = yield* Deferred.make<Permission.AssertInput>()
+    decision = Effect.void
+    const registry = yield* Tool.Service
+    const registration = yield* McpTool.Service
+    yield* registration.flush
+    const toolSet = yield* registry.snapshot()
+
+    const run = (code: string) =>
+      toolSet
+        .execute({
+          sessionID: Session.ID.make("ses_mcp_json_text"),
+          ...toolIdentity,
+          call: { type: "tool-call", id: `call_${code.length}`, name: "execute", input: { code } },
+        })
+        .pipe(Effect.map((execution) => execution.output.output))
+
+    expect(yield* run("return (await tools.demo.issues({})).issues[0].id")).toBe("1")
+    expect(yield* run("return typeof (await tools.demo.count({}))")).toBe("string")
+    expect(yield* run("return typeof (await tools.demo.typed({}))")).toBe("string")
+
+    // Outside Code Mode the content the model reads is the original text.
+    expect(
+      yield* toolSet.execute({
+        sessionID: Session.ID.make("ses_mcp_json_text"),
+        ...toolIdentity,
+        call: { type: "tool-call", id: "call_direct_issues", name: "direct_issues", input: {} },
+      }),
+    ).toMatchObject({ output: { issues: [{ id: 1 }] }, content: [{ type: "text", text: '{"issues":[{"id":1}]}' }] })
   }),
 )
 


### PR DESCRIPTION
## Summary

Most MCP servers return JSON serialized into a text content block with no `structuredContent`. Code mode handed the program a string, so this failed on every such tool and the model had to guess `JSON.parse`:

```js
const result = await tools.github.list_issues({ repo })
result.issues.length        // TypeError — result is '{"issues":[…]}'
```

Agents assume JSON returned as text is already an object, so parse it for them. The change is in `McpTool` where the result's `output` is already chosen — the one place that sees `structuredContent`, the content blocks, and whether the server declared an `outputSchema`:

```ts
const output = () => {
  if (result.structured !== undefined) return result.structured
  if (text === "") return null
  // Agents assume JSON returned as text is already an object, so parse it when the server declares no schema.
  if (tool.outputSchema === undefined && (text.startsWith("{") || text.startsWith("["))) {
    try {
      return JSON.parse(text)
    } catch {}
  }
  return text
}
```

- **Structured output is used as is.**
- **No `outputSchema` only.** A declared schema is never second-guessed. Code mode already advertises schemaless MCP tools as `Promise<unknown>`, so the signature does not change.
- **Objects and arrays only.** `"42"` or `"null"` as text stay text; anything that fails to parse stays text.

## Scope

`output` is in-process only: the persisted tool state (`ToolStateCompleted`) has `content`, not `output`, and the model, TUI, and history all read `content`, which is unchanged. Only code mode programs see the parsed value.

## Tests

`test/mcp.test.ts`: new `demo.issues` / `demo.count` / `demo.typed` fixtures. Through code mode, `(await tools.demo.issues({})).issues[0].id` works, `count` (text `42`) stays a string, and `typed` (declares `{ type: "string" }`) stays a string. A direct `direct_issues` call shows `output` parsed while `content` keeps the original text.