### PR TITLE
fix(session-ui): grow markdown live tail in place

### DIFF
--- a/packages/session-ui/src/components/markdown-stream.test.ts
+++ b/packages/session-ui/src/components/markdown-stream.test.ts
@@ -228,4 +228,36 @@ describe("markdown stream", () => {
       complete: true,
     })
   })
+
+  test("appends plain text deltas without reprojecting frozen blocks", () => {
+    const previous = project(undefined, "# Plan\n\nFinished paragraph.\n\n- final", true)
+    const next = project(previous, `${previous.text} item`, true)
+
+    expect(next.blocks[0]).toBe(previous.blocks[0])
+    expect(next.blocks[1]).toBe(previous.blocks[1])
+    expect(next.blocks.at(-1)).toEqual({ raw: "- final item", src: "- final item", mode: "live" })
+  })
+
+  test("boundedly re-lexes the live tail once it exceeds the cap", () => {
+    const unit = "para\n\n"
+    let grown = project(undefined, unit, true)
+    for (let i = 0; i < 400; i++) {
+      grown = project(grown, `${grown.text}${unit}`, true)
+    }
+
+    expect(grown.blocks.at(-1)!.mode).toBe("live")
+    expect(grown.blocks.filter((block) => block.mode === "full").length).toBeGreaterThan(0)
+  })
+
+  test("grows a boundary-less oversized tail in place without splitting", () => {
+    const word = "word "
+    let grown = project(undefined, word, true)
+    for (let i = 0; i < 600; i++) {
+      grown = project(grown, `${grown.text}${word}`, true)
+    }
+
+    expect(grown.blocks).toHaveLength(1)
+    expect(grown.blocks[0]!.mode).toBe("live")
+    expect(grown.blocks[0]!.raw).toBe(word.repeat(601))
+  })
 })

--- a/packages/session-ui/src/components/markdown-stream.ts
+++ b/packages/session-ui/src/components/markdown-stream.ts
@@ -85,6 +85,19 @@ export function stream(text: string, live: boolean): Block[] {
   return [...result, { raw, src: openCode(code.raw), mode: "code", language: language(code.lang) }]
 }
 
+// Streaming projection bounds the work done per delta. Re-lexing the whole
+// accumulated text on every delta is O(n²) for a long single part and freezes
+// the UI (see sync.tsx delta coalescing; freeze tracked in #36043 — see also #6172, #42264). While a tail
+// block is still open we grow it in place, only re-lexing when the appended
+// text introduces a block boundary (a blank line) or the tail exceeds this cap.
+// A boundary-less tail (one giant paragraph, list, or table) keeps growing in
+// place past the cap so it is never re-lexed on every delta.
+const LIVE_TAIL_MAX = 2048
+
+function hasBlockBoundary(text: string) {
+  return text.includes("\n\n")
+}
+
 export function project(previous: Projection | undefined, text: string, live: boolean): Projection {
   if (!live) {
     const current =
@@ -106,17 +119,26 @@ export function project(previous: Projection | undefined, text: string, live: bo
   if (!previous || !text.startsWith(previous.text)) return { text, blocks: stream(text, live) }
   const tail = previous.blocks.at(-1)
   const suffix = text.slice(previous.text.length)
-  if (!suffix || tail?.mode !== "code" || tail.complete || closesFence(tail.raw, suffix))
-    return { text, blocks: stream(text, live) }
-  return {
-    text,
-    blocks: [
-      ...previous.blocks.slice(0, -1),
-      {
-        ...tail,
-        raw: tail.raw + suffix,
-        src: tail.src + suffix,
-      },
-    ],
+  if (!suffix) return previous
+  if (tail?.mode === "live") {
+    const raw = tail.raw + suffix
+    if (raw.length <= LIVE_TAIL_MAX || !hasBlockBoundary(suffix)) {
+      return { text, blocks: [...previous.blocks.slice(0, -1), { ...tail, raw, src: heal(raw) }] }
+    }
+    return { text, blocks: [...previous.blocks.slice(0, -1), ...stream(raw, true)] }
   }
+  if (tail?.mode === "code" && !tail.complete && !closesFence(tail.raw, suffix)) {
+    return {
+      text,
+      blocks: [
+        ...previous.blocks.slice(0, -1),
+        {
+          ...tail,
+          raw: tail.raw + suffix,
+          src: tail.src + suffix,
+        },
+      ],
+    }
+  }
+  return { text, blocks: stream(text, live) }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #36043 — jointly with the tui-delta-coalesce PR. Each applies
independently (different layer, no shared code, merge in either order);
only together do they remove O(n²) from both client-side stages of the
stream path and fully close the freeze. Builds on the freeze diagnosis in
#41472.

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

While streaming, the markdown projection re-parsed the entire accumulated text
on every delta, even when the previous text was unchanged and the new suffix
was small. Each re-lex is O(length), so a stream of n small deltas costs
O(n²) — the dominant cost in the TUI freeze once deltas are batched.

`project()` in `markdown-stream.ts` now grows the open `live` tail in place
instead of re-lexing, and only re-lexes when the new suffix contains a
blank-line block boundary or the raw text exceeds a 2048-char cap. A single
giant boundary-less paragraph/list/table therefore never re-parses per delta.

Because the projection lives in the shared `session-ui` package, web and
desktop also inherit the cheaper `project()` as a free performance win, even
though their per-token rendering is not the freeze described in #36043.

Counterpart on the store side: the tui-delta-coalesce PR (coalesces
`message.part.delta` events per part in a delta buffer, flushing to the store
on a 32 ms timer instead of once per event). Together they remove O(n²) from
both halves of the TUI stream path — the markdown projection here, the store
writes there.

### How did you verify your code works?

- `bun test`: 26 `markdown-stream` tests (incl. a new test growing a
  boundary-less oversized tail in place without splitting) — 86 tests, 0
  failures.
- `bun typecheck` clean in `packages/session-ui`.
- `oxlint`: 0 errors.
- Micro-benchmark streaming 6–15 KB through `project()` in small deltas
  (Bun): paragraphs 1399 ms → 20 ms, single 15 KB paragraph 32345 ms → 161 ms,
  growing list 4467 ms → 60 ms.

### Screenshots / recordings

N/A — no visual change; it's a rendering-perf fix (benchmark above).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


Tracking: anomalyco/opencode#48430
