### PR TITLE
docs(zh): add policies translation

### DIFF
--- a/packages/web/src/content/docs/zh-cn/policies.mdx
+++ b/packages/web/src/content/docs/zh-cn/policies.mdx
@@ -1,0 +1,137 @@
+---
+title: 策略
+description: 控制 OpenCode 可以使用哪些已配置资源。
+---
+
+策略控制 OpenCode 是否可以对指定资源执行操作。此功能目前处于实验阶段，通过 `opencode.json` 中的 `experimental.policies` 数组进行配置。
+
+策略与[权限](/docs/permissions)相互独立。权限控制工具在会话期间可以执行的操作，而策略控制 OpenCode 是否可以使用某个资源，例如 LLM 提供商。
+
+---
+
+## 配置
+
+每条策略声明包含三个字段：
+
+- `effect` - 可以是 `"allow"` 或 `"deny"`。
+- `action` - 要控制的操作。
+- `resource` - 声明所适用的资源 ID 或通配符模式。
+
+例如，禁止使用 `openai` 提供商：
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "openai"
+      }
+    ]
+  }
+}
+```
+
+被策略禁止的提供商不会出现在模型选择中，也无法用于模型调用，即使其凭据存在或其他配置均正确。
+
+---
+
+## 可用策略
+
+OpenCode 目前支持一个策略操作：
+
+| 操作           | 资源                         | 描述                   |
+| -------------- | ---------------------------- | ---------------------- |
+| `provider.use` | 提供商 ID，例如 `openai`     | 允许或禁止使用 LLM 提供商。 |
+
+未来可能会添加更多策略操作。
+
+---
+
+## 匹配
+
+`resource` 字段支持通配符匹配。使用 `*` 匹配零个或多个字符，使用 `?` 匹配一个字符。
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "company-*"
+      }
+    ]
+  }
+}
+```
+
+这会禁止使用 `company-us` 和 `company-eu` 等提供商。
+
+---
+
+## 规则顺序
+
+当多条策略声明匹配时，最后一条匹配的声明生效。请先配置更宽泛的规则，再配置更具体的特殊规则。
+
+例如，仅允许使用 Anthropic：
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "*"
+      },
+      {
+        "effect": "allow",
+        "action": "provider.use",
+        "resource": "anthropic"
+      }
+    ]
+  }
+}
+```
+
+如果没有策略匹配某个提供商，则默认允许使用该提供商。
+
+策略可以同时设置在全局配置和项目配置中。如果两处的策略都匹配同一个提供商，全局策略优先于项目策略。这样可以防止仓库重新启用你在全局配置中禁止的提供商。
+
+---
+
+## 提供商列表
+
+在控制提供商的可访问权限时，请使用策略，不要再使用旧版的 `disabled_providers` 和 `enabled_providers` 设置。
+
+如要替代 `disabled_providers`：
+
+```json title="opencode.json"
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "openai" },
+      { "effect": "deny", "action": "provider.use", "resource": "google" }
+    ]
+  }
+}
+```
+
+如要替代 `enabled_providers` ，先禁止所有提供商，再允许选定的提供商：
+
+```json title="opencode.json"
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" },
+      { "effect": "allow", "action": "provider.use", "resource": "openai" }
+    ]
+  }
+}
+```


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the missing Simplified Chinese (zh-cn) translation for the policies docs page (`packages/web/src/content/docs/zh-cn/policies.mdx`).

### How did you verify your code works?

Translated by human.

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
