### PR TITLE
fix(ci): re-sign macOS CLI binaries after cross-compilation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -217,6 +217,72 @@ jobs:
             packages/opencode/dist/opencode-windows-x64
             packages/opencode/dist/opencode-windows-x64-baseline
 
+  sign-cli-macos:
+    needs:
+      - build-cli
+      - version
+    runs-on: macos-26
+    if: github.repository == 'anomalyco/opencode'
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: opencode-cli
+          path: packages/opencode/dist
+
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+
+      # The darwin binaries are cross-compiled on linux, which injects the JS
+      # payload into bun's pre-signed executable and leaves the embedded
+      # signature invalid. Re-sign so codesign verification passes and macOS
+      # can cache validation instead of re-hashing every page on each exec.
+      - name: Sign macOS CLI binaries
+        working-directory: packages/opencode/dist
+        run: |
+          for name in opencode-darwin-arm64 opencode-darwin-x64 opencode-darwin-x64-baseline; do
+            chmod +x "$name/bin/opencode"
+            codesign --force --sign - "$name/bin/opencode"
+            codesign --verify --strict --verbose=2 "$name/bin/opencode"
+          done
+
+      - name: Smoke test signed binary
+        run: ./packages/opencode/dist/opencode-darwin-arm64/bin/opencode --version
+
+      - name: Repack macOS CLI archives
+        working-directory: packages/opencode/dist
+        run: |
+          for name in opencode-darwin-arm64 opencode-darwin-x64 opencode-darwin-x64-baseline; do
+            rm -f "$name.zip"
+            (cd "$name/bin" && zip -r "../../$name.zip" ./*)
+          done
+
+      - name: Upload signed macOS CLI release assets
+        if: needs.version.outputs.release != ''
+        env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
+        run: |
+          gh release upload "v${{ needs.version.outputs.version }}" \
+            packages/opencode/dist/opencode-darwin-arm64.zip \
+            packages/opencode/dist/opencode-darwin-x64.zip \
+            packages/opencode/dist/opencode-darwin-x64-baseline.zip \
+            --clobber \
+            --repo "${{ needs.version.outputs.repo }}"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: opencode-cli-signed-macos
+          path: |
+            packages/opencode/dist/opencode-darwin-arm64
+            packages/opencode/dist/opencode-darwin-x64
+            packages/opencode/dist/opencode-darwin-x64-baseline
+            packages/opencode/dist/opencode-darwin-*.zip
+
   build-electron:
     needs:
       - version
@@ -406,6 +472,7 @@ jobs:
       - version
       - build-cli
       - sign-cli-windows
+      - sign-cli-macos
       - build-electron
     if: always() && !failure() && !cancelled()
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -435,6 +502,17 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: opencode-cli
+          path: packages/opencode/dist
+
+      # The signed darwin binaries and zips replace the unsigned output of
+      # build-cli so npm packages and the Homebrew sha256 match the release
+      # assets uploaded by sign-cli-macos.
+      - name: Remove unsigned macOS CLI binaries
+        run: rm -rf packages/opencode/dist/opencode-darwin*
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: opencode-cli-signed-macos
           path: packages/opencode/dist
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
### Issue for this PR

Closes #46313

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The darwin CLI binaries are cross-compiled on a Linux runner (`packages/opencode/script/build.ts` via `Bun.build({ compile })`). Bun injects the JS payload into its pre-signed executable and nothing re-signs it, so the shipped binary fails `codesign --verify` (x64 still carries Bun's Developer ID, arm64 a stale linker adhoc signature). macOS can never cache validation, which causes ~10s launches under EDR agents and the Xcode MCP `SIGKILL (Code Signature Invalid)` crashes reported in the issue.

Windows already has a `sign-cli-windows` job; this adds the macOS analog:

- new `sign-cli-macos` job downloads the `opencode-cli` artifact, adhoc re-signs the three darwin binaries (`codesign --force --sign -`, same approach `packages/desktop/scripts/utils.ts` already uses for the bundled CLI), verifies with `codesign --verify --strict`, smoke tests, repacks the zips with the same layout as `build.ts`, and re-uploads the release assets with `--clobber`
- the `publish` job now depends on it and replaces the unsigned darwin dirs/zips with the signed artifact before `script/publish.ts` runs, so npm platform packages ship signed binaries and the Homebrew sha256 matches the release zips

This works because replacing the invalid embedded signature with a fresh adhoc one makes it match the file contents again, so validation passes and gets cached. Developer ID + notarization (which would also keep FDA grants across updates) can be layered on later using the existing `APPLE_CERTIFICATE` secrets, but needs JIT entitlements and a notarytool flow, so it's left as a follow-up.

### How did you verify your code works?

- `actionlint` on the workflow: no new findings
- verified the repack step produces zip entry paths identical to what `build.ts` produces
- the signing command is the exact fix the issue reporter verified locally (`codesign -s - -f` making `--version` and `codesign --verify` pass), and matches what the desktop build already does to the same bun-compiled binary
- full end-to-end requires a release run of `publish.yml`, which I can't trigger from a fork

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
