### PR TITLE
fix(win32): exit-first plus bounded drain so shell settles on pipe leak

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -273,8 +273,16 @@ export const make = Effect.gen(function* () {
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
+      // fix(win32-close-vs-exit): exit-first, not close-first.
+      // Node emits `exit` when the process ends and `close` when stdio
+      // pipes are closed. A grandchild holding an inherited pipe
+      // delays `close` indefinitely. Resolving on `exit` gives
+      // Claude-style exit semantics; streams drain separately.
       proc.on("exit", (...args) => {
         exit = args
+        if (end) return
+        end = true
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
       })
       proc.on("close", (...args) => {
         if (end) return
@@ -505,3 +513,4 @@ const layer: Layer.Layer<ChildProcessSpawner, never, FileSystem.FileSystem | Pat
 export const node = makeGlobalNode({ service: ChildProcessSpawner, layer, deps: [filesystem, path] })
 
 export * as CrossSpawnSpawner from "./cross-spawn-spawner"
+

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -141,16 +141,30 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner
 
+    const DRAIN_GRACE_MS = 2000
+    // Bounded drain: exit already arrived, don't wait for close/EOF forever
+    // when a detached grandchild holds an inherited pipe (win32
+    // Start-Process single-side redirect, adb server, python sink).
+    const drainOrEmpty = <A, E, R>(stream: Effect.Effect<A, E, R>): Effect.Effect<A, never, R> =>
+      stream.pipe(
+        Effect.timeoutOrElse({
+          duration: Duration.millis(DRAIN_GRACE_MS),
+          orElse: () => Effect.succeed({ buffer: Buffer.alloc(0), truncated: true } as unknown as A),
+        }),
+        Effect.catch(() => Effect.succeed({ buffer: Buffer.alloc(0), truncated: true } as unknown as A)),
+      )
     const runCommand = (command: ChildProcess.Command, options?: RunOptions) => {
       const description = describeCommand(command)
       const collect = Effect.scoped(
         Effect.gen(function* () {
           const handle = yield* spawner.spawn(command)
           if (options?.combineOutput) {
-            const [output, exitCode] = yield* Effect.all(
-              [collectStream(handle.all, options.maxOutputBytes), handle.exitCode],
-              { concurrency: "unbounded" },
-            )
+            // exit-first: don't let a leaked pipe block exitCode (close vs exit).
+            const exitCode = yield* handle.exitCode
+            const output = (yield* drainOrEmpty(collectStream(handle.all, options.maxOutputBytes))) as unknown as {
+              buffer: Buffer
+              truncated: boolean
+            }
             return {
               command: description,
               exitCode,
@@ -162,14 +176,15 @@ const layer = Layer.effect(
               stderrTruncated: false,
             } satisfies RunResult
           }
-          const [stdout, stderr, exitCode] = yield* Effect.all(
+          // exit-first + bounded drain (see above).
+          const exitCode = yield* handle.exitCode
+          const [stdout, stderr] = (yield* Effect.all(
             [
-              collectStream(handle.stdout, options?.maxOutputBytes),
-              collectStream(handle.stderr, options?.maxErrorBytes),
-              handle.exitCode,
+              drainOrEmpty(collectStream(handle.stdout, options?.maxOutputBytes)),
+              drainOrEmpty(collectStream(handle.stderr, options?.maxErrorBytes)),
             ],
             { concurrency: "unbounded" },
-          )
+          )) as unknown as [{ buffer: Buffer; truncated: boolean }, { buffer: Buffer; truncated: boolean }]
           return {
             command: description,
             exitCode,
@@ -259,3 +274,4 @@ const layer = Layer.effect(
 export const node = makeGlobalNode({ service: Service, layer: layer, deps: [CrossSpawnSpawner.node] })
 
 export * as AppProcess from "./process"
+

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Duration, Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -290,8 +290,21 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
   })
 })
 
+// fix(win32-start-process): single-side RedirectStandardOutput/Error leaves the
+// other pipe inherited. Auto-complete the missing side to $null so the
+// parent can exit; explicit double redirect still wins.
+function normalizeWin32PsCommand(command: string): string {
+  if (!/Start-Process/i.test(command)) return command
+  const hasOut = /-RedirectStandardOutput\b/i.test(command)
+  const hasErr = /-RedirectStandardError\b/i.test(command)
+  if (hasOut === hasErr) return command
+  if (hasOut && !hasErr) return command + ' -RedirectStandardError "$null"'
+  return command + ' -RedirectStandardOutput "$null"'
+}
+
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
+    command = normalizeWin32PsCommand(command)
     return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
       cwd,
       env,
@@ -483,7 +496,9 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          // Bounded drain: forkScoped would otherwise keep Effect.scoped
+          // open forever when a grandchild holds the pipe (close vs exit).
+          const drain = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -553,6 +568,13 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+
+          // Give drain a brief grace to flush, then interrupt so scoped can
+          // settle even if close/EOF never arrives (leaked pipe).
+          yield* Fiber.interrupt(drain).pipe(
+            Effect.timeoutOption(Duration.millis(500)),
+            Effect.ignore,
+          )
 
           return exit.kind === "exit" ? exit.code : null
         }),
@@ -643,3 +665,4 @@ export const ShellTool = Tool.define(
       })
   }),
 )
+


### PR DESCRIPTION
Fixes #37838. See also #32504, #24784, #29822, #20902.

On Windows, the shell tool waits for pipe EOF (close) instead of process exit, so a grandchild holding an inherited pipe (Start-Process single-side redirect, python sink, adb server, serve_forever) blocks Effect.scoped forever (120s timeout plus 16min hang reported).

- core/cross-spawn-spawner: resolve exitCode on exit, not close- core/process: exit-first then 2s bounded drain, truncate and settle- opencode/tool/shell: interrupt drain fiber with 500ms grace; auto-complete single-side Start-Process redirect to/null so the parent pwsh can exit

Verified: single-side sink-long goes from 130s timeout to 11s exit 0; typecheck plus core shell tests pass; win32 cloud build green.