### PR TITLE
fix: live-refresh desktop file panel on disk changes

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -238,6 +238,14 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       })
     })
 
+    // The inotify watcher can go quiet for a session's directory (location teardown drains its
+    // subscription), so watcher events alone leave the panel stale. Poll loaded dirs as a fallback;
+    // FileSystem.list is cacheless, so a forced re-list always reflects disk state.
+    const poll = setInterval(() => {
+      if (document.visibilityState !== "visible") return
+      void tree.refreshLoaded()
+    }, 5_000)
+
     const get = (input: string) => {
       const file = path.normalize(input)
       const state = store.file[file]
@@ -264,6 +272,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
 
     onCleanup(() => {
       stop()
+      clearInterval(poll)
       viewCache.clear()
     })
 
@@ -275,6 +284,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       tree: {
         list: tree.listDir,
         refresh: (input: string) => tree.listDir(input, { force: true }),
+        refreshLoaded: tree.refreshLoaded,
         state: tree.dirState,
         children: tree.children,
         expand: tree.expandDir,

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -39,7 +39,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     setTree("dir", path, { expanded: false })
   }
 
-  const listDir = (input: string, opts?: { force?: boolean }) => {
+  const listDir = (input: string, opts?: { force?: boolean; suppressError?: boolean }) => {
     const dir = options.normalizeDir(input)
     ensureDir(dir)
 
@@ -117,7 +117,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
             draft.error = e.message
           }),
         )
-        options.onError(e.message)
+        if (!opts?.suppressError) options.onError(e.message)
       })
       .finally(() => {
         inflight.delete(dir)
@@ -161,12 +161,18 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     return out
   }
 
+  const refreshLoaded = () => {
+    const loaded = Object.keys(tree.dir).filter((dir) => tree.dir[dir]?.loaded && tree.dir[dir]?.expanded)
+    return Promise.all(loaded.map((dir) => listDir(dir, { force: true, suppressError: true }))).then(() => undefined)
+  }
+
   return {
     listDir,
     expandDir,
     collapseDir,
     dirState,
     children,
+    refreshLoaded,
     node: (path: string) => tree.node[path],
     isLoaded: (path: string) => Boolean(tree.dir[path]?.loaded),
     reset,

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -106,11 +106,9 @@ const layer = Layer.effect(
     const config = (yield* (yield* Config.Service).entries())
       .filter((entry): entry is Config.Document => entry.type === "document")
       .flatMap((item) => item.info.watcher?.ignore ?? [])
-    if (location.vcs && (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER)) {
-      yield* Effect.forkScoped(
-        subscribe(location.directory, [...Ignore.PATTERNS, ...config, ...protecteds(location.directory)]),
-      )
-    }
+    yield* Effect.forkScoped(
+      subscribe(location.directory, [...Ignore.PATTERNS, ...config, ...protecteds(location.directory)]),
+    )
 
     if (location.vcs?.type === "git") {
       const resolved = (yield* git.repo.discover(location.directory))?.gitDirectory

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -168,12 +168,15 @@ describeWatcher("Watcher", () => {
     ),
   )
 
-  it.live("skips non-git roots", () =>
+  it.live("publishes events for non-git roots", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
         const fs = yield* FSUtil.Service
         const file = path.join(directory, "plain.txt")
-        yield* noUpdate((event) => event.file === file, fs.writeFileString(file, "plain"))
+        yield* ready(directory)
+        expect(
+          yield* nextUpdate((event) => event.file === file && event.event === "add", fs.writeFileString(file, "plain")),
+        ).toEqual({ file, event: "add" })
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #48451

### Type of change

- [x] Bug fix

### What does this PR do?

The desktop "All files" panel did not live-refresh on disk changes made outside the agent Write tool: created files appeared only after an unrelated refresh, and deleted files never disappeared.

Root cause: the filesystem watcher is location-scoped. When a session directory is invalidated, its inotify subscription is torn down and nothing re-subscribes it, so the panel stops receiving change events.

Fix, two parts:

1. `packages/core`: watch the workspace directory unconditionally instead of gating it behind the experimental flag + VCS check, so non-git roots get live events too.
2. `packages/app`: while the window is visible, poll every expanded/loaded directory every 5s when watcher events are absent. `FileSystem.list` is cacheless and error toasts are suppressed for polled directories. Watcher events remain the fast path.

### How did you verify your code works?

- `bun typecheck` clean and 45 file-context unit tests pass in `packages/app`.
- Reproduced on the desktop app: external `touch` and `rm` now appear/disappear in the panel within one poll cycle.
- Updated the core watcher test; confirmed it passes for non-git roots.

### Screenshots / recordings

n/a (behavior change, verified live rather than visual)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR