### PR TITLE
feat(tui): add recursive grouping tree

### DIFF
--- a/packages/tui/src/routes/session/grouping/tree.ts
+++ b/packages/tui/src/routes/session/grouping/tree.ts
@@ -18,24 +18,38 @@ export function groupEntries<Entry, Kind extends string>(
   entries: readonly Entry[],
   path: (entry: Entry) => readonly Kind[],
 ): readonly GroupNode<Entry, Kind>[] {
-  const result: GroupNode<Entry, Kind>[] = []
-  // Only fresh groups are mutable during construction. No input tree is edited.
-  const stack: { type: "group"; kind: Kind; children: GroupNode<Entry, Kind>[]; size: number }[] = []
+  const result: BuildingNode<Entry, Kind>[] = []
   entries.forEach((entry) => {
-    const kinds = path(entry)
-    const shared = kinds.findIndex((kind, depth) => stack[depth]?.kind !== kind)
-    stack.length = shared === -1 ? kinds.length : shared
-    kinds.slice(stack.length).forEach((kind) => {
-      const group = { type: "group" as const, kind, children: [] as GroupNode<Entry, Kind>[], size: 0 }
-      const children = stack.at(-1)?.children ?? result
-      children.push(group)
-      stack.push(group)
-    })
-    stack.forEach((group) => group.size++)
-    const children = stack.at(-1)?.children ?? result
-    children.push({ type: "entry", entry, size: 1 })
+    appendEntry(result, entry, path(entry))
   })
   return result
+}
+
+// Only freshly constructed nodes are writable; the published tree is readonly.
+type BuildingNode<Entry, Kind extends string> =
+  | { type: "entry"; entry: Entry; size: 1 }
+  | { type: "group"; kind: Kind; children: BuildingNode<Entry, Kind>[]; size: number }
+
+function appendEntry<Entry, Kind extends string>(
+  nodes: BuildingNode<Entry, Kind>[],
+  entry: Entry,
+  path: readonly Kind[],
+  depth = 0,
+) {
+  const kind = path[depth]
+  if (kind === undefined) {
+    nodes.push({ type: "entry", entry, size: 1 })
+    return
+  }
+  const previous = nodes.at(-1)
+  if (previous?.type === "group" && previous.kind === kind) {
+    previous.size++
+    appendEntry(previous.children, entry, path, depth + 1)
+    return
+  }
+  const children: BuildingNode<Entry, Kind>[] = []
+  appendEntry(children, entry, path, depth + 1)
+  nodes.push({ type: "group", kind, children, size: 1 })
 }
 
 /**

--- a/packages/tui/src/routes/session/grouping/tree.ts
+++ b/packages/tui/src/routes/session/grouping/tree.ts
@@ -1,0 +1,97 @@
+export type GroupNode<Entry, Kind extends string> =
+  | { readonly type: "entry"; readonly entry: Entry; readonly size: 1 }
+  | {
+      readonly type: "group"
+      readonly kind: Kind
+      readonly children: readonly GroupNode<Entry, Kind>[]
+      /** Number of descendant leaves, independent of disclosure state. */
+      readonly size: number
+    }
+
+/**
+ * Group adjacent entries by their configured nesting paths. For example, a read
+ * can use ["exploration"] today or ["activity", "exploration"] in Low.
+ * Entries are opaque: message/part identity, visibility and live state remain
+ * owned by the session projection. A path of [] creates a standalone leaf.
+ */
+export function groupEntries<Entry, Kind extends string>(
+  entries: readonly Entry[],
+  path: (entry: Entry) => readonly Kind[],
+): readonly GroupNode<Entry, Kind>[] {
+  const result: GroupNode<Entry, Kind>[] = []
+  // Only fresh groups are mutable during construction. No input tree is edited.
+  const stack: { type: "group"; kind: Kind; children: GroupNode<Entry, Kind>[]; size: number }[] = []
+  entries.forEach((entry) => {
+    const kinds = path(entry)
+    const shared = kinds.findIndex((kind, depth) => stack[depth]?.kind !== kind)
+    stack.length = shared === -1 ? kinds.length : shared
+    kinds.slice(stack.length).forEach((kind) => {
+      const group = { type: "group" as const, kind, children: [] as GroupNode<Entry, Kind>[], size: 0 }
+      const children = stack.at(-1)?.children ?? result
+      children.push(group)
+      stack.push(group)
+    })
+    stack.forEach((group) => group.size++)
+    const children = stack.at(-1)?.children ?? result
+    children.push({ type: "entry", entry, size: 1 })
+  })
+  return result
+}
+
+/**
+ * Concatenate ordered, disjoint chunks, recursively merging compatible groups
+ * at their seam. Untouched subtrees retain their object identity.
+ *
+ * This is concatenation, not ingestion: callers must reconcile overlapping
+ * pages/replayed message IDs before merging. Equal payloads may be distinct
+ * entries and must not be silently deduplicated here.
+ */
+export function mergeGroups<Entry, Kind extends string>(
+  left: readonly GroupNode<Entry, Kind>[],
+  right: readonly GroupNode<Entry, Kind>[],
+): readonly GroupNode<Entry, Kind>[] {
+  if (!left.length) return right
+  if (!right.length) return left
+  const a = left[left.length - 1]
+  const b = right[0]
+  if (a.type !== "group" || b.type !== "group" || a.kind !== b.kind) return [...left, ...right]
+  return [
+    ...left.slice(0, -1),
+    {
+      type: "group",
+      kind: a.kind,
+      size: a.size + b.size,
+      children: mergeGroups(a.children, b.children),
+    },
+    ...right.slice(1),
+  ]
+}
+
+/**
+ * Split at a depth-first leaf offset. Group headers count as zero. Cached sizes
+ * skip whole subtrees; only the ancestors crossing the cut are reconstructed.
+ * The returned halves can be seam-merged again without changing their meaning.
+ */
+export function splitGroups<Entry, Kind extends string>(
+  nodes: readonly GroupNode<Entry, Kind>[],
+  count: number,
+): readonly [readonly GroupNode<Entry, Kind>[], readonly GroupNode<Entry, Kind>[]] {
+  if (!Number.isInteger(count) || count < 0) throw new RangeError("Group split requires a non-negative integer")
+  if (count === 0) return [[], nodes]
+  let offset = 0
+  for (const [index, node] of nodes.entries()) {
+    const end = offset + node.size
+    if (count === end) return [nodes.slice(0, index + 1), nodes.slice(index + 1)]
+    if (count < end) {
+      if (node.type !== "group") throw new RangeError("Cannot split inside an entry")
+      const size = count - offset
+      const [left, right] = splitGroups(node.children, size)
+      return [
+        [...nodes.slice(0, index), { ...node, children: left, size }],
+        [{ ...node, children: right, size: node.size - size }, ...nodes.slice(index + 1)],
+      ]
+    }
+    offset = end
+  }
+  throw new RangeError("Group split exceeds entry count")
+}

--- a/packages/tui/test/cli/tui/grouping-tree.test.ts
+++ b/packages/tui/test/cli/tui/grouping-tree.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { groupEntries, mergeGroups, splitGroups } from "../../../src/routes/session/grouping/tree"
+
+const path = (entry: { path: string[] }) => entry.path
+const read = { id: "read", path: ["activity", "exploration"] }
+const search = { id: "search", path: ["activity", "exploration"] }
+const thought = { id: "thought", path: ["activity", "reasoning"] }
+const text = { id: "text", path: [] }
+const leaf = (entry: typeof read) => ({ type: "entry" as const, entry, size: 1 as const })
+
+test("groups adjacent entries by path and counts leaves, not wrappers", () => {
+  expect(groupEntries([read, search, thought, text, read], path)).toEqual([
+    {
+      type: "group",
+      kind: "activity",
+      size: 3,
+      children: [
+        { type: "group", kind: "exploration", size: 2, children: [leaf(read), leaf(search)] },
+        { type: "group", kind: "reasoning", size: 1, children: [leaf(thought)] },
+      ],
+    },
+    leaf(text),
+    {
+      type: "group",
+      kind: "activity",
+      size: 1,
+      children: [{ type: "group", kind: "exploration", size: 1, children: [leaf(read)] }],
+    },
+  ])
+})
+
+test("a direct child breaks a subgroup without ending the outer group", () => {
+  const shell = { id: "shell", path: ["activity"] }
+  expect(groupEntries([read, shell, search], path)).toEqual([
+    {
+      type: "group",
+      kind: "activity",
+      size: 3,
+      children: [
+        { type: "group", kind: "exploration", size: 1, children: [leaf(read)] },
+        leaf(shell),
+        { type: "group", kind: "exploration", size: 1, children: [leaf(search)] },
+      ],
+    },
+  ])
+})
+
+test("merges both grouping levels at a page seam without changing the inputs", () => {
+  const left = groupEntries([text, read], path)
+  const right = groupEntries([search, thought], path)
+  const saved = structuredClone([left, right])
+  const merged = mergeGroups(left, right)
+  expect(merged).toEqual(groupEntries([text, read, search, thought], path))
+  expect([left, right]).toEqual(saved)
+  expect(merged[0]).toBe(left[0])
+})
+
+test("splits at each leaf boundary and merges back to the original tree", () => {
+  const entries = [read, search, thought, text]
+  const tree = groupEntries(entries, path)
+  for (let count = 0; count <= entries.length; count++) {
+    const [left, right] = splitGroups(tree, count)
+    expect(left).toEqual(groupEntries(entries.slice(0, count), path))
+    expect(right).toEqual(groupEntries(entries.slice(count), path))
+    expect(mergeGroups(left, right)).toEqual(tree)
+  }
+})
+
+test("handles empty chunks", () => {
+  const tree = groupEntries([read], path)
+  expect(groupEntries([], path)).toEqual([])
+  expect(mergeGroups([], tree)).toBe(tree)
+  expect(mergeGroups(tree, [])).toBe(tree)
+  expect(splitGroups([], 0)).toEqual([[], []])
+})
+
+test("rejects invalid split offsets", () => {
+  const tree = groupEntries([read], path)
+  for (const count of [-1, 0.5, 2, NaN]) {
+    expect(() => splitGroups(tree, count)).toThrow(RangeError)
+  }
+})


### PR DESCRIPTION
## Base
Rebased onto `v2` after #48393 merged. This PR contains only the grouping-engine increment.

## Summary
Add the pure grouping engine before connecting it to the production session projection.

- Generic entries with configurable nesting paths, including `activity -> exploration/reasoning/instructions`.
- Ordered construction and associative recursive seam merges.
- Split by depth-first leaf count using cached subtree sizes; group headers count as zero.
- Readonly trees, immutable operations, and retained identity for untouched subtrees.

The current session projection and rendering are unchanged. This module has no runtime dependencies and is not wired in yet. The next integration step owns replay/overlapping-page deduplication and stable disclosure keys; seam merging explicitly concatenates disjoint ordered chunks.

## Verification
- TUI `bun typecheck`: passed
- New module Prettier and staged whitespace checks: passed
- Local deterministic suite: **18 tests passed, 161215 assertions**
- Exhaustively checked all 2801 sequences of up to four entries over seven grouping paths: every split and three-page partition, fresh/incremental equivalence, associativity, leaf counts and split/merge round trips
- Additional cases cover nested activity structure, native PartRef payloads, immutable inputs, unchanged subtree identity, invalid offsets, replacements/deletions and deeper nesting

The PR now includes six basic tests covering grouping, direct-child boundaries, recursive merging, splitting, empty chunks and invalid offsets (all passing; TUI typecheck also passes). The exhaustive diagnostic suite remains local at `/tmp/opencode/grouping-tree.test.ts`; the work log remains local too. No screenshot replay for this unwired pure module; production integration will repeat visual parity checks.