### PR TITLE
fix(core): resolve saved Workers AI account IDs

### DIFF
--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -132,6 +132,23 @@ export function map(input: MapInput): Mapping | undefined {
       }
     case "@ai-sdk/openai-compatible":
       if (typeof input.settings.baseURL !== "string") return
+      if (input.providerID === "cloudflare-workers-ai") {
+        const accountId =
+          process.env.CLOUDFLARE_ACCOUNT_ID ??
+          (typeof input.settings.accountId === "string" ? input.settings.accountId : undefined)
+        return {
+          package: "@opencode/ai/providers/openai-compatible",
+          settings: {
+            ...baseSettings,
+            ...mapAPIKey(input.settings),
+            baseURL: accountId
+              ? input.settings.baseURL.replaceAll("${CLOUDFLARE_ACCOUNT_ID}", encodeURIComponent(accountId))
+              : input.settings.baseURL,
+            provider: input.providerID,
+            ...mapProviderOptions(input.settings, ["apiKey", "baseURL", "accountId"]),
+          },
+        }
+      }
       return {
         package: "@opencode/ai/providers/openai-compatible",
         settings: {

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -73,6 +73,66 @@ function withConfigEnv<A, E, R>(env: Record<string, string>, effect: () => Effec
 }
 
 describe("ModelResolver", () => {
+  it.effect("resolves Workers AI account configuration without an environment variable", () =>
+    withEnv({ CLOUDFLARE_ACCOUNT_ID: undefined }, () =>
+      Effect.gen(function* () {
+        for (const credential of [
+          Credential.Key.make({ type: "key", key: "test-key", configuration: { accountId: "account" } }),
+          Credential.Key.make({ type: "key", key: "test-key", metadata: { accountId: "account" } }),
+        ]) {
+          const resolved = yield* ModelResolver.fromCatalogModel(
+            model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+              providerID: Provider.ID.make("cloudflare-workers-ai"),
+              modelID: "@cf/deepseek-ai/deepseek-v4-flash-0731",
+              settings: { baseURL: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1" },
+            }),
+            credential,
+          )
+          expect(resolved.route.endpoint.baseURL).toBe("https://api.cloudflare.com/client/v4/accounts/account/ai/v1")
+          expect(resolved.route.defaults.providerOptions).not.toHaveProperty("accountId")
+        }
+      }),
+    ),
+  )
+
+  it.effect("resolves Workers AI settings for an alias and preserves explicit endpoints", () =>
+    withEnv({ CLOUDFLARE_ACCOUNT_ID: undefined }, () =>
+      Effect.gen(function* () {
+        for (const baseURL of [
+          "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+          "https://proxy.example/v1",
+        ]) {
+          const resolved = yield* ModelResolver.fromCatalogModel(
+            model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+              providerID: Provider.ID.make("workers-alias"),
+              canonical: Provider.ID.make("cloudflare-workers-ai"),
+              settings: { baseURL, accountId: "account" },
+            }),
+          )
+          expect(resolved.route.endpoint.baseURL).toBe(baseURL.replace("${CLOUDFLARE_ACCOUNT_ID}", "account"))
+          expect(resolved.route.defaults.providerOptions).not.toHaveProperty("accountId")
+        }
+      }),
+    ),
+  )
+
+  it.effect("preserves Workers AI environment account precedence", () =>
+    withEnv({ CLOUDFLARE_ACCOUNT_ID: "env-account" }, () =>
+      Effect.gen(function* () {
+        const resolved = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+            providerID: Provider.ID.make("cloudflare-workers-ai"),
+            settings: {
+              baseURL: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+              accountId: "configured-account",
+            },
+          }),
+        )
+        expect(resolved.route.endpoint.baseURL).toBe("https://api.cloudflare.com/client/v4/accounts/env-account/ai/v1")
+      }),
+    ),
+  )
+
   it.effect("constructs native Azure requests with deployment IDs and projected resource URLs", () =>
     Effect.gen(function* () {
       const responses = yield* ModelResolver.fromCatalogModel(


### PR DESCRIPTION
### Issue for this PR

Closes #48404

Bug report: https://github.com/anomalyco/opencode/issues/48404

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Workers AI's catalog endpoint still contains `${CLOUDFLARE_ACCOUNT_ID}` after `/connect` saves `accountId`, so the native resolver rejects it before sending a request. Substitute the saved account ID during OpenAI-compatible mapping and keep it out of provider request options.

Preserves explicit endpoints and environment-account precedence. Covers saved configuration, legacy metadata, provider settings, and canonical provider aliases.

### How did you verify your code works?

- Regression test reproduced the initialization error before the change.
- Core resolver, native mapping, and Workers AI plugin tests: 74 passed.
- Core retry/incomplete-stream/malformed-tool tests: 20 passed.
- `bun typecheck` in `packages/core` passed.
- Live patched resolver request to Workers AI DeepSeek Flash 0731 succeeded with the account ID supplied only through credential configuration and the environment variable unset.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
