### PR TITLE
feat(core): append comment guidance to Anthropic system prompt

### DIFF
--- a/packages/core/src/plugin/optimize.ts
+++ b/packages/core/src/plugin/optimize.ts
@@ -11,12 +11,26 @@ import PROMPT_ASTRA from "./system-prompt/gpt-astra.txt"
 import PROMPT_KIMI from "./system-prompt/kimi.txt"
 import PROMPT_META from "./system-prompt/meta.txt"
 import PROMPT_TRINITY from "./system-prompt/trinity.txt"
+import PROMPT_ANTHROPIC from "./system-prompt/anthropic.txt"
 
 export const OpenAIPlugin = make("opencode.prompt.openai", (model) => {
   const id = model.id.toLowerCase()
   if (!id.includes("gpt")) return undefined
   return id.includes("gpt-6") ? PROMPT_ASTRA : PROMPT_GPT
 })
+
+export const AnthropicPlugin = make(
+  "opencode.prompt.anthropic",
+  (model) => {
+    const id = model.id.toLowerCase()
+    if (!id.includes("claude")) return undefined
+    return PROMPT_ANTHROPIC
+  },
+  "append",
+)
+
+// Both OpenAIToolsPlugin and AnthropicToolsPlugin are disabled intentionally until we can figure out a good ux for displaying
+// heavy grep/glob usage done via shell or other mechanisms
 
 export const OpenAIToolsPlugin = make("opencode.optimize.openai.tools", (model, tools) => {
   const ids = [model.id, model.modelID, model.family].join(" ").toLowerCase()
@@ -45,11 +59,12 @@ export const MetaPlugin = make("opencode.prompt.meta", (model) => {
   return PROMPT_META.replaceAll("{{MODEL_NAME}}", model.name)
 })
 
-export const Plugins = [OpenAIPlugin, KimiPlugin, ArceePlugin, MetaPlugin] as const
+export const Plugins = [OpenAIPlugin, AnthropicPlugin, KimiPlugin, ArceePlugin, MetaPlugin] as const
 
 function make(
   id: string,
   optimize: (model: Model.Info, tools: SessionHooks["context"]["tools"]) => string | undefined,
+  mode: "override" | "append" = "override",
 ) {
   return define({
     id,
@@ -66,7 +81,9 @@ function make(
           if ((yield* ctx.agent.get({ agentID: event.agent })).data.system) return
           const system = event.system[0]
           if (!system) return
-          event.system[0] = { ...system, text: SessionSystemPrompt.render(template, Object.keys(event.tools)) }
+          const rendered = SessionSystemPrompt.render(template, Object.keys(event.tools))
+          const text = mode === "append" ? `${system.text}\n\n${rendered}` : rendered
+          event.system[0] = { ...system, text }
         }).pipe(Effect.catch(() => Effect.void))
       yield* ctx.session.hook("context", hook)
       yield* ctx.session.hook("compaction", hook)

--- a/packages/core/src/plugin/system-prompt/anthropic.txt
+++ b/packages/core/src/plugin/system-prompt/anthropic.txt
@@ -1,0 +1,2 @@
+# Code comments
+By default, match the surrounding comment density: where the code has none, add none. Use comments sparingly, only where they are appropriate, such as for behavior that is not obvious from the code itself. Instructions from the user or the project take precedence over this guidance.

--- a/packages/core/test/plugin/optimize.test.ts
+++ b/packages/core/test/plugin/optimize.test.ts
@@ -19,9 +19,11 @@ import PROMPT_GPT from "../../src/plugin/system-prompt/gpt.txt"
 import PROMPT_ASTRA from "../../src/plugin/system-prompt/gpt-astra.txt"
 import PROMPT_KIMI from "../../src/plugin/system-prompt/kimi.txt"
 import PROMPT_TRINITY from "../../src/plugin/system-prompt/trinity.txt"
+import PROMPT_ANTHROPIC from "../../src/plugin/system-prompt/anthropic.txt"
 
 const it = testEffect(PluginTestLayer)
 const fallback = SessionSystemPrompt.make([])
+const appended = `${fallback}\n\n${SessionSystemPrompt.render(PROMPT_ANTHROPIC, [])}`
 const makeHost = Effect.gen(function* () {
   const agents = yield* Agent.Service
   const plugins = yield* Plugin.Service
@@ -48,6 +50,7 @@ describe("OptimizePlugin", () => {
   test("enables prompt plugins without model-specific tool optimization", () => {
     expect(OptimizePlugin.Plugins.map((plugin) => plugin.id)).toEqual([
       "opencode.prompt.openai",
+      "opencode.prompt.anthropic",
       "opencode.prompt.kimi",
       "opencode.prompt.arcee",
       "opencode.prompt.meta",
@@ -76,7 +79,7 @@ describe("OptimizePlugin", () => {
         ["gpt-5-codex", PROMPT_GPT],
         ["gpt-6-astra", PROMPT_ASTRA],
         ["gemini-2.5-pro", fallback],
-        ["claude-sonnet-4", fallback],
+        ["claude-sonnet-4", appended],
         ["kimi-k2", PROMPT_KIMI],
         ["trinity", PROMPT_TRINITY],
         ["meta/muse-spark-1.1", PROMPT_META.replaceAll("{{MODEL_NAME}}", "Muse Spark")],
@@ -124,6 +127,30 @@ describe("OptimizePlugin", () => {
         "Project instructions",
       ])
       expect(event.system[0]?.text).not.toContain("${OPENCODE_TOOL_GUIDANCE}")
+      expect(Object.keys(event.tools).sort()).toEqual(["edit", "glob", "grep", "patch", "read", "shell", "write"])
+    }),
+  )
+
+  it.effect("appends the Anthropic prompt to the baseline without changing tools or project instructions", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const hooks = yield* PluginHooks.Service
+      const pluginHost = yield* makeHost
+      yield* catalog.transform((editor) =>
+        editor.model.update(Provider.ID.make("test"), Model.ID.make("claude-sonnet-4"), () => {}),
+      )
+      yield* OptimizePlugin.AnthropicPlugin.effect(pluginHost)
+      const event = context("claude-sonnet-4")
+      event.system.push(SystemPart.make("Project instructions"))
+
+      yield* hooks.trigger("session", "context", event)
+
+      const baseline = SessionSystemPrompt.render(fallback, Object.keys(event.tools))
+      expect(event.system.map((part) => part.text)).toEqual([
+        `${baseline}\n\n${SessionSystemPrompt.render(PROMPT_ANTHROPIC, Object.keys(event.tools))}`,
+        "Project instructions",
+      ])
+      expect(event.system[0]?.text.startsWith(baseline)).toBe(true)
       expect(Object.keys(event.tools).sort()).toEqual(["edit", "glob", "grep", "patch", "read", "shell", "write"])
     }),
   )
@@ -298,7 +325,7 @@ describe("OptimizePlugin", () => {
         ["codex-family-alias", "custom-deployment", "GPT-CODEX", fallback],
         ["astra-api-alias", "gpt-6-astra", undefined, fallback],
         ["astra-family-alias", "custom-deployment", "gpt-6", fallback],
-        ["claude-catalog-alias", "custom-model", undefined, fallback],
+        ["claude-catalog-alias", "custom-model", undefined, appended],
         ["anthropic-api-alias", "Claude-Opus-4-8", undefined, fallback],
         ["anthropic-family-alias", "custom-deployment", "CLAUDE-SONNET", fallback],
       ] as const


### PR DESCRIPTION
## Summary

- Add an `append` mode to the optimize plugin `make` helper alongside the existing `override` behavior. Append keeps the baseline system prompt and adds the rendered template after it.
- Add `AnthropicPlugin`, enabled by default, which appends a `# Code comments` section for Claude models to curb reflexive per-function commenting.
- Cover the append path in `optimize.test.ts`.

## Prompt

```
# Code comments
By default, match the surrounding comment density: where the code has none, add none. Use comments sparingly, only where they are appropriate, such as for behavior that is not obvious from the code itself. Instructions from the user or the project take precedence over this guidance.
```