### PR TITLE
feat: interrupt with prompt

### DIFF
--- a/packages/app/e2e/regression/session-queue.spec.ts
+++ b/packages/app/e2e/regression/session-queue.spec.ts
@@ -167,6 +167,23 @@ test("follow-up preference controls Enter while Mod+Enter uses the alternate del
   await expect(view.input).toHaveText("")
 })
 
+test("interrupts before steering a correction", async ({ page }) => {
+  const requests: URL[] = []
+  page.on("request", (request) => {
+    const url = new URL(request.url())
+    if (url.pathname.endsWith("/interrupt") || url.pathname.endsWith("/prompt")) requests.push(url)
+  })
+  const mock = createQueueMock([])
+  const view = await openSession(page, mock)
+
+  await view.input.fill("change direction now")
+  await view.composer.locator('[data-action="composer-interrupt"]').click()
+
+  await expect.poll(() => requests.map((url) => url.pathname.split("/").at(-1))).toEqual(["interrupt", "prompt"])
+  expect(requests[0]?.searchParams.has("continue")).toBe(false)
+  expect(mock.prompts[0]?.delivery).toBe("steer")
+})
+
 test("dragging reorders queued prompts", async ({ page }) => {
   const mock = createQueueMock(["first queued prompt", "second queued prompt", "third queued prompt"])
   const view = await openSession(page, mock)

--- a/packages/app/e2e/utils/mock-api.ts
+++ b/packages/app/e2e/utils/mock-api.ts
@@ -228,7 +228,8 @@ const Group = HttpApiGroup.make("mock")
   .add(
     HttpApiEndpoint.post("sessionInterrupt", "/api/session/:sessionID/interrupt", {
       params: SessionParams,
-      success: NoContent,
+      query: Schema.Struct({ continue: Schema.optional(Schema.String) }),
+      success: Json,
     }),
   )
   .add(

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -458,7 +458,7 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
         },
         sessionPermissionReply: () => noContent,
         sessionRename: () => noContent,
-        sessionInterrupt: () => noContent,
+        sessionInterrupt: () => Effect.succeed({ data: { interrupted: true } }),
         sessionRevertStage: (ctx) => {
           const payload = record(ctx.payload) ? ctx.payload : {}
           const messageID = payload.messageID

--- a/packages/app/src/composer/adapter.ts
+++ b/packages/app/src/composer/adapter.ts
@@ -94,7 +94,7 @@ type ComposerAdapterBase = {
 export type ActiveComposerAdapter = ComposerAdapterBase & {
   kind: "active-session"
   session: () => ComposerSession
-  interrupt: () => Promise<void>
+  interrupt: (options?: { continue?: boolean }) => Promise<void>
   setEditor: (element: HTMLDivElement) => void
 }
 

--- a/packages/app/src/composer/editor/editor.tsx
+++ b/packages/app/src/composer/editor/editor.tsx
@@ -304,6 +304,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
           </div>
           <div data-slot="composer-actions" class="flex shrink-0 items-center">
             <Show when={state.mode === "normal"}>
+              <ComposerEditorInterrupt controller={props.controller} />
               <ComposerEditorAlternateDelivery
                 controller={props.controller}
                 keybind={props.alternateKeybind ?? ["Mod", "Enter"]}
@@ -774,6 +775,30 @@ export function ComposerEditorPopover(props: {
         </For>
       </Show>
     </div>
+  )
+}
+
+function ComposerEditorInterrupt(props: { controller: ComposerEditorModel }) {
+  const i18n = useI18n()
+  const visible = () =>
+    props.controller.view.submit.working?.() &&
+    !props.controller.view.submit.queue?.editing() &&
+    props.controller.canSubmit()
+  return (
+    <Show when={visible()}>
+      <Tooltip placement="top" value={i18n.t("ui.promptInput.interruptHint")}>
+        <Button
+          data-action="composer-interrupt"
+          type="button"
+          variant="ghost-faint"
+          size="small"
+          class="me-3 px-1.5 ![font-weight:530]"
+          onClick={() => props.controller.submit({ interrupt: true })}
+        >
+          {i18n.t("ui.promptInput.interrupt")}
+        </Button>
+      </Tooltip>
+    </Show>
   )
 }
 

--- a/packages/app/src/composer/editor/interaction.ts
+++ b/packages/app/src/composer/editor/interaction.ts
@@ -41,7 +41,7 @@ export type ComposerEditorView = {
     stopping: Accessor<boolean>
     working?: Accessor<boolean>
     queue?: ComposerQueue
-    onSubmit: (options?: { alternate?: boolean }) => void
+    onSubmit: (options?: { alternate?: boolean; interrupt?: boolean }) => void
     onStop: () => void
   }
   shell?: {
@@ -366,7 +366,7 @@ export function createComposerEditor(input: {
     openShell() {
       dispatch({ type: "mode.shell" })
     },
-    submit(options?: { alternate?: boolean }) {
+    submit(options?: { alternate?: boolean; interrupt?: boolean }) {
       if (input.view.submit.available?.() === false) return
       if (input.view.draftOnly) return
       input.view.submit.onSubmit(options)

--- a/packages/app/src/composer/submit.test.ts
+++ b/packages/app/src/composer/submit.test.ts
@@ -405,6 +405,54 @@ describe("Composer submission", () => {
     expect(state.current()).toEqual([{ type: "text", content: "", start: 0, end: 0 }])
   })
 
+  test.each([
+    ["prompt", "change direction"],
+    ["command", "/review change direction"],
+  ] as const)("interrupts before steering without clearing subsequent edits: %s", async (kind, prompt) => {
+    const state = createMemoryComposerState({ prompt }).capture()
+    const calls: string[] = []
+    const interrupted = Promise.withResolvers<void>()
+    const admitted = Promise.withResolvers<{ text: string; delivery?: "queue" | "steer" | null }>()
+    const target = session({
+      calls,
+      prompt: async (value) => admitted.resolve(value),
+      command: async (value) => {
+        calls.push("command")
+        admitted.resolve(value)
+      },
+    })
+    const adapter: ActiveComposerAdapter = {
+      kind: "active-session",
+      state,
+      ready: () => true,
+      controls,
+      working: () => true,
+      session: () => target,
+      interrupt: async (options) => {
+        expect(options).toBeUndefined()
+        calls.push("interrupt")
+        await interrupted.promise
+      },
+      submitted() {},
+      setEditor() {},
+    }
+
+    const submitted = submitInput(adapter, undefined, "normal", () =>
+      kind === "command" ? [{ name: "review" }] : [],
+    ).submit(new Event("submit"), { interrupt: true })
+    await Promise.resolve()
+    expect(state.current()).toEqual([{ type: "text", content: "", start: 0, end: 0 }])
+    state.set([{ type: "text", content: "next thought", start: 0, end: 12 }])
+    interrupted.resolve()
+    await submitted
+    const request = await admitted.promise
+
+    expect(calls).toEqual(["interrupt", "switch-agent", "switch-model", kind])
+    expect(request.text).toBe("change direction")
+    expect(request.delivery).toBe("steer")
+    expect(state.current()).toEqual([{ type: "text", content: "next thought", start: 0, end: 12 }])
+  })
+
   test("starts and promotes a New Session once before admitting its first prompt", async () => {
     const draft = createMemoryComposerState({ prompt: "first prompt" }).capture()
     const promoted = createMemoryComposerState({ prompt: "restored draft" }).capture()

--- a/packages/app/src/composer/submit.ts
+++ b/packages/app/src/composer/submit.ts
@@ -50,7 +50,11 @@ type ComposerSubmitInput = {
 }
 
 export function createComposerSubmit(input: ComposerSubmitInput) {
-  const submit = async (event: globalThis.Event, options?: { alternate?: boolean }) => {
+  const stop = () =>
+    input.adapter.kind === "active-session"
+      ? input.adapter.interrupt({ continue: true }).catch(() => undefined)
+      : Promise.resolve()
+  const submit = async (event: globalThis.Event, options?: { alternate?: boolean; interrupt?: boolean }) => {
     event.preventDefault()
 
     const submission = createComposerSubmission({
@@ -63,7 +67,7 @@ export function createComposerSubmit(input: ComposerSubmitInput) {
     })
     const value = readSubmission(input, submission.prompt, submission.context, options?.alternate ?? false)
     if (!value) {
-      if (input.adapter.working() && input.adapter.kind === "active-session") void input.adapter.interrupt()
+      if (input.adapter.working()) void stop()
       return
     }
     if (submitting.has(input.adapter.state)) return
@@ -72,8 +76,22 @@ export function createComposerSubmit(input: ComposerSubmitInput) {
     // Capture command intent before starting a session in a worktree whose catalog has not loaded.
     const command = value.mode === "normal" ? findCommand(input.commands(), value.text) : undefined
     if (value.mode === "normal" && !command) value.prompt = withSlashSkill(value.prompt, input.skills())
+    const restore = () => restoreSubmission(input, submission, value, comments)
+    let cleared = false
 
     try {
+      if (options?.interrupt && input.adapter.kind === "active-session" && input.adapter.working()) {
+        value.delivery = "steer"
+        clearSubmission(input, submission)
+        cleared = true
+        try {
+          await input.adapter.interrupt()
+        } catch (error) {
+          input.notify.failed("prompt", error)
+          restore()
+          return
+        }
+      }
       const started =
         input.adapter.kind === "active-session"
           ? { session: input.adapter.session(), cleanupReady: Promise.resolve() }
@@ -83,7 +101,6 @@ export function createComposerSubmit(input: ComposerSubmitInput) {
 
       input.addToHistory(value.prompt, value.mode)
       input.resetHistory()
-      const restore = () => restoreSubmission(input, submission, value, comments)
 
       if (value.mode === "normal" && !command) {
         session.handoff?.set(handoffMessage(value))
@@ -104,7 +121,7 @@ export function createComposerSubmit(input: ComposerSubmitInput) {
           .filter((item) => !!item.comment?.trim())
           .forEach((item) => submission.target().context.remove(item.key))
         input.comments.clear()
-        clearSubmission(input, submission)
+        if (!cleared) clearSubmission(input, submission)
         void sending.then((result) => {
           if (!result.ok)
             failSubmission(input, session, "prompt", result.error, restore, value.id, () => {
@@ -119,13 +136,13 @@ export function createComposerSubmit(input: ComposerSubmitInput) {
       input.adapter.submitted()
 
       if (value.mode === "shell") {
-        clearSubmission(input, submission)
+        if (!cleared) clearSubmission(input, submission)
         void sendShell(session, value).catch((error) => failSubmission(input, session, "shell", error, restore))
         return
       }
 
       if (command) {
-        clearSubmission(input, submission)
+        if (!cleared) clearSubmission(input, submission)
         void sendCommand(session, value, command, input.adapter.controls().model.selection.trackSessionCommit).catch(
           (error) => failSubmission(input, session, "command", error, restore, value.id),
         )
@@ -138,7 +155,7 @@ export function createComposerSubmit(input: ComposerSubmitInput) {
 
   return {
     submit,
-    stop: () => (input.adapter.kind === "active-session" ? input.adapter.interrupt() : Promise.resolve()),
+    stop,
   }
 }
 

--- a/packages/app/src/session/composer/adapter.ts
+++ b/packages/app/src/session/composer/adapter.ts
@@ -35,11 +35,8 @@ export function createActiveComposerAdapter(input: {
       current: () => data.session.get(id),
       admitted: (messageID) => data.session.input.has(id, messageID) || !!data.session.message.get(id, messageID),
     }),
-    interrupt: () =>
-      server.api.session
-        .interrupt({ sessionID: id, continue: true })
-        .then(() => undefined)
-        .catch(() => undefined),
+    interrupt: (options) =>
+      server.api.session.interrupt({ sessionID: id, continue: options?.continue }).then(() => undefined),
   }
   return adapter
 }

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -456,6 +456,19 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Interrupt with prompt",
+        name: "prompt.break",
+        category: "Prompt",
+        enabled: status() === "running",
+        run: async (_input: string | undefined, event?: KeyEvent) => {
+          event?.preventDefault()
+          event?.stopPropagation()
+          const handled = await submit("steer", true)
+          if (!handled) return
+          dialog.clear()
+        },
+      },
+      {
         title: "Remove editor context",
         name: "prompt.editor_context.clear",
         category: "Prompt",
@@ -652,6 +665,7 @@ export function Prompt(props: PromptProps) {
     enabled: !disabled(),
     bindings: [
       "prompt.submit",
+      "prompt.break",
       "prompt.editor",
       "prompt.editor_context.clear",
       "prompt.images.view",
@@ -1083,7 +1097,7 @@ export function Prompt(props: PromptProps) {
   })
 
   let submitting = false
-  async function submit(delivery: SessionInbox.Delivery = "steer") {
+  async function submit(delivery: SessionInbox.Delivery = "steer", interrupt = false) {
     if (disabled()) return false
     // Prevent overlapping invocations (e.g. a double-pressed Enter, or the
     // input's native onSubmit racing another dispatch). Without this guard,
@@ -1094,13 +1108,13 @@ export function Prompt(props: PromptProps) {
     if (submitting) return false
     submitting = true
     try {
-      return await submitInner(delivery)
+      return await submitInner(delivery, interrupt)
     } finally {
       submitting = false
     }
   }
 
-  async function submitInner(delivery: SessionInbox.Delivery) {
+  async function submitInner(delivery: SessionInbox.Delivery, interrupt: boolean) {
     // IME: double-defer may fire before onContentChange flushes the last
     // composed character (e.g. Korean hangul) to the store, so read
     // plainText directly and sync before any downstream reads.
@@ -1111,12 +1125,12 @@ export function Prompt(props: PromptProps) {
     if (move.creating()) return false
     if (auto()?.visible) return false
     const trimmed = store.prompt.text.trim()
-    if (!trimmed) return delivery === "steer" ? (await props.onEmptySubmit?.()) === true : false
+    if (!trimmed) return !interrupt && delivery === "steer" ? (await props.onEmptySubmit?.()) === true : false
     if (
-      delivery === "queue" &&
+      (delivery === "queue" || interrupt) &&
       (store.mode === "shell" || trimmed === "exit" || trimmed === "quit" || trimmed === ":q")
     ) {
-      toast.show({ message: "This prompt cannot be queued", variant: "warning" })
+      toast.show({ message: `This prompt cannot be ${interrupt ? "used to interrupt" : "queued"}`, variant: "warning" })
       return false
     }
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
@@ -1125,8 +1139,11 @@ export function Prompt(props: PromptProps) {
     }
     const slash = argumentSlash(store.prompt.text, keymapCommands())
     if (slash) {
-      if (delivery === "queue") {
-        toast.show({ message: "This prompt cannot be queued", variant: "warning" })
+      if (delivery === "queue" || interrupt) {
+        toast.show({
+          message: `This prompt cannot be ${interrupt ? "used to interrupt" : "queued"}`,
+          variant: "warning",
+        })
         return false
       }
       clearPrompt()
@@ -1153,6 +1170,10 @@ export function Prompt(props: PromptProps) {
     const isCommand =
       slashHead !== undefined &&
       (data.location.command.list(currentLocation.ref) ?? []).some((command) => command.name === slashHead.name)
+    if (interrupt && (isSkill || isCommand)) {
+      toast.show({ message: "Commands cannot interrupt a session", variant: "warning" })
+      return false
+    }
     if (delivery === "queue" && isSkill) {
       toast.show({ message: "Skills cannot be queued", variant: "warning" })
       return false
@@ -1362,6 +1383,17 @@ export function Prompt(props: PromptProps) {
       // and rolls back if the server rejects it, so submission does not wait
       // on the network. On rejection the row is already rolled back; restore
       // the composer unless the user has started typing something new.
+      if (interrupt) {
+        const error = await client.api.session.interrupt({ sessionID: target }).then(
+          () => undefined,
+          (error) => error,
+        )
+        if (error) {
+          toast.show({ title: "Failed to interrupt session", message: errorMessage(error), variant: "error" })
+          restoreEntry()
+          return false
+        }
+      }
       data.session
         .prompt({
           sessionID: target,

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -190,6 +190,7 @@ export const Definitions = {
   "session.toggle.thinking": keybind("none", "Toggle thinking blocks visibility"),
 
   "prompt.submit": keybind("none", "Submit prompt"),
+  "prompt.break": keybind("none", "Interrupt with prompt"),
   "prompt.queue": keybind("<leader>return", "Queue prompt"),
   "prompt.editor_context.clear": keybind("none", "Clear editor context"),
   "prompt.images.view": keybind("<leader>i", "View image attachments"),

--- a/packages/tui/test/prompt-break.test.tsx
+++ b/packages/tui/test/prompt-break.test.tsx
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { InputRenderable } from "@opentui/core"
+import { createAppFixture } from "./fixture/app"
+import { directory, json } from "./fixture/tui-client"
+
+test("interrupts before steering the prompt", async () => {
+  const session = {
+    id: "ses_break",
+    projectID: "proj_test",
+    title: "Break fixture",
+    agent: "build",
+    model: { providerID: "provider", id: "model" },
+    location: { directory },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 0, updated: 0 },
+  }
+  const interrupted = Promise.withResolvers<Response>()
+  const requests: { path: string; body?: unknown }[] = []
+  await using setup = await createAppFixture({
+    args: { sessionID: session.id },
+    config: { animations: false },
+    fetch: async (url, request) => {
+      if (url.pathname === "/api/session/active") return json({ data: { [session.id]: { type: "running" } } })
+      if (url.pathname === `/api/session/${session.id}`) return json({ data: session })
+      if (/^\/api\/session\/[^/]+\/(message|inbox|permission)$/.test(url.pathname))
+        return json({ data: [], cursor: {} })
+      if (url.pathname === "/api/agent")
+        return json({
+          location: { directory },
+          data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }],
+        })
+      if (url.pathname === "/api/provider")
+        return json({ location: { directory }, data: [{ id: "provider", name: "Provider" }] })
+      if (url.pathname === "/api/model")
+        return json({
+          location: { directory },
+          data: [{ id: "model", providerID: "provider", name: "Model", variants: [], cost: [], time: { released: 0 } }],
+        })
+      if (url.pathname === `/api/session/${session.id}/prompt`) {
+        requests.push({ path: url.pathname, body: await request.json() })
+        return json({ data: { id: "msg_break" } })
+      }
+      if (url.pathname === `/api/session/${session.id}/interrupt`) {
+        requests.push({ path: url.pathname })
+        return interrupted.promise
+      }
+      return undefined
+    },
+  })
+
+  try {
+    await setup.ready
+    await setup.waitForFrame((frame) => frame.includes("Build · Model Provider"))
+    await setup.mockInput.typeText("change direction")
+    setup.mockInput.pressKey("p", { ctrl: true })
+    await setup.waitFor(() => setup.renderer.currentFocusedEditor instanceof InputRenderable)
+    await setup.mockInput.typeText("interrupt with prompt")
+    await setup.waitForFrame((frame) => frame.includes("Interrupt with prompt"))
+    setup.mockInput.pressEnter()
+    await setup.waitFor(() => requests.length === 1)
+    expect(requests[0]).toEqual({ path: `/api/session/${session.id}/interrupt` })
+
+    interrupted.resolve(json({ data: true }))
+    await setup.waitFor(() => requests.length === 2)
+    expect(requests[1]).toMatchObject({
+      path: `/api/session/${session.id}/prompt`,
+      body: { text: "change direction", delivery: "steer" },
+    })
+  } finally {
+    interrupted.resolve(json({ data: true }))
+  }
+})

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -164,6 +164,8 @@ const source = {
   "ui.promptInput.steer": "Steer",
   "ui.promptInput.queue": "Queue",
   "ui.promptInput.steerHint": "Send without interrupting",
+  "ui.promptInput.interrupt": "Interrupt",
+  "ui.promptInput.interruptHint": "Stop the current response and send now",
 
   "ui.tabs.close": "Close tab",
 


### PR DESCRIPTION
### Issue for this PR

Closes #32157

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds one-step interrupt-and-steer actions to the TUI and app. They stop the active response before sending the correction through the existing prompt path.

### How did you verify your code works?

- Typechecks and focused prompt/composer tests
- Core interrupt-continuation tests
- V2 build and live TUI stream abort
- App E2E asserting interrupt-before-prompt ordering

### Screenshots / recordings

| Before | After |
| --- | --- |
| ![Active response with a correction ready to interrupt](https://github.com/user-attachments/assets/476ada2f-c16c-4c8c-aba6-fefe45be303b) | ![Correction admitted after interrupting the active response](https://github.com/user-attachments/assets/7cdd0264-f722-4cbb-bbe3-647ec63c21c7) |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
