### PR TITLE
fix(codemode): use Bun's wording for the missing atob/btoa argument

### DIFF
--- a/packages/codemode/src/stdlib/web.ts
+++ b/packages/codemode/src/stdlib/web.ts
@@ -5,9 +5,8 @@ import { coerceToString } from "./value.js"
 // WebIDL DOMString conversion: a missing argument is a TypeError, anything else stringifies.
 const base64 = (name: "atob" | "btoa") =>
   sync(name, (args, node) => {
-    if (args.length === 0) {
-      throw new InterpreterRuntimeError(`${name} requires 1 argument, but only 0 were provided.`, node).as("TypeError")
-    }
+    if (args.length === 0)
+      throw new InterpreterRuntimeError(`${name} requires a string argument.`, node).as("TypeError")
     const input = coerceToString(args[0])
     try {
       return name === "atob" ? atob(input) : btoa(input)

--- a/packages/codemode/src/stdlib/web.ts
+++ b/packages/codemode/src/stdlib/web.ts
@@ -6,7 +6,7 @@ import { coerceToString } from "./value.js"
 const base64 = (name: "atob" | "btoa") =>
   sync(name, (args, node) => {
     if (args.length === 0)
-      throw new InterpreterRuntimeError(`${name} requires a string argument.`, node).as("TypeError")
+      throw new InterpreterRuntimeError(`${name} requires 1 argument (a string)`, node).as("TypeError")
     const input = coerceToString(args[0])
     try {
       return name === "atob" ? atob(input) : btoa(input)


### PR DESCRIPTION
## Summary

`atob()` with no argument said `atob requires 1 argument, but only 0 were provided.` — the browser's WebIDL phrasing, which reads awkwardly. Runtimes differ here:

| Runtime | Message |
|---|---|
| Browsers | `1 argument required, but only 0 present.` |
| Bun | `atob requires 1 argument (a string)` |
| Node | `The "input" argument must be specified` |

We run on Bun and its message also says what to pass, so use that:

```text
atob requires 1 argument (a string)
```

Still a `TypeError`. `test/web-wpt.test.ts` asserts the error name, not the message, so it passes unchanged.