### PR TITLE
feat(ai): type provider configuration errors

### DIFF
--- a/packages/ai/src/providers/alibaba.ts
+++ b/packages/ai/src/providers/alibaba.ts
@@ -6,7 +6,7 @@ import { AuthOptions, type AtLeastOne, type ProviderAuthOption } from "../route/
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
 import { Framing } from "../route/framing.js"
-import { ProviderID, ToolDefinition, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, ToolDefinition, type ModelID } from "../schema/index.js"
 
 export const id = ProviderID.make("alibaba")
 
@@ -82,8 +82,13 @@ export const configure = (input: Config) => {
         ? hosts.get(region)
         : `${workspaceID}.${region}.maas.aliyuncs.com`
   if (baseURL === undefined) {
-    if (region === undefined) throw new Error("Alibaba requires region or baseURL")
-    if (host === undefined) throw new Error(`Alibaba region ${region} requires workspaceID or baseURL`)
+    if (region === undefined)
+      throw new ProviderConfigurationError({ provider: id, message: "Alibaba requires region or baseURL" })
+    if (host === undefined)
+      throw new ProviderConfigurationError({
+        provider: id,
+        message: `Alibaba region ${region} requires workspaceID or baseURL`,
+      })
   }
   const opts = { ...rest, auth: AuthOptions.bearer(input, ["DASHSCOPE_API_KEY", "ALIBABA_API_KEY"]) }
   const common = { ...opts, endpoint: { baseURL: baseURL ?? `https://${host}/compatible-mode/v1` } }

--- a/packages/ai/src/providers/amazon-bedrock-mantle.ts
+++ b/packages/ai/src/providers/amazon-bedrock-mantle.ts
@@ -4,7 +4,7 @@ import type { ProviderPackage } from "../provider-package.js"
 import { OpenAIChat } from "../protocols/openai-chat.js"
 import { OpenResponses } from "../protocols/open-responses.js"
 import { BedrockAuth, type Credentials } from "../protocols/utils/bedrock-auth.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import { withOpenAIOptions, type OpenAIProviderOptionsInput } from "./openai-options.js"
 
 export const id = ProviderID.make("amazon-bedrock")
@@ -79,9 +79,12 @@ const defaults = (input: Config) => {
 
 export const configure = (input: Config = {}) => {
   if (input.auth === "bearer" && input.apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
-    throw new Error("Amazon Bedrock Mantle bearer auth requires apiKey")
+    throw new ProviderConfigurationError({ provider: id, message: "Amazon Bedrock Mantle bearer auth requires apiKey" })
   if (input.auth === "sigv4" && input.apiKey !== undefined)
-    throw new Error("Amazon Bedrock Mantle SigV4 auth does not accept apiKey")
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "Amazon Bedrock Mantle SigV4 auth does not accept apiKey",
+    })
   const configuredResponsesRoute = configuredRoute(responsesRoute, input)
   const configuredChatRoute = configuredRoute(chatRoute, input)
   const modelDefaults = defaults(input)

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1,6 +1,6 @@
 import type { RouteDefaultsInput } from "../route/client.js"
 import type { ProviderPackage } from "../provider-package.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import * as BedrockConverse from "../protocols/bedrock-converse.js"
 import type { BedrockCredentials } from "../protocols/bedrock-converse.js"
 import { BedrockAuth } from "../protocols/utils/bedrock-auth.js"
@@ -39,8 +39,9 @@ const bedrockBaseURL = (region: string) => `https://bedrock-runtime.${region}.am
 const configuredRoute = (input: Config) => {
   const { apiKey, auth, credentials, profile, region, baseURL, ...rest } = input
   if (auth === "bearer" && apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
-    throw new Error("Amazon Bedrock bearer auth requires apiKey")
-  if (auth === "sigv4" && apiKey !== undefined) throw new Error("Amazon Bedrock SigV4 auth does not accept apiKey")
+    throw new ProviderConfigurationError({ provider: id, message: "Amazon Bedrock bearer auth requires apiKey" })
+  if (auth === "sigv4" && apiKey !== undefined)
+    throw new ProviderConfigurationError({ provider: id, message: "Amazon Bedrock SigV4 auth does not accept apiKey" })
   const resolvedRegion = BedrockAuth.resolveRegion(input)
   return BedrockConverse.route.with({
     ...rest,

--- a/packages/ai/src/providers/anthropic-compatible.ts
+++ b/packages/ai/src/providers/anthropic-compatible.ts
@@ -3,7 +3,7 @@ import { AnthropicMessages } from "../protocols/anthropic-messages.js"
 import { Auth } from "../route/auth.js"
 import type { ProviderAuthOption } from "../route/auth-options.js"
 import type { RouteDefaultsInput } from "../route/client.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 
 export type AnthropicOptionsInput = AnthropicMessages.OptionsInput
 export type AnthropicProviderOptionsInput = AnthropicMessages.ProviderOptionsInput
@@ -36,8 +36,12 @@ const auth = (input: ProviderAuthOption<"optional">) => {
 }
 
 export const configure = (input: Config) => {
-  if (!input.baseURL) throw new Error("Anthropic-compatible providers require a baseURL")
   const provider = input.provider ?? "anthropic-compatible"
+  if (!input.baseURL)
+    throw new ProviderConfigurationError({
+      provider: ProviderID.make(provider),
+      message: "Anthropic-compatible providers require a baseURL",
+    })
   const { provider: _, baseURL, apiKey: _apiKey, auth: _auth, ...rest } = input
   const route = AnthropicMessages.route.with({
     ...rest,
@@ -61,8 +65,13 @@ export const model: ProviderPackage.Definition<Settings, AnthropicMessages.Provi
   modelID,
   settings,
 ) => {
+  // Read before the exclusivity check narrows a conflicting settings object to `never`.
+  const provider = ProviderID.make(settings.provider ?? id)
   if (settings.apiKey !== undefined && settings.authToken !== undefined)
-    throw new Error("Anthropic-compatible apiKey cannot be combined with authToken")
+    throw new ProviderConfigurationError({
+      provider,
+      message: "Anthropic-compatible apiKey cannot be combined with authToken",
+    })
   return configure({
     ...(settings.authToken === undefined ? { apiKey: settings.apiKey } : { auth: Auth.bearer(settings.authToken) }),
     baseURL: settings.baseURL,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2,7 +2,7 @@ import type { RouteDefaultsInput } from "../route/client.js"
 import { Auth } from "../route/auth.js"
 import type { ProviderAuthOption } from "../route/auth-options.js"
 import type { ProviderPackage } from "../provider-package.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import { AnthropicMessages } from "../protocols/anthropic-messages.js"
 import { AnthropicCompatible } from "./anthropic-compatible.js"
 
@@ -57,7 +57,10 @@ export const model: ProviderPackage.Definition<Settings, AnthropicMessages.Provi
   settings,
 ) => {
   if (settings.apiKey !== undefined && settings.authToken !== undefined)
-    throw new Error("Anthropic apiKey cannot be combined with authToken")
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "Anthropic apiKey cannot be combined with authToken",
+    })
   return configure({
     ...(settings.authToken === undefined ? { apiKey: settings.apiKey } : { auth: Auth.bearer(settings.authToken) }),
     baseURL: settings.baseURL,

--- a/packages/ai/src/providers/azure.ts
+++ b/packages/ai/src/providers/azure.ts
@@ -3,7 +3,7 @@ import { Auth } from "../route/auth.js"
 import { type AtLeastOne, type ProviderAuthOption } from "../route/auth-options.js"
 import type { Route, RouteDefaultsInput, CompactionOperations } from "../route/client.js"
 import type { ProviderPackage } from "../provider-package.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import * as OpenAIChat from "../protocols/openai-chat.js"
 import * as OpenAIResponses from "../protocols/openai-responses.js"
 import { ProviderShared } from "../protocols/shared.js"
@@ -163,7 +163,7 @@ const config = (settings: Settings): Config => {
   }
   if (settings.baseURL !== undefined) return { ...common, baseURL: settings.baseURL }
   if (settings.resourceName !== undefined) return { ...common, resourceName: settings.resourceName }
-  throw new Error("Azure requires resourceName or baseURL")
+  throw new ProviderConfigurationError({ provider: id, message: "Azure requires resourceName or baseURL" })
 }
 
 export const responsesModel: ProviderPackage.Definition<

--- a/packages/ai/src/providers/cloudflare-ai-gateway.ts
+++ b/packages/ai/src/providers/cloudflare-ai-gateway.ts
@@ -5,7 +5,7 @@ import { Auth } from "../route/auth.js"
 import type { AtLeastOne, ProviderAuthOption } from "../route/auth-options.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import type { OpenAIProviderOptionsInput } from "./openai-options.js"
 
 export const id = ProviderID.make("cloudflare-ai-gateway")
@@ -35,7 +35,11 @@ export type Settings = ProviderPackage.Settings &
 
 export const baseURL = (input: GatewayURL) => {
   if (input.baseURL) return input.baseURL
-  if (!input.accountId) throw new Error("CloudflareAIGateway.configure requires accountId unless baseURL is supplied")
+  if (!input.accountId)
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "CloudflareAIGateway.configure requires accountId unless baseURL is supplied",
+    })
   return `https://gateway.ai.cloudflare.com/v1/${encodeURIComponent(input.accountId)}/${encodeURIComponent(input.gatewayId?.trim() || "default")}/compat`
 }
 

--- a/packages/ai/src/providers/cloudflare-workers-ai.ts
+++ b/packages/ai/src/providers/cloudflare-workers-ai.ts
@@ -3,7 +3,7 @@ import { OpenAIChat } from "../protocols/openai-chat.js"
 import { AuthOptions, type AtLeastOne, type ProviderAuthOption } from "../route/auth-options.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import type { OpenAIProviderOptionsInput } from "./openai-options.js"
 
 export const id = ProviderID.make("cloudflare-workers-ai")
@@ -28,7 +28,11 @@ export type Settings = ProviderPackage.Settings &
 
 export const baseURL = (input: WorkersAIURL) => {
   if (input.baseURL) return input.baseURL
-  if (!input.accountId) throw new Error("CloudflareWorkersAI.configure requires accountId unless baseURL is supplied")
+  if (!input.accountId)
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "CloudflareWorkersAI.configure requires accountId unless baseURL is supplied",
+    })
   return `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(input.accountId)}/ai/v1`
 }
 

--- a/packages/ai/src/providers/google-vertex-chat.ts
+++ b/packages/ai/src/providers/google-vertex-chat.ts
@@ -2,7 +2,7 @@ import type { ProviderPackage } from "../provider-package.js"
 import { OpenAIChat } from "../protocols/openai-chat.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import { GoogleVertexShared } from "./google-vertex-shared.js"
 import type { OpenAIProviderOptionsInput } from "./openai-options.js"
 
@@ -37,7 +37,8 @@ const route = Route.make({
 export const routes = [route]
 
 const configuredRoute = (input: Config) => {
-  if ("apiKey" in input && input.apiKey !== undefined) throw new Error("Google Vertex Chat does not support API keys")
+  if ("apiKey" in input && input.apiKey !== undefined)
+    throw new ProviderConfigurationError({ provider: id, message: "Google Vertex Chat does not support API keys" })
   const {
     accessToken: _accessToken,
     auth: _auth,
@@ -74,7 +75,8 @@ export const provider = {
 }
 
 export const model: ProviderPackage.Definition<Settings, OpenAIProviderOptionsInput>["model"] = (modelID, settings) => {
-  if (settings.apiKey !== undefined) throw new Error("Google Vertex Chat does not support API keys")
+  if (settings.apiKey !== undefined)
+    throw new ProviderConfigurationError({ provider: id, message: "Google Vertex Chat does not support API keys" })
   return configure({
     accessToken: settings.accessToken,
     baseURL: settings.baseURL,

--- a/packages/ai/src/providers/google-vertex-messages.ts
+++ b/packages/ai/src/providers/google-vertex-messages.ts
@@ -5,7 +5,7 @@ import { Auth } from "../route/auth.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
 import { Protocol } from "../route/protocol.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import { GoogleVertexShared } from "./google-vertex-shared.js"
 
 export type AnthropicOptionsInput = AnthropicMessages.OptionsInput
@@ -67,7 +67,7 @@ export const routes = [route]
 
 const configuredRoute = (input: Config) => {
   if ("apiKey" in input && input.apiKey !== undefined)
-    throw new Error("Google Vertex Messages does not support API keys")
+    throw new ProviderConfigurationError({ provider: id, message: "Google Vertex Messages does not support API keys" })
   const {
     accessToken: _accessToken,
     auth: _auth,
@@ -107,7 +107,8 @@ export const model: ProviderPackage.Definition<Settings, AnthropicMessages.Provi
   modelID,
   settings,
 ) => {
-  if (settings.apiKey !== undefined) throw new Error("Google Vertex Messages does not support API keys")
+  if (settings.apiKey !== undefined)
+    throw new ProviderConfigurationError({ provider: id, message: "Google Vertex Messages does not support API keys" })
   return configure({
     accessToken: settings.accessToken,
     baseURL: settings.baseURL,

--- a/packages/ai/src/providers/google-vertex-responses.ts
+++ b/packages/ai/src/providers/google-vertex-responses.ts
@@ -2,7 +2,7 @@ import type { ProviderPackage } from "../provider-package.js"
 import { OpenResponses } from "../protocols/open-responses.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type ModelID } from "../schema/index.js"
 import { GoogleVertexShared } from "./google-vertex-shared.js"
 import type { OpenResponsesProviderOptionsInput } from "./open-responses-options.js"
 
@@ -39,7 +39,7 @@ export const routes = [route]
 
 const configuredRoute = (input: Config) => {
   if ("apiKey" in input && input.apiKey !== undefined)
-    throw new Error("Google Vertex Responses does not support API keys")
+    throw new ProviderConfigurationError({ provider: id, message: "Google Vertex Responses does not support API keys" })
   const {
     accessToken: _accessToken,
     auth: _auth,
@@ -79,7 +79,8 @@ export const model: ProviderPackage.Definition<Settings, OpenResponsesProviderOp
   modelID,
   settings,
 ) => {
-  if (settings.apiKey !== undefined) throw new Error("Google Vertex Responses does not support API keys")
+  if (settings.apiKey !== undefined)
+    throw new ProviderConfigurationError({ provider: id, message: "Google Vertex Responses does not support API keys" })
   return configure({
     accessToken: settings.accessToken,
     baseURL: settings.baseURL,

--- a/packages/ai/src/providers/google-vertex-shared.ts
+++ b/packages/ai/src/providers/google-vertex-shared.ts
@@ -1,8 +1,10 @@
 import type { AnyAuthClient } from "google-auth-library"
 import { Effect, Redacted } from "effect"
 import { Auth, MissingCredentialError } from "../route/auth.js"
+import { ProviderConfigurationError, ProviderID } from "../schema/index.js"
 
 const SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+const id = ProviderID.make("google-vertex")
 
 export type OAuthOptions =
   | { readonly accessToken?: string; readonly auth?: never }
@@ -35,12 +37,18 @@ export const host = (location: string) => {
 
 export const requireProject = (value: string | undefined) => {
   if (value) return value
-  throw new Error("Google Vertex requires a project when baseURL is not configured")
+  throw new ProviderConfigurationError({
+    provider: id,
+    message: "Google Vertex requires a project when baseURL is not configured",
+  })
 }
 
 export const apiKey = (input: ApiKeyOptions) => {
   if (input.apiKey !== undefined && (input.accessToken !== undefined || input.auth !== undefined))
-    throw new Error("Google Vertex apiKey cannot be combined with accessToken or auth")
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "Google Vertex apiKey cannot be combined with accessToken or auth",
+    })
   if (input.accessToken !== undefined || input.auth !== undefined) return undefined
   return input.apiKey ?? process.env.GOOGLE_VERTEX_API_KEY
 }
@@ -68,7 +76,10 @@ const adc = (project?: string) => {
 
 export const oauth = (input: OAuthOptions, project?: string) => {
   if (input.accessToken !== undefined && input.auth !== undefined)
-    throw new Error("Google Vertex accessToken cannot be combined with auth")
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "Google Vertex accessToken cannot be combined with auth",
+    })
   if (input.auth) return input.auth
   if (input.accessToken !== undefined) return Auth.bearer(input.accessToken)
   return adc(project)

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -6,7 +6,7 @@ import { Auth } from "../route/auth.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import { Endpoint } from "../route/endpoint.js"
 import { Framing } from "../route/framing.js"
-import { ProviderID, type LLMRequest, type ModelID } from "../schema/index.js"
+import { ProviderConfigurationError, ProviderID, type LLMRequest, type ModelID } from "../schema/index.js"
 import { GoogleVertexShared } from "./google-vertex-shared.js"
 
 export interface GeminiOptionsInput extends Gemini.OptionsInput {
@@ -93,7 +93,10 @@ const configuredRoute = (input: Config, modelID: string | ModelID) => {
   const apiKey = GoogleVertexShared.apiKey(input)
   const endpointModel = String(modelID).startsWith("endpoints/")
   if (apiKey !== undefined && endpointModel)
-    throw new Error("Google Vertex tuned models do not support Express Mode API keys")
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "Google Vertex tuned models do not support Express Mode API keys",
+    })
   const location = GoogleVertexShared.location(inputLocation, "us-central1")
   const project = GoogleVertexShared.project(inputProject)
   const endpoint =
@@ -123,7 +126,10 @@ export const provider = {
 }
 export const model: ProviderPackage.Definition<Settings, GeminiProviderOptionsInput>["model"] = (modelID, settings) => {
   if (settings.apiKey !== undefined && settings.accessToken !== undefined)
-    throw new Error("Google Vertex apiKey cannot be combined with accessToken or auth")
+    throw new ProviderConfigurationError({
+      provider: id,
+      message: "Google Vertex apiKey cannot be combined with accessToken or auth",
+    })
   return configure({
     ...(settings.apiKey === undefined ? { accessToken: settings.accessToken } : { apiKey: settings.apiKey }),
     baseURL: settings.baseURL,

--- a/packages/ai/src/route/client.ts
+++ b/packages/ai/src/route/client.ts
@@ -23,6 +23,7 @@ import {
   LanguageModel,
   LLMEvent,
   InvalidProviderOutputError,
+  ProviderConfigurationError,
   ProviderID,
   mergeGenerationOptions,
   mergeHttpOptions,
@@ -128,7 +129,10 @@ const makeRouteLanguageModel = <Options extends ProviderOptions, Compact extends
   const provider = route.provider ?? ("provider" in mapped ? mapped.provider : undefined)
   if (!provider) throw new Error(`Route.model(${route.id}) requires a provider`)
   if (!endpointBaseURL(route.endpoint))
-    throw new Error(`Route.model(${route.id}) requires an endpoint baseURL — configure it on the route first`)
+    throw new ProviderConfigurationError({
+      provider: ProviderID.make(provider),
+      message: `Route.model(${route.id}) requires an endpoint baseURL — configure it on the route first`,
+    })
   return LanguageModel.make<Options, Compact>({
     ...mapped,
     provider,

--- a/packages/ai/src/schema/errors.ts
+++ b/packages/ai/src/schema/errors.ts
@@ -50,6 +50,19 @@ export class UnsupportedOperationError extends Schema.TaggedError<UnsupportedOpe
   route: Schema.optional(RouteID),
 }) {}
 
+/**
+ * Provider settings that are missing, conflicting, or unsupported, such as
+ * Azure without `resourceName` or `baseURL`. Thrown synchronously while a
+ * provider facade or package entrypoint configures a model, before any
+ * request exists, so it is not an `AIError` reason.
+ */
+export class ProviderConfigurationError extends Schema.TaggedError<ProviderConfigurationError>(
+  "AI.Error.ProviderConfiguration",
+)("ProviderConfiguration", {
+  provider: ProviderID,
+  message: Schema.String,
+}) {}
+
 export class NoRouteError extends Schema.TaggedError<NoRouteError>("AI.Error.NoRoute")("NoRoute", {
   ...ReasonFields,
   route: RouteID,

--- a/packages/ai/test/provider-package.test.ts
+++ b/packages/ai/test/provider-package.test.ts
@@ -3,6 +3,9 @@ import { model } from "@opencode/ai/providers/openai"
 import { LLM } from "../src/index.js"
 import { Endpoint } from "../src/route/endpoint.js"
 
+const configuration = (provider: string, message: string) =>
+  expect.objectContaining({ _tag: "ProviderConfiguration", provider, message })
+
 describe("provider package entrypoints", () => {
   test("semantic API aliases expose the same contract", async () => {
     const modules = await Promise.all([
@@ -322,7 +325,7 @@ describe("provider package entrypoints", () => {
     const AnthropicCompatible = await import("@opencode/ai/providers/anthropic-compatible")
     expect(() =>
       Reflect.apply(AnthropicCompatible.model, undefined, ["compatible-model", { apiKey: "fixture" }]),
-    ).toThrow("Anthropic-compatible providers require a baseURL")
+    ).toThrow(configuration("anthropic-compatible", "Anthropic-compatible providers require a baseURL"))
   })
 
   test("rejects conflicting Anthropic-compatible auth settings at runtime", async () => {
@@ -337,10 +340,10 @@ describe("provider package entrypoints", () => {
           baseURL: "https://messages.example.test/v1",
         },
       ]),
-    ).toThrow("Anthropic-compatible apiKey cannot be combined with authToken")
+    ).toThrow(configuration("anthropic-compatible", "Anthropic-compatible apiKey cannot be combined with authToken"))
     expect(() =>
       Reflect.apply(Anthropic.model, undefined, ["claude-sonnet-4-6", { apiKey: "fixture", authToken: "token" }]),
-    ).toThrow("Anthropic apiKey cannot be combined with authToken")
+    ).toThrow(configuration("anthropic", "Anthropic apiKey cannot be combined with authToken"))
   })
 
   test("maps legacy OpenAI organization and project settings to headers", () => {
@@ -490,43 +493,45 @@ describe("provider package entrypoints", () => {
         "gemini-3.5-flash",
         { accessToken: "token", apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex apiKey cannot be combined with accessToken or auth")
+    ).toThrow(configuration("google-vertex", "Google Vertex apiKey cannot be combined with accessToken or auth"))
     const configured = Reflect.apply(GoogleVertex.configure, undefined, [
       { accessToken: "token", auth: {}, project: "vertex-project" },
     ])
-    expect(() => configured.model("gemini-3.5-flash")).toThrow("Google Vertex accessToken cannot be combined with auth")
+    expect(() => configured.model("gemini-3.5-flash")).toThrow(
+      configuration("google-vertex", "Google Vertex accessToken cannot be combined with auth"),
+    )
     expect(() =>
       Reflect.apply(GoogleVertexMessages.model, undefined, [
         "claude-sonnet-4-6",
         { apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex Messages does not support API keys")
+    ).toThrow(configuration("google-vertex", "Google Vertex Messages does not support API keys"))
     expect(() =>
       Reflect.apply(Providers.GoogleVertexMessages.configure, undefined, [
         { apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex Messages does not support API keys")
+    ).toThrow(configuration("google-vertex", "Google Vertex Messages does not support API keys"))
     expect(() =>
       Reflect.apply(GoogleVertexChat.model, undefined, [
         "deepseek-ai/deepseek-v3.2-maas",
         { apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex Chat does not support API keys")
+    ).toThrow(configuration("google-vertex", "Google Vertex Chat does not support API keys"))
     expect(() =>
       Reflect.apply(Providers.GoogleVertexChat.configure, undefined, [
         { apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex Chat does not support API keys")
+    ).toThrow(configuration("google-vertex", "Google Vertex Chat does not support API keys"))
     expect(() =>
       Reflect.apply(GoogleVertexResponses.model, undefined, [
         "xai/grok-4.20-reasoning",
         { apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex Responses does not support API keys")
+    ).toThrow(configuration("google-vertex", "Google Vertex Responses does not support API keys"))
     expect(() =>
       Reflect.apply(Providers.GoogleVertexResponses.configure, undefined, [
         { apiKey: "fixture", project: "vertex-project" },
       ]),
-    ).toThrow("Google Vertex Responses does not support API keys")
+    ).toThrow(configuration("google-vertex", "Google Vertex Responses does not support API keys"))
   })
 })

--- a/packages/ai/test/provider/alibaba.test.ts
+++ b/packages/ai/test/provider/alibaba.test.ts
@@ -76,7 +76,13 @@ it.effect("Alibaba owns regional shared and workspace-specific endpoints", () =>
 
 test("Alibaba requires explicit placement and supports complete base URL overrides", () => {
   for (const region of ["eu-central-1", "ap-northeast-1", "future-region"])
-    expect(() => Alibaba.configure({ region })).toThrow("requires workspaceID or baseURL")
+    expect(() => Alibaba.configure({ region })).toThrow(
+      expect.objectContaining({
+        _tag: "ProviderConfiguration",
+        provider: "alibaba",
+        message: `Alibaba region ${region} requires workspaceID or baseURL`,
+      }),
+    )
   for (const config of [
     { baseURL: "https://gateway.example/prefix" },
     { region: "future-region", workspaceID: "ignored", baseURL: "https://gateway.example/prefix" },

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -1458,7 +1458,13 @@ describe("Bedrock Converse route", () => {
         expect(headers.get("authorization")).toContain("Credential=AKIACHAINEXAMPLE/")
         expect(headers.get("authorization")).toContain("/ap-southeast-2/bedrock/aws4_request")
       }
-      expect(() => AmazonBedrock.configure({ auth: "sigv4", apiKey: "k" })).toThrow("does not accept apiKey")
+      expect(() => AmazonBedrock.configure({ auth: "sigv4", apiKey: "k" })).toThrow(
+        expect.objectContaining({
+          _tag: "ProviderConfiguration",
+          provider: "amazon-bedrock",
+          message: "Amazon Bedrock SigV4 auth does not accept apiKey",
+        }),
+      )
     }).pipe(
       withProcessEnv({
         ...noAmbientAWS,

--- a/packages/ai/test/provider/google-vertex.test.ts
+++ b/packages/ai/test/provider/google-vertex.test.ts
@@ -378,7 +378,11 @@ describe("Google Vertex providers", () => {
 
   test("rejects tuned Gemini models in express mode", () => {
     expect(() => GoogleVertex.configure({ apiKey: "fixture" }).model("endpoints/1234567890")).toThrow(
-      "Google Vertex tuned models do not support Express Mode API keys",
+      expect.objectContaining({
+        _tag: "ProviderConfiguration",
+        provider: "google-vertex",
+        message: "Google Vertex tuned models do not support Express Mode API keys",
+      }),
     )
   })
 })


### PR DESCRIPTION
## Summary

Provider facades and package entrypoints in `@opencode/ai` rejected invalid settings with untyped `throw new Error(...)`, so consumers such as core's model resolver could only catch `unknown` and read `.message`. Every one of these throws is the same category: the settings handed to the provider are missing, conflicting, or unsupported.

This adds one typed error to the schema and uses it at each of those sites:

```ts
export class ProviderConfigurationError extends Schema.TaggedError<ProviderConfigurationError>(
  "AI.Error.ProviderConfiguration",
)("ProviderConfiguration", {
  provider: ProviderID,
  message: Schema.String,
}) {}
```

It is thrown synchronously during model configuration, before any request exists, so it is intentionally not added to the `AIErrorReason` union.

## Converted sites

- Alibaba: missing `region`/`baseURL`, unknown region without `workspaceID`
- Amazon Bedrock and Bedrock Mantle: bearer auth without `apiKey`, SigV4 with `apiKey`
- Anthropic and Anthropic-compatible: `apiKey` combined with `authToken`, missing `baseURL`
- Azure: missing `resourceName`/`baseURL`
- Cloudflare AI Gateway and Workers AI: missing `accountId`
- Google Vertex (Gemini, Chat, Messages, Responses, shared helpers): API key combined with OAuth, API keys on unsupported APIs, tuned models in express mode, missing project
- `Route.model(...)` without an endpoint `baseURL` (reachable from unconfigured OpenAI-compatible providers)

Left untouched as non-configuration failures: `Route.model` missing provider (internal invariant with no provider to name), the empty-ADC-token throw (already mapped to `MissingCredentialError`), WebSocket URL protocol, and partial-JSON parsing.

## Tests

Existing assertions that checked these messages now also assert the `ProviderConfiguration` tag and `provider` via `expect.objectContaining`. No new tests.

- `bun typecheck` in `packages/ai` and `packages/core`
- `bun test` in `packages/ai` (1300 pass, 0 fail)