### PR TITLE
fix: add Android/Termux support to postinstall.mjs

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -15,6 +15,7 @@ const platformMap = {
   darwin: "darwin",
   linux: "linux",
   win32: "windows",
+  android: "linux",
 }
 const archMap = {
   x64: "x64",
@@ -78,6 +79,9 @@ function supportsAvx2() {
 
 function isMusl() {
   if (platform !== "linux") return false
+
+  // Termux on Android uses the musl binary + Alpine musl loader via patchelf
+  if (os.platform() === "android") return true
 
   try {
     if (fs.existsSync("/etc/alpine-release")) return true


### PR DESCRIPTION
### Issue for this PR

Closes #47612

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v2 CLI postinstall script fails on Termux/Android because `os.platform()` returns `"android"`, which isn't in the platform map. This causes:

```
Error: OpenCode does not provide a binary for android-arm64
```

Two small changes fix this:

1. **Platform map** (line 17): add `android: "linux"` so `os.platform()` resolves correctly on Termux
2. **isMusl()** (line 83): return `true` on Android — Termux uses the musl binary with Alpine's musl loader via patchelf

The v2 musl binary already works on Android without modification. It only depends on `libstdc++.so.6` and `libc.musl-aarch64.so.1` — no Bun, no JSC, no WebKit.

### How did you verify your code works?

Tested on Termux (Android 17, aarch64):

```sh
npm install -g @opencode-ai/cli@beta --force
opencode2 --version
# opencode2 v0.0.0-beta-19228
```

Without this change, the install fails with the EBADPLATFORM error above.

### Screenshots / recordings

_N/A — CLI change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR