### PR TITLE
fix(merman): support ampersand fan-out in flowcharts

### DIFF
--- a/packages/merman/src/flowchart/flowchart.test.ts
+++ b/packages/merman/src/flowchart/flowchart.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { MermaidSyntaxError } from "../diagnostics.js"
 import { parseColor, TextAttributes } from "@opentui/core"
 import stringWidth from "string-width"
 import { diagramArrowHeadBetween } from "../core/drawing.js"
@@ -1278,6 +1279,45 @@ flowchart TD
       { from: "B", to: "C", label: "retry", style: "dashed" },
       { from: "C", to: "D", label: "done", style: "thick" },
     ])
+  })
+
+  test("expands ampersand fan-out into one edge per pair", () => {
+    const diagram = parseMermaidFlowchartDiagram(`flowchart LR
+  N & M & O --> LM[LanguageModel]`)
+
+    expect(diagram.nodes.map((node) => node.id)).toEqual(["N", "M", "O", "LM"])
+    expect(diagram.edges).toEqual([
+      { from: "N", to: "LM", label: "" },
+      { from: "M", to: "LM", label: "" },
+      { from: "O", to: "LM", label: "" },
+    ])
+  })
+
+  test("expands ampersand groups on both sides of an edge", () => {
+    const diagram = parseMermaidFlowchartDiagram(`flowchart LR
+  A[X] & B[Y] -->|shared| C & D`)
+
+    expect(diagram.nodes.map((node) => node.id)).toEqual(["A", "B", "C", "D"])
+    expect(diagram.edges).toEqual([
+      { from: "A", to: "C", label: "shared" },
+      { from: "A", to: "D", label: "shared" },
+      { from: "B", to: "C", label: "shared" },
+      { from: "B", to: "D", label: "shared" },
+    ])
+  })
+
+  test("keeps ampersands inside labels and edge labels intact", () => {
+    const diagram = parseMermaidFlowchartDiagram(`flowchart LR
+  X[a & b] -->|x & y| Y`)
+
+    expect(diagram.nodes.find((node) => node.id === "X")?.label).toBe("a & b")
+    expect(diagram.edges).toEqual([{ from: "X", to: "Y", label: "x & y" }])
+  })
+
+  test("rejects empty ampersand segments", () => {
+    for (const statement of ["A & --> B", "& A --> B", "A --> B &"]) {
+      expect(() => parseMermaidFlowchartDiagram(`flowchart LR\n  ${statement}`)).toThrow(MermaidSyntaxError)
+    }
   })
 
   test("parses chained undirected solid edges", () => {

--- a/packages/merman/src/flowchart/parser.ts
+++ b/packages/merman/src/flowchart/parser.ts
@@ -127,6 +127,40 @@ function stripNodeToken(token: string): string {
     .trim()
 }
 
+function splitFanoutToken(token: string): string[] {
+  const parts: string[] = []
+  const stack: string[] = []
+  let quote: '"' | "'" | undefined
+  let start = 0
+  const closes: Record<string, string> = { "[": "]", "(": ")", "{": "}" }
+
+  for (let index = 0; index < token.length; index++) {
+    const character = token[index]!
+    if (quote) {
+      if (character === quote && token[index - 1] !== "\\") quote = undefined
+      continue
+    }
+    if (character === '"' || character === "'") {
+      quote = character
+      continue
+    }
+    if (character in closes) {
+      stack.push(character)
+      continue
+    }
+    if (stack.length > 0 && character === closes[stack.at(-1)!]) {
+      stack.pop()
+      continue
+    }
+    if (stack.length === 0 && character === "&") {
+      parts.push(token.slice(start, index))
+      start = index + 1
+    }
+  }
+  parts.push(token.slice(start))
+  return parts
+}
+
 function edgeStyleFromArrow(...arrows: string[]): FlowchartEdgeStyle | undefined {
   if (arrows.some((arrow) => arrow.includes("=="))) return "thick"
   if (arrows.some((arrow) => arrow.includes("."))) return "dashed"
@@ -313,38 +347,67 @@ export function parseMermaidFlowchartDiagram(content: string): FlowchartDiagram 
       ]
 
       if (nodeTokens.every((token) => stripNodeToken(token).length > 0)) {
-        const unsupportedEndpoint = nodeTokens.find((token, index) => {
-          const stripped = stripNodeToken(token)
-          const orderOnlyEndpoint = edgeOperators[index - 1]?.orderOnly || edgeOperators[index]?.orderOnly
-          return (
-            !(orderOnlyEndpoint && subgraphs.some((subgraph) => subgraph.id === stripped)) &&
-            !isSupportedNodeToken(stripped)
-          )
-        })
+        const groups = nodeTokens.map((token) => splitFanoutToken(token))
+        if (groups.some((parts) => parts.some((part) => stripNodeToken(part).length === 0))) {
+          throw new MermaidSyntaxError("flowchart", source.lineNumber, line)
+        }
+        const unsupportedEndpoint = groups.find((parts, index) =>
+          parts.some((part) => {
+            const stripped = stripNodeToken(part)
+            const orderOnlyEndpoint = edgeOperators[index - 1]?.orderOnly || edgeOperators[index]?.orderOnly
+            return (
+              !(orderOnlyEndpoint && subgraphs.some((subgraph) => subgraph.id === stripped)) &&
+              !isSupportedNodeToken(stripped)
+            )
+          }),
+        )
         if (unsupportedEndpoint) throw new MermaidSyntaxError("flowchart", source.lineNumber, line)
-        const chainNodeIds = nodeTokens.map((token, index) => {
-          const stripped = stripNodeToken(token)
-          const orderOnlyEndpoint = edgeOperators[index - 1]?.orderOnly || edgeOperators[index]?.orderOnly
-          if (orderOnlyEndpoint && subgraphs.some((subgraph) => subgraph.id === stripped)) return stripped
-          return ensureNode(nodes, stripped).id
-        })
-        for (const nodeId of chainNodeIds) {
-          if (nodes.has(nodeId)) addNodeToSubgraph(currentSubgraph, nodeId)
+        const chainNodeGroups = groups.map((parts, index) =>
+          parts.map((part) => {
+            const stripped = stripNodeToken(part)
+            const orderOnlyEndpoint = edgeOperators[index - 1]?.orderOnly || edgeOperators[index]?.orderOnly
+            if (orderOnlyEndpoint && subgraphs.some((subgraph) => subgraph.id === stripped)) return stripped
+            return ensureNode(nodes, stripped).id
+          }),
+        )
+        for (const group of chainNodeGroups) {
+          for (const nodeId of group) {
+            if (nodes.has(nodeId)) addNodeToSubgraph(currentSubgraph, nodeId)
+          }
         }
         for (let index = 0; index < edgeOperators.length; index++) {
           const operator = edgeOperators[index]!
-          const edge = createEdge(
-            chainNodeIds[index]!,
-            chainNodeIds[index + 1]!,
-            operator.label,
-            operator.style,
-            operator.arrowhead,
-            operator.sourceArrowhead,
-          )
-          edges.push(operator.orderOnly ? { ...edge, orderOnly: true } : edge)
+          for (const from of chainNodeGroups[index]!) {
+            for (const to of chainNodeGroups[index + 1]!) {
+              const edge = createEdge(
+                from,
+                to,
+                operator.label,
+                operator.style,
+                operator.arrowhead,
+                operator.sourceArrowhead,
+              )
+              edges.push(operator.orderOnly ? { ...edge, orderOnly: true } : edge)
+            }
+          }
         }
         continue
       }
+    }
+
+    const fanoutParts = splitFanoutToken(line)
+    if (fanoutParts.length > 1) {
+      if (fanoutParts.some((part) => stripNodeToken(part).length === 0)) {
+        throw new MermaidSyntaxError("flowchart", source.lineNumber, line)
+      }
+      if (!fanoutParts.every((part) => isSupportedNodeToken(stripNodeToken(part)))) {
+        throw new MermaidSyntaxError("flowchart", source.lineNumber, line)
+      }
+      for (const part of fanoutParts) {
+        const node = ensureNode(nodes, stripNodeToken(part))
+        addNodeToSubgraph(currentSubgraph, node.id)
+      }
+      continue
     }
 
     if (isSupportedNodeToken(line)) {

--- a/packages/merman/src/test/diagnostics.test.ts
+++ b/packages/merman/src/test/diagnostics.test.ts
@@ -29,7 +29,7 @@ describe("parser diagnostics", () => {
   })
 
   test("does not partially parse unsupported flowchart syntax", () => {
-    for (const statement of ["A & B --> C", "A((Start)) --> B", "A-->B; B-->C"]) {
+    for (const statement of ["A((Start)) --> B", "A-->B; B-->C"]) {
       expect(() => parseMermaidFlowchartDiagram(`flowchart LR\n  ${statement}`)).toThrow(MermaidSyntaxError)
     }
   })


### PR DESCRIPTION
Valid mermaid such as `N & M & O --> LM` threw MermaidSyntaxError, so the TUI fell back to a code block instead of rendering. Split edge endpoints on top-level & (bracket/quote aware) and expand to one edge per pair, e.g. A & B --> C & D yields four edges. Ampersands inside node labels and |edge labels| are preserved, empty segments still error. Updates the diagnostics test that asserted & was unsupported and adds fan-out coverage. merman: 501 pass, typecheck clean.