### PR TITLE
fix(app): preserve reasoning capability

### DIFF
--- a/packages/app/src/runtime/server/global-sync/utils.test.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.test.ts
@@ -84,7 +84,7 @@ describe("normalizeProviderList", () => {
     expect(result.all.get("openai")?.models["gpt-5"]).toMatchObject({
       id: "gpt-5",
       providerID: "openai",
-      capabilities: { toolcall: true, attachment: true },
+      capabilities: { toolcall: true, attachment: true, reasoning: true },
       cost: { input: 1, output: 2 },
       variants: { high: {} },
     })

--- a/packages/app/src/runtime/server/global-sync/utils.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.ts
@@ -75,7 +75,7 @@ export function normalizeProviderList(
       family: model.family,
       capabilities: {
         temperature: false,
-        reasoning: false,
+        reasoning: model.variants.length > 0,
         attachment: model.capabilities.input.some((item) => item !== "text"),
         toolcall: model.capabilities.tools,
         input: {


### PR DESCRIPTION
### Issue for this PR

No linked issue; discovered while integrating a V2 model catalog with the app.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The app adapter currently reports every model from the V2 catalog as having no reasoning support. V2 exposes configurable reasoning through model variants, so this derives the legacy UI capability from whether variants are available.

### How did you verify your code works?

Ran the focused adapter test and the app typecheck. The repository pre-push typecheck also completed successfully across 35 packages.

### Screenshots / recordings

Not included; this changes the metadata consumed by the existing model tooltip.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR