### PR TITLE
fix(tui): avoid invalid dummy session id on continue

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -285,10 +285,10 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                                 <ToastProvider>
                                   <RouteProvider
                                     initialRoute={
-                                      input.args.continue
+                                      input.args.sessionID && !input.args.fork
                                         ? {
                                             type: "session",
-                                            sessionID: "dummy",
+                                            sessionID: input.args.sessionID,
                                           }
                                         : undefined
                                     }
@@ -518,6 +518,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       } else {
         route.navigate({ type: "session", sessionID: match })
       }
+    } else if (sync.status === "complete") {
+      continued = true
+      toast.show({ message: "No session found to continue", variant: "warning" })
     }
   })
 

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -65,19 +65,22 @@ test("app.exit prints the session epilogue after scoped cleanup", async () => {
   const core = await import("@opentui/core")
   mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
   const events = createEventSource()
+  const requestedUrls: string[] = []
   const calls = createFetch((url) => {
+    requestedUrls.push(url.pathname)
     if (url.pathname === "/session")
       return json([
         {
-          id: "dummy",
+          id: "ses_demo",
           title: "Demo session",
-          slug: "dummy",
+          slug: "ses_demo",
           projectID: "project",
           directory,
           version: "0.0.0-test",
           time: { created: 0, updated: 0 },
         },
       ])
+    return undefined
   })
   const originalWrite = process.stdout.write.bind(process.stdout)
   let stdout = ""
@@ -119,9 +122,58 @@ test("app.exit prints the session epilogue after scoped cleanup", async () => {
     await task
 
     expect(stdout).toContain("Demo session")
-    expect(stdout).toContain("opencode -s dummy")
+    expect(stdout).toContain("opencode -s ses_demo")
+    expect(requestedUrls.some((path) => path.includes("dummy"))).toBe(false)
   } finally {
     process.stdout.write = originalWrite
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})
+
+test("continue without sessions does not crash with dummy session", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const events = createEventSource()
+  const requestedUrls: string[] = []
+  const calls = createFetch((url) => {
+    requestedUrls.push(url.pathname)
+    if (url.pathname === "/session") return json([])
+    return undefined
+  })
+  let api: TuiPluginApi | undefined
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        args: { continue: true },
+        pluginHost: {
+          async start(input) {
+            api = input.api
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node))),
+    )
+
+    await ready
+    await setup.renderOnce()
+    expect(requestedUrls.some((path) => path.includes("dummy"))).toBe(false)
+    api?.keymap.dispatchCommand("app.exit")
+    await task
+  } finally {
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()
     mock.restore()
   }


### PR DESCRIPTION
## Summary

Fixes an error where running `opencode --continue` fails backend schema validation:

```
Error: Expected a string starting with "ses", got "dummy"
```

### Cause
When `--continue` was passed, `RouteProvider` in `packages/tui/src/app.tsx` initialized `initialRoute` with `{ type: "session", sessionID: "dummy" }`. Mounting the session view immediately invoked `sdk.client.session.get({ sessionID: "dummy" })`, which failed schema validation because `SessionID` requires strings to start with `"ses"`.

### Solution
- Remove the hardcoded `"dummy"` session ID from `initialRoute` so that `--continue` waits for `sync.data.session` to resolve the latest valid session before navigating.
- Pass `input.args.sessionID` to `initialRoute` when `--session` is provided without `--fork`.
- Show a warning toast when `--continue` is used in a repository without any existing sessions.
- Update tests in `packages/tui/test/app-lifecycle.test.tsx` to verify no requests are made to `"dummy"` session IDs.

Fixes #29748 