### PR TITLE
docs: fix v2 plugin system example

### DIFF
--- a/services/www/src/docs/content/build/plugins/index.mdx
+++ b/services/www/src/docs/content/build/plugins/index.mdx
@@ -1222,7 +1222,7 @@ differently:
 
 ```ts
 await ctx.session.hook("context", (event) => {
-  event.system.push({ text: "Keep the review focused on correctness." })
+  event.system.push({ type: "text", text: "Keep the review focused on correctness." })
   delete event.tools.write
   event.options.temperature = 0.2
   event.options.maxTokens = 8_000


### PR DESCRIPTION
### Issue for this PR

Fixes #48450

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the required `type: "text"` discriminant to the V2 plugin `event.system` example so it matches `LLM.SystemPart`.

### How did you verify your code works?

- `bun run check:generated` from `services/www`
- `bun typecheck` from `services/www`
- `bun run build` from `services/www`

The repository-wide pre-push typecheck has an unrelated existing `TS1128` failure in `packages/app/src/custom-elements.d.ts`.

### Screenshots / recordings

Not applicable for this documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
