### PR TITLE
fix(app): decouple MCP resource refresh from toggle

### DIFF
--- a/packages/app/src/context/global-sync/mcp.test.ts
+++ b/packages/app/src/context/global-sync/mcp.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { toggleMcp } from "./mcp"
 
 describe("toggleMcp", () => {
-  test("runs the status action before refreshing the owning query", async () => {
+  test("runs the status action before refreshing the owning queries", async () => {
     const calls: string[] = []
     const input = (status: "connected" | "needs_auth" | "disabled") => ({
       status,
@@ -15,21 +15,24 @@ describe("toggleMcp", () => {
       authenticate: async () => {
         calls.push("authenticate")
       },
-      refresh: async () => {
-        calls.push("refresh")
+      refreshStatus: async () => {
+        calls.push("refresh-status")
+      },
+      refreshResources: async () => {
+        calls.push("refresh-resources")
       },
     })
 
     await toggleMcp(input("connected"))
-    expect(calls).toEqual(["disconnect", "refresh"])
+    expect(calls).toEqual(["disconnect", "refresh-status", "refresh-resources"])
 
     calls.length = 0
     await toggleMcp(input("needs_auth"))
-    expect(calls).toEqual(["authenticate", "refresh"])
+    expect(calls).toEqual(["authenticate", "refresh-status", "refresh-resources"])
 
     calls.length = 0
     await toggleMcp(input("disabled"))
-    expect(calls).toEqual(["connect", "refresh"])
+    expect(calls).toEqual(["connect", "refresh-status", "refresh-resources"])
   })
 
   test("does not toggle a server while its connection is pending", async () => {
@@ -45,10 +48,51 @@ describe("toggleMcp", () => {
       authenticate: async () => {
         calls.push("authenticate")
       },
-      refresh: async () => {
-        calls.push("refresh")
+      refreshStatus: async () => {
+        calls.push("refresh-status")
+      },
+      refreshResources: async () => {
+        calls.push("refresh-resources")
       },
     })
     expect(calls).toEqual([])
+  })
+
+  test("does not wait for resource discovery", async () => {
+    let releaseResources: () => void = () => undefined
+    let resourcesStarted = false
+    const resources = new Promise<void>((resolve) => {
+      releaseResources = resolve
+    })
+
+    await toggleMcp({
+      status: "disabled",
+      connect: async () => undefined,
+      disconnect: async () => undefined,
+      authenticate: async () => undefined,
+      refreshStatus: async () => undefined,
+      refreshResources: async () => {
+        resourcesStarted = true
+        await resources
+      },
+    })
+
+    expect(resourcesStarted).toBe(true)
+    releaseResources()
+  })
+
+  test("ignores resource discovery failures", async () => {
+    await expect(
+      toggleMcp({
+        status: "disabled",
+        connect: async () => undefined,
+        disconnect: async () => undefined,
+        authenticate: async () => undefined,
+        refreshStatus: async () => undefined,
+        refreshResources: async () => {
+          throw new Error("resources/list is unsupported")
+        },
+      }),
+    ).resolves.toBeUndefined()
   })
 })

--- a/packages/app/src/context/global-sync/mcp.ts
+++ b/packages/app/src/context/global-sync/mcp.ts
@@ -5,7 +5,8 @@ export async function toggleMcp(input: {
   connect: () => Promise<void>
   disconnect: () => Promise<void>
   authenticate: () => Promise<void>
-  refresh: () => Promise<void>
+  refreshStatus: () => Promise<void>
+  refreshResources: () => Promise<void>
 }) {
   if (input.status === "pending") return
   await {
@@ -15,5 +16,6 @@ export async function toggleMcp(input: {
     failed: input.connect,
     needs_client_registration: input.connect,
   }[input.status]()
-  await input.refresh()
+  await input.refreshStatus()
+  void input.refreshResources().catch(() => undefined)
 }

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -714,8 +714,10 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
           authenticate: async () => {
             await sdk.mcp.auth.authenticate({ name })
           },
-          refresh: async () => {
+          refreshStatus: async () => {
             await queryClient.refetchQueries(queryOptionsApi.mcp(key))
+          },
+          refreshResources: async () => {
             await queryClient.refetchQueries(queryOptionsApi.mcpResources(key))
           },
         })


### PR DESCRIPTION
### Issue for this PR

Fixes #48386

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After an MCP toggle connects, the Desktop UI now awaits only the MCP status refresh. Resource catalog discovery runs as a non-blocking best-effort refresh, so a slow or unsupported `resources/list` from any connected server cannot block the toggle or make it appear to fail. Resource refresh rejections are caught so they do not become unhandled rejections.

The regression tests cover the three toggle actions, pending connections, non-blocking resource discovery, and a rejected `refreshResources()` call.

### How did you verify your code works?

- `cd packages/app && bun test --conditions=solid --preload ./happydom.ts ./src/context/global-sync/mcp.test.ts`
- `bun --cwd packages/app typecheck`
- `bunx prettier --check packages/app/src/context/global-sync/mcp.ts packages/app/src/context/global-sync/mcp.test.ts packages/app/src/context/server-sync.tsx`
- Pre-push `bun turbo typecheck`

### Screenshots / recordings

Not applicable; this is a behavior-only fix with no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._