### PR TITLE
fix(core): keep a refused inotify instance from wedging the process

### DIFF
--- a/packages/core/src/filesystem/watcher-inotify.ts
+++ b/packages/core/src/filesystem/watcher-inotify.ts
@@ -1,0 +1,76 @@
+export * as WatcherInotify from "./watcher-inotify"
+
+import { dlopen, FFIType, read } from "bun:ffi"
+import os from "os"
+import { lazy } from "../util/lazy"
+
+declare const OPENCODE_LIBC: string | undefined
+
+// The flags @parcel/watcher's InotifyBackend passes to inotify_init1. Probing
+// with any other flags would not prove that the real call can succeed.
+const IN_NONBLOCK = 0o4000
+const IN_CLOEXEC = 0o2000000
+
+export interface ProbeFailure {
+  readonly errno: number
+  readonly code: string
+}
+
+const errnoCodes = Object.entries(os.constants.errno)
+
+const libc = lazy(() => {
+  const musl = `libc.musl-${process.arch === "arm64" ? "aarch64" : "x86_64"}.so.1`
+  const glibc = "libc.so.6"
+  const preferred = (typeof OPENCODE_LIBC === "undefined" ? undefined : OPENCODE_LIBC) === "musl" ? musl : glibc
+  for (const candidate of [preferred, preferred === musl ? glibc : musl, "libc.so"]) {
+    try {
+      return dlopen(candidate, {
+        inotify_init1: { args: [FFIType.i32], returns: FFIType.i32 },
+        close: { args: [FFIType.i32], returns: FFIType.i32 },
+        __errno_location: { args: [], returns: FFIType.ptr },
+      }).symbols
+    } catch {
+      continue
+    }
+  }
+  return
+})
+
+/**
+ * Ask the kernel for one inotify instance and immediately give it back.
+ *
+ * `@parcel/watcher` builds its shared inotify backend inside the synchronous
+ * constructor of the N-API `SubscribeRunner`, on whichever thread called
+ * `subscribe()`. When `inotify_init1` fails there, `InotifyBackend::start()`
+ * throws before `notifyStarted()`, and `Backend::handleError()` only notifies
+ * already-registered watchers - so `Backend::run()` keeps waiting on
+ * `mStartedSignal` and the calling thread never returns. For opencode that
+ * thread is the JS main thread, which parks the event loop permanently: no
+ * timer, no fiber and no interrupt can run afterwards, which is why the failure
+ * produced neither a log line nor an abortable turn.
+ *
+ * Returning the errno instead of a boolean keeps the caller honest: EMFILE can
+ * mean either the per-process descriptor limit or the per-uid
+ * `fs.inotify.max_user_instances` ceiling, and this cannot tell them apart.
+ *
+ * Returns `undefined` when an instance is obtainable, or when the probe itself
+ * cannot run (no `bun:ffi`, no libc, missing symbols). An unprobeable runtime
+ * keeps the pre-existing behaviour rather than silently losing file watching.
+ */
+export function probe(): ProbeFailure | undefined {
+  const symbols = libc()
+  if (!symbols) return
+
+  const fd = symbols.inotify_init1(IN_NONBLOCK | IN_CLOEXEC)
+  if (fd !== -1) {
+    symbols.close(fd)
+    return
+  }
+
+  // errno is thread-local and is clobbered by the next failing libc call, so it
+  // has to be read before anything else happens on this thread.
+  const location = symbols.__errno_location()
+  const errno = location ? read.i32(location) : 0
+  const code = errnoCodes.find(([, value]) => value === errno)
+  return { errno, code: code ? code[0] : "UNKNOWN" }
+}

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -16,6 +16,7 @@ import { Location } from "../location"
 import { lazy } from "../util/lazy"
 import { Ignore } from "./ignore"
 import { Protected } from "./protected"
+import type { ProbeFailure } from "./watcher-inotify"
 
 declare const OPENCODE_LIBC: string | undefined
 
@@ -54,87 +55,138 @@ export interface Interface {}
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/FileWatcher") {}
 
-const layer = Layer.effect(
-  Service,
-  Effect.gen(function* () {
-    if (yield* Flag.OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER) return Service.of({})
+export interface LayerOptions {
+  readonly backend?: ReturnType<typeof getBackend>
+  readonly watcher?: () => Pick<typeof import("@parcel/watcher"), "subscribe"> | undefined
+  readonly probe?: () => ProbeFailure | undefined
+}
 
-    const backend = getBackend()
-    const location = yield* Location.Service
-    if (!backend) {
-      yield* Effect.logError("watcher backend not supported", {
-        directory: location.directory,
-        platform: process.platform,
-      })
-      return Service.of({})
-    }
-
-    const w = watcher()
-    if (!w) return Service.of({})
-
-    yield* Effect.logInfo("watcher backend", { directory: location.directory, platform: process.platform, backend })
-    const events = yield* EventV2.Service
-    const fs = yield* FSUtil.Service
-    const git = yield* Git.Service
-    const context = yield* Effect.context()
-    const runFork = Effect.runForkWith(context)
-    const subscriptions: ParcelWatcher.AsyncSubscription[] = []
-    yield* Effect.addFinalizer(() =>
-      Effect.promise(() => Promise.allSettled(subscriptions.map((subscription) => subscription.unsubscribe()))),
-    )
-
-    const callback: ParcelWatcher.SubscribeCallback = (_error, updates) => {
-      for (const update of updates) {
-        if (update.type === "create") runFork(events.publish(Event.Updated, { file: update.path, event: "add" }))
-        if (update.type === "update") runFork(events.publish(Event.Updated, { file: update.path, event: "change" }))
-        if (update.type === "delete") runFork(events.publish(Event.Updated, { file: update.path, event: "unlink" }))
-      }
-    }
-
-    const subscribe = (directory: string, ignore: string[]) => {
-      const pending = w.subscribe(directory, callback, { ignore, backend })
-      return Effect.promise(() => pending).pipe(
-        Effect.tap((subscription) => Effect.sync(() => subscriptions.push(subscription))),
-        Effect.timeout(SUBSCRIBE_TIMEOUT_MS),
-        Effect.catchCause((cause) => {
-          pending.then((subscription) => subscription.unsubscribe()).catch(() => {})
-          return Effect.logError("failed to subscribe", { directory, cause: Cause.pretty(cause) })
-        }),
-      )
-    }
-
-    const config = (yield* (yield* Config.Service).entries())
-      .filter((entry): entry is Config.Document => entry.type === "document")
-      .flatMap((item) => item.info.watcher?.ignore ?? [])
-    if (location.vcs && (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER)) {
-      yield* Effect.forkScoped(
-        subscribe(location.directory, [...Ignore.PATTERNS, ...config, ...protecteds(location.directory)]),
-      )
-    }
-
-    if (location.vcs?.type === "git") {
-      const resolved = (yield* git.repo.discover(location.directory))?.gitDirectory
-      const vcs = resolved ? yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved))) : undefined
-      if (vcs && !config.includes(".git") && !config.includes(vcs) && (!resolved || !config.includes(resolved))) {
-        const ignore = (yield* fs.readDirectoryEntries(vcs).pipe(Effect.catch(() => Effect.succeed([])))).flatMap(
-          (entry) => (entry.name === "HEAD" ? [] : [entry.name]),
-        )
-        yield* Effect.forkScoped(subscribe(vcs, ignore))
-      }
-    }
-
-    return Service.of({})
-  }).pipe(
-    Effect.catchCause((cause) => {
-      return Effect.logError("failed to init watcher service", { cause: Cause.pretty(cause) }).pipe(
-        Effect.as(Service.of({})),
-      )
-    }),
-  ),
+// Loaded only on the inotify branch: the helper depends on bun:ffi, so a
+// runtime without it keeps the pre-existing behaviour rather than losing file
+// watching altogether.
+const loadProbe = Effect.promise(() => import("./watcher-inotify")).pipe(
+  Effect.map((module) => module.probe),
+  Effect.catchCause(() => Effect.succeed(undefined)),
 )
 
-export const node = makeLocationNode({
-  service: Service,
-  layer,
-  deps: [FSUtil.node, Location.node, Config.node, Git.node, EventV2.node],
-})
+export const layerWith = (options?: LayerOptions) =>
+  Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      if (yield* Flag.OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER) return Service.of({})
+
+      const backend = options?.backend ?? getBackend()
+      const location = yield* Location.Service
+      if (!backend) {
+        yield* Effect.logError("watcher backend not supported", {
+          directory: location.directory,
+          platform: process.platform,
+        })
+        return Service.of({})
+      }
+
+      const w = (options?.watcher ?? watcher)()
+      if (!w) return Service.of({})
+
+      const probe = options?.probe ?? (backend === "inotify" ? yield* loadProbe : undefined)
+
+      yield* Effect.logInfo("watcher backend", { directory: location.directory, platform: process.platform, backend })
+      const events = yield* EventV2.Service
+      const fs = yield* FSUtil.Service
+      const git = yield* Git.Service
+      const context = yield* Effect.context()
+      const runFork = Effect.runForkWith(context)
+      const subscriptions: ParcelWatcher.AsyncSubscription[] = []
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => Promise.allSettled(subscriptions.map((subscription) => subscription.unsubscribe()))),
+      )
+
+      const callback: ParcelWatcher.SubscribeCallback = (_error, updates) => {
+        for (const update of updates) {
+          if (update.type === "create") runFork(events.publish(Event.Updated, { file: update.path, event: "add" }))
+          if (update.type === "update") runFork(events.publish(Event.Updated, { file: update.path, event: "change" }))
+          if (update.type === "delete") runFork(events.publish(Event.Updated, { file: update.path, event: "unlink" }))
+        }
+      }
+
+      const subscribe = (directory: string, ignore: string[]) =>
+        Effect.gen(function* () {
+          const started = yield* Effect.sync(() => {
+            const failure = probe?.()
+            if (failure) return { type: "unavailable" as const, failure }
+            // Nothing may run between the probe and this call. subscribe()
+            // reaches the native backend synchronously on the calling thread,
+            // and a kernel that refuses an inotify instance there parks that
+            // thread forever instead of failing, so the window in which another
+            // process can take the last instance stays one expression wide.
+            return { type: "started" as const, pending: w.subscribe(directory, callback, { ignore, backend }) }
+          })
+
+          if (started.type === "unavailable") {
+            yield* Effect.logWarning("watcher unavailable, continuing without it", {
+              directory,
+              backend,
+              errno: started.failure.errno,
+              code: started.failure.code,
+            })
+            return false
+          }
+
+          yield* Effect.forkScoped(
+            Effect.promise(() => started.pending).pipe(
+              Effect.tap((subscription) => Effect.sync(() => subscriptions.push(subscription))),
+              Effect.timeout(SUBSCRIBE_TIMEOUT_MS),
+              Effect.catchCause((cause) => {
+                started.pending.then((subscription) => subscription.unsubscribe()).catch(() => {})
+                return Effect.logError("failed to subscribe", { directory, cause: Cause.pretty(cause) })
+              }),
+            ),
+          )
+          return true
+        })
+
+      const config = (yield* (yield* Config.Service).entries())
+        .filter((entry): entry is Config.Document => entry.type === "document")
+        .flatMap((item) => item.info.watcher?.ignore ?? [])
+      if (location.vcs && (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER)) {
+        const subscribed = yield* subscribe(location.directory, [
+          ...Ignore.PATTERNS,
+          ...config,
+          ...protecteds(location.directory),
+        ])
+        // The .git watcher below would ask the same exhausted kernel for the
+        // same resource, so there is nothing left to try.
+        if (!subscribed) return Service.of({})
+      }
+
+      if (location.vcs?.type === "git") {
+        const resolved = (yield* git.repo.discover(location.directory))?.gitDirectory
+        const vcs = resolved
+          ? yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved)))
+          : undefined
+        if (vcs && !config.includes(".git") && !config.includes(vcs) && (!resolved || !config.includes(resolved))) {
+          const ignore = (yield* fs.readDirectoryEntries(vcs).pipe(Effect.catch(() => Effect.succeed([])))).flatMap(
+            (entry) => (entry.name === "HEAD" ? [] : [entry.name]),
+          )
+          yield* subscribe(vcs, ignore)
+        }
+      }
+
+      return Service.of({})
+    }).pipe(
+      Effect.catchCause((cause) => {
+        return Effect.logError("failed to init watcher service", { cause: Cause.pretty(cause) }).pipe(
+          Effect.as(Service.of({})),
+        )
+      }),
+    ),
+  )
+
+export const nodeWith = (options?: LayerOptions) =>
+  makeLocationNode({
+    service: Service,
+    layer: layerWith(options),
+    deps: [FSUtil.node, Location.node, Config.node, Git.node, EventV2.node],
+  })
+
+export const node = nodeWith()

