### PR TITLE
fix(tui): use main-font glyph for inactive scanner cells

### DIFF
--- a/packages/tui/src/ui/spinner.ts
+++ b/packages/tui/src/ui/spinner.ts
@@ -321,7 +321,7 @@ export function createFrames(options: KnightRiderOptions = {}): string[] {
       // Default to blocks
       // It's active if we have a valid color index that is within our colors array
       const isActive = index >= 0 && index < trailOptions.colors.length
-      return isActive ? "■" : "⬝"
+      return isActive ? "■" : "·"
     }).join("")
   })
 

--- a/packages/tui/test/ui/spinner.test.ts
+++ b/packages/tui/test/ui/spinner.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { createColors, createFrames } from "../../src/ui/spinner"
+
+const ACTIVE = "■"
+const INACTIVE = "·"
+
+describe("createFrames blocks style", () => {
+  const frames = createFrames({ color: "#4682dc", style: "blocks", inactiveFactor: 0.6, minAlpha: 0.3 })
+
+  test("only uses glyphs that are present in common terminal fonts", () => {
+    const glyphs = new Set(frames.flatMap((frame) => [...frame]))
+    expect(glyphs).toEqual(new Set([ACTIVE, INACTIVE]))
+    expect(glyphs.has("\u2b1d")).toBe(false)
+  })
+
+  test("keeps every frame eight cells wide", () => {
+    expect(frames).toHaveLength(54)
+    for (const frame of frames) expect([...frame]).toHaveLength(8)
+  })
+
+  test("starts at the left edge", () => {
+    expect(frames[0]).toBe(ACTIVE + INACTIVE.repeat(7))
+  })
+
+  test("moves the head and trail to the right", () => {
+    expect(frames[1]).toBe(ACTIVE.repeat(2) + INACTIVE.repeat(6))
+    expect(frames[5]).toBe(ACTIVE.repeat(6) + INACTIVE.repeat(2))
+  })
+
+  test("provides a per-cell color generator", () => {
+    const color = createColors({ color: "#4682dc", style: "blocks", inactiveFactor: 0.6, minAlpha: 0.3 })
+    expect(typeof color).toBe("function")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #48378

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The blocks-style Knight Rider scanner in the prompt footer renders inactive cells with `⬝` (U+2B1D). That codepoint is missing from common terminal monospace fonts (Noto Sans Mono, DejaVu Sans Mono, Fira Mono, Liberation Mono, Nimbus Mono PS), so it is shaped from a fallback face such as FreeMono or FreeSans. cosmic-text lays fallback glyphs out with advances that are not snapped to the monospace cell width (pop-os/cosmic-text#503, pop-os/cosmic-text#507), so the colorized, rapidly redrawn scanner jitters and leaves streaks in COSMIC Terminal (pop-os/cosmic-term#785).

This changes only the inactive glyph to `·` (U+00B7), which is present in every font that provides the active `■` (U+25A0) and is already used for inactive cells by the `diamonds` style in the same function. Both scanner glyphs then come from the main font, so the animation no longer triggers the fallback-width bug. This is a compatibility workaround; the root fix is in cosmic-text.

### How did you verify your code works?

- `bun test test/ui/spinner.test.ts` (new) in `packages/tui`: 5 pass
- `bun test` in `packages/tui`: 198 pass, 1 skip, 0 fail
- `bun run typecheck` in `packages/tui`: clean
- `bun test test/cli/run/footer.view.test.tsx` in `packages/opencode`: 23 pass, 5 skip, 0 fail
- Manual check in COSMIC Terminal 1.8.0 (Pop!_OS 24.04, Wayland, Noto Sans Mono): the TUI was started from this branch with `bun dev` during active turns; the scanner no longer streaks. The standalone script from #48378 streaks with the stock 1.18.30 build and is clean after the change.

### Screenshots / recordings

Not attached: the artifact only appears while the animation is running. The reproduction script and manual COSMIC check are described in #48378.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