--- a/packages/core/test/filesystem/watcher-preflight.test.ts
+++ b/packages/core/test/filesystem/watcher-preflight.test.ts
@@ -1,0 +1,124 @@
+import { $ } from "bun"
+import { describe, expect } from "bun:test"
+import os from "os"
+import path from "path"
+import { ConfigProvider, Effect, Layer, Logger } from "effect"
+import { Config } from "@opencode-ai/core/config"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { EventV2 } from "@opencode-ai/core/event"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { Location } from "@opencode-ai/core/location"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { location } from "../fixture/location"
+import { tmpdir } from "../fixture/tmpdir"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([FSUtil.node, EventV2.node])))
+
+const configLayer = Layer.succeed(
+  Config.Service,
+  Config.Service.of({
+    entries: () => Effect.succeed([]),
+  }),
+)
+
+const flagsLayer = ConfigProvider.layer(
+  ConfigProvider.fromUnknown({
+    OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
+    OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "false",
+  }),
+)
+
+const WARNING = "watcher unavailable, continuing without it"
+
+// Builds the watcher against a real git directory with the native binding
+// faked, so the only thing under test is what the preflight decides. The
+// backend is pinned to inotify because that is the only platform where the
+// kernel can refuse the resource.
+function build(probe: () => ReturnType<NonNullable<Watcher.LayerOptions["probe"]>>) {
+  return Effect.gen(function* () {
+    const tmp = yield* Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    )
+    yield* Effect.promise(() => $`git init`.cwd(tmp.path).quiet())
+
+    const messages: unknown[] = []
+    const directories: string[] = []
+
+    yield* Effect.asVoid(Watcher.Service).pipe(
+      Effect.provide(
+        AppNodeBuilder.build(
+          Watcher.nodeWith({
+            backend: "inotify",
+            probe,
+            watcher: () => ({
+              subscribe: async (directory: string) => {
+                directories.push(directory)
+                return { unsubscribe: async () => {} }
+              },
+            }),
+          }),
+          [
+            [Config.node, configLayer],
+            [
+              Location.node,
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(
+                  location(
+                    { directory: AbsolutePath.make(tmp.path) },
+                    { vcs: { type: "git", store: AbsolutePath.make(path.join(tmp.path, ".git")) } },
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ).pipe(Layer.provide(flagsLayer)),
+      ),
+      Effect.provide(
+        Logger.layer([
+          Logger.make<unknown, void>((options) => {
+            messages.push(options.message)
+          }),
+        ]),
+      ),
+      Effect.scoped,
+    )
+
+    return { messages, directories }
+  })
+}
+
+describe("Watcher preflight", () => {
+  it.live("degrades to no watcher when the kernel refuses an inotify instance", () =>
+    Effect.gen(function* () {
+      const result = yield* build(() => ({ errno: os.constants.errno.EMFILE, code: "EMFILE" }))
+
+      // Reaching any assertion at all is the regression: the layer settled
+      // instead of parking the thread that asked for the instance.
+      expect(result.directories).toEqual([])
+      expect(result.messages.filter((item) => Array.isArray(item) && item[0] === WARNING)).toEqual([
+        [
+          WARNING,
+          expect.objectContaining({
+            backend: "inotify",
+            errno: os.constants.errno.EMFILE,
+            code: "EMFILE",
+          }),
+        ],
+      ])
+    }),
+  )
+
+  it.live("subscribes as usual when an inotify instance is available", () =>
+    Effect.gen(function* () {
+      const result = yield* build(() => undefined)
+
+      expect(result.directories.length).toBeGreaterThan(0)
+      expect(result.messages.filter((item) => Array.isArray(item) && item[0] === WARNING)).toEqual([])
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #16610

Same deadlock as the still-open #37111, but this only fixes one of its two triggers - see the end of the description.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

You open opencode in a git repo, type a prompt, press Enter - and nothing happens, forever. No error, no toast, nothing in the log, and Esc-Esc won't cancel it. Menus and the model picker still respond, so it doesn't look broken, it looks like the model is thinking. Restarting doesn't help and a fresh session does the same. #16610 hit this a few releases back as a blank screen at startup; today the UI paints fine and the prompt simply never starts a turn.

The trigger is the machine being out of inotify instances. `fs.inotify.max_user_instances` is a per-uid ceiling, 1024 by default, shared with every other program you run, and raising it needs root. On the machine I found this on, 954 of the 1024 were held by a herd of orphaned KDE `kbuildsycoca6` processes - nothing to do with opencode, but opencode is what broke.

Under that pressure `inotify_init1` fails inside `@parcel/watcher`'s `subscribe()`, which builds its shared backend in a synchronous N-API constructor on the calling thread - for us the JS main thread. `InotifyBackend::start()` throws before `notifyStarted()`, and `Backend::handleError()` only notifies watchers that are already registered, so `Backend::run()` waits on `mStartedSignal` and never returns. That parks the event loop rather than one fiber, which is why the `Effect.timeout(SUBSCRIBE_TIMEOUT_MS)` and `Effect.catchCause` already wrapped around the subscription never fired and nothing reached the log: once the main thread stops returning to the loop, no timer, fiber or signal handler runs again. Only directories under version control are affected, because that is the only branch that reaches `subscribe()`.

The fix is to ask the kernel for one inotify instance, hand it straight back, and call `subscribe()` only if that worked. The probe and the call sit in one synchronous thunk with nothing in between, so the window where another process takes the last instance is one expression wide. That window is not closed and I'm not claiming otherwise - only fixing `@parcel/watcher`, or owning the watcher in a killable subprocess, removes the race. What goes away is the permanent silent wedge: a refusal now logs `watcher unavailable, continuing without it` with the errno, and the session continues without file watching. EMFILE doesn't say whether it was the per-process descriptor limit or the per-uid inotify ceiling, so the errno is logged as-is rather than interpreted. The probe needs `bun:ffi`, so it is imported only on the inotify branch and only if that import succeeds; a runtime without it keeps the current behaviour instead of silently losing file watching.

What this does **not** fix: #37111's other trigger, several concurrent subscribes deadlocking while instances are still available. The probe succeeds there and the deadlock still happens.

### How did you verify your code works?

Three levels, each under real inotify exhaustion on Linux against the real `@parcel/watcher-linux-x64-glibc`: the native boundary, a whole turn from source, and a whole turn in a compiled binary.

**1. Native boundary.** Holding inotify instances open until `inotify_init1` returned EMFILE:

```
1. probe, no pressure      -> undefined            (an instance is obtainable)
   pressure: 841 instances held, stopped on errno=24 EMFILE
2. probe under pressure    -> {"errno":24,"code":"EMFILE"}
3. subscribe() UNGUARDED   -> printed "calling subscribe()", never reached the next line
                              killed at 20s, exit 137
4. subscribe() GUARDED     -> logged the warning, exit 0, 0s
5. probe after release     -> undefined
```

Step 3 is the bug in two lines: the statement after `subscribe()` never executes.

**2. Whole turn, from source.** Throwaway Ubuntu 24.04 VM (glibc 2.39, `max_user_instances` 128, 124 held until EMFILE). `bun run ./src/index.ts run --pure 'say ok'` in a fresh git repo, against a local OpenAI-compatible mock so a turn can complete without credentials. Same host, same pressure, same command; the only variable is this patch. Two runs each way, both reproduced:

| Tree | Exit | Elapsed | Model replied | Watcher log |
|---|---|---|---|---|
| this PR | 0 | 7s / 8s | yes | `WARN watcher unavailable, continuing without it ... backend=inotify errno=24 code=EMFILE` |
| `dev` unpatched | 137 (SIGKILL) | 120s, never returned | no | `INFO watcher backend`, then silence |

**3. Whole turn, compiled.** Running from source does not cover `bun build --compile`, and a failure there would be invisible: if the probe's `bun:ffi` import could not load, that failure is swallowed by design, leaving no probe and no message. Throwaway Arch VM (kernel 7.2.3, glibc 2.44, `max_user_instances` 1024, 1020 held until EMFILE). Arch packages opencode, so `opencode-bin` supplies a binary built by the distro package maintainer, and `script/build.ts --single` supplies patched and unpatched binaries built identically to each other:

| Binary | Exit | Model replied | Watcher log |
|---|---|---|---|
| packaged `opencode-bin` 1.18.30 | 137 at 120s | no | `INFO watcher backend`, then silence |
| self-compiled, this PR | 0 in 5s | yes | `WARN watcher unavailable ... errno=24 code=EMFILE` |
| self-compiled, unpatched | 137 at 120s | no | `INFO watcher backend`, then silence |

Unpressured, all three complete the turn normally. So the defect is present in a released binary, the fix works inside `bun build --compile` output, and the difference is this patch rather than the build method - the last two binaries came from the same command on the same host minutes apart.

In every wedged run above, the last log line is `project copy refresh started`, which is also the last line produced on the machine where this was originally found - so these reproduce the original failure rather than merely resembling it.

**Reproducing it yourself** needs no root, because the ceiling is per-uid: open inotify instances as your own user until `inotify_init1` returns EMFILE, then run opencode in any git directory. Before this patch the turn never starts; after it you get the warning and a working session with no file watching.

**Tests and gates.** `packages/core/test/filesystem/watcher-preflight.test.ts` is new, and fails with the preflight removed because the watcher then subscribes to both the root and `.git` and logs no warning. `bun test test/filesystem` in `packages/core` is 38 pass on macOS; on Linux `watcher.test.ts` plus the new `watcher-preflight.test.ts` are 8 pass, which is the first time the six pre-existing watcher tests have run against the real inotify backend rather than macOS fs-events. The repo's pre-push `turbo typecheck` is 30/30.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
