### PR TITLE
feat(tui): show active skills in session sidebar

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -9,6 +9,7 @@ import { Token } from "@/util/token"
 import { SessionProcessor } from "./processor"
 import { Agent } from "@/agent/agent"
 import { Plugin } from "@/plugin"
+import { Skill } from "@/skill"
 import { Config } from "@/config/config"
 import { NotFoundError } from "@/storage/storage"
 
@@ -194,6 +195,7 @@ const layer = Layer.effect(
     const config = yield* Config.Service
     const session = yield* Session.Service
     const agents = yield* Agent.Service
+    const skill = yield* Skill.Service
     const plugin = yield* Plugin.Service
     const processors = yield* SessionProcessor.Service
     const provider = yield* Provider.Service
@@ -360,6 +362,8 @@ const layer = Layer.effect(
         ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
         : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
       const cfg = yield* config.get()
+      const sessionAgent = yield* agents.get(userMessage.agent)
+      const sessionSkills = sessionAgent ? yield* skill.available(sessionAgent) : []
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
       const prior = completedCompactions(history)
       const hidden = new Set(prior.flatMap((item) => [item.userIndex, item.assistantIndex]))
@@ -378,17 +382,21 @@ const layer = Layer.effect(
       const msgs = structuredClone(selected.head)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const conversation = msgs.map(serialize).filter(Boolean).join("\n\n")
-      const nextPrompt =
-        compacting.prompt ??
-        [
-          buildPrompt({
-            previousSummary,
-            context: [conversation],
-          }),
-          ...compacting.context,
-        ]
-          .filter(Boolean)
-          .join("\n\n")
+      const skillsBlock = sessionSkills.length
+        ? [
+            "<session_skills>",
+            "These skills were available to the coding agent during this session. In the summary's Important Details section, include exactly one bullet listing these skill names (comma-separated) so later turns know they exist and can load them with the skill tool:",
+            Skill.fmt(sessionSkills, { verbose: false }),
+            "</session_skills>",
+          ].join("\n")
+        : undefined
+      const nextPrompt = [
+        compacting.prompt ?? buildPrompt({ previousSummary, context: [conversation] }),
+        ...compacting.context,
+        skillsBlock,
+      ]
+        .filter(Boolean)
+        .join("\n\n")
       const ctx = yield* InstanceState.context
       const msg: SessionV1.Assistant = {
         id: MessageID.ascending(),
@@ -528,7 +536,10 @@ const layer = Layer.effect(
               (input.overflow
                 ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
                 : "") +
-              "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
+              "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed." +
+              (sessionSkills.length
+                ? `\n\nThese skills are still available — load one with the skill tool when the task matches: ${sessionSkills.map((item) => item.name).join(", ")}.`
+                : "")
             yield* session.updatePart({
               id: PartID.ascending(),
               messageID: continueMsg.id,
@@ -597,6 +608,7 @@ export const node = LayerNode.make({
     Config.node,
     Session.node,
     Agent.node,
+    Skill.node,
     Plugin.node,
     SessionProcessor.node,
     Provider.node,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1267,6 +1267,28 @@ const layer = Layer.effect(
               ...(mcpInstructions ? [mcpInstructions] : []),
               ...(skills ? [skills] : []),
             ]
+            const loadedSkills = [
+              ...new Set(
+                msgs
+                  .flatMap((m) => m.parts)
+                  .filter(
+                    (p): p is SessionV1.ToolPart =>
+                      p.type === "tool" && p.tool === "skill" && p.state.status === "completed",
+                  )
+                  .map((p) => p.state.input.name)
+                  .filter((name): name is string => typeof name === "string"),
+              ),
+            ]
+            if (loadedSkills.length > 0) {
+              system.push(
+                [
+                  "<loaded_skills>",
+                  "These skills have already been loaded into the conversation via the skill tool. Their content is in the message history. Do NOT load them again — reference the existing content directly.",
+                  ...loadedSkills.map((name) => `  <skill>${name}</skill>`),
+                  "</loaded_skills>",
+                ].join("\n"),
+              )
+            }
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -104,6 +104,7 @@ type Opts = {
     part?: HostPluginApi["state"]["part"]
     lsp?: HostPluginApi["state"]["lsp"]
     mcp?: HostPluginApi["state"]["mcp"]
+    skills?: HostPluginApi["state"]["skills"]
   }
   theme?: {
     selected?: string
@@ -325,6 +326,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       part: opts.state?.part ?? (() => []),
       lsp: opts.state?.lsp ?? (() => []),
       mcp: opts.state?.mcp ?? (() => []),
+      skills: opts.state?.skills ?? (() => []),
     },
     theme: {
       get current() {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -396,6 +396,7 @@ export type TuiState = {
   part: (messageID: string) => ReadonlyArray<Part>
   lsp: () => ReadonlyArray<TuiSidebarLspItem>
   mcp: () => ReadonlyArray<TuiSidebarMcpItem>
+  skills: () => ReadonlyArray<TuiSidebarSkillItem>
 }
 
 type TuiBindingLookupView = {
@@ -445,6 +446,12 @@ export type TuiSidebarMcpItem = {
 export type TuiSidebarLspItem = Pick<LspStatus, "id" | "root" | "status">
 
 export type TuiSidebarTodoItem = Pick<Todo, "content" | "status">
+
+export type TuiSidebarSkillItem = {
+  name: string
+  description?: string
+  location: string
+}
 
 export type TuiSidebarFileItem = {
   file: string

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -20,6 +20,7 @@ import type {
   SnapshotFileDiff,
   ConsoleState,
 } from "@opencode-ai/sdk/v2"
+import type { TuiSidebarSkillItem } from "@opencode-ai/plugin/tui"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useProject } from "./project"
 import { useEvent } from "./event"
@@ -103,6 +104,7 @@ export const {
         [messageID: string]: Part[]
       }
       lsp: LspStatus[]
+      skills: TuiSidebarSkillItem[]
       mcp: {
         [key: string]: McpStatus
       }
@@ -137,6 +139,7 @@ export const {
       message: {},
       part: {},
       lsp: [],
+      skills: [],
       mcp: {},
       mcp_resource: {},
       formatter: [],
@@ -522,6 +525,7 @@ export const {
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
+            sdk.client.app.skills({ workspace }).then((x) => setStore("skills", reconcile(x.data ?? []))),
             sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
             sdk.client.experimental.resource
               .list({ workspace })

--- a/packages/tui/src/feature-plugins/builtins.ts
+++ b/packages/tui/src/feature-plugins/builtins.ts
@@ -6,6 +6,7 @@ import SidebarFiles from "./sidebar/files"
 import SidebarFooter from "./sidebar/footer"
 import SidebarLsp from "./sidebar/lsp"
 import SidebarMcp from "./sidebar/mcp"
+import SidebarSkills from "./sidebar/skills"
 import SidebarTodo from "./sidebar/todo"
 import DiffViewer from "./system/diff-viewer"
 import Notifications from "./system/notifications"
@@ -24,6 +25,7 @@ export function createBuiltinPlugins(options: { experimentalEventSystem: boolean
     HomeTips,
     SidebarContext,
     SidebarMcp,
+    SidebarSkills,
     SidebarLsp,
     SidebarTodo,
     SidebarFiles,

--- a/packages/tui/src/feature-plugins/sidebar/skills.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/skills.tsx
@@ -1,0 +1,88 @@
+import path from "path"
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { ToolPart } from "@opencode-ai/sdk/v2"
+import type { BuiltinTuiPlugin } from "../builtins"
+import { createMemo, For, Show, createSignal } from "solid-js"
+
+const id = "internal:sidebar-skills"
+
+function View(props: { api: TuiPluginApi; session_id: string }) {
+  const [open, setOpen] = createSignal(true)
+  const theme = () => props.api.theme.current
+  const all = createMemo(() => props.api.state.skills())
+  const invoked = createMemo(() => {
+    const names = props.api.state
+      .session.messages(props.session_id)
+      .flatMap((message) =>
+        props.api.state
+          .part(message.id)
+          .filter((part): part is ToolPart => part.type === "tool" && part.tool === "skill"),
+      )
+      .map((part) => part.state.input.name)
+      .filter((name): name is string => typeof name === "string")
+    return new Set(names)
+  })
+  const list = createMemo(() => all().filter((item) => invoked().has(item.name)))
+
+  const source = (location: string) => {
+    if (location === "<built-in>") return "built-in"
+    if (location.startsWith(props.api.state.path.worktree)) return "project"
+    const configDir = path.dirname(props.api.state.path.config)
+    if (configDir && configDir !== "." && location.startsWith(configDir)) return "global"
+    return "external"
+  }
+
+  return (
+    <box>
+      <box flexDirection="row" gap={1} onMouseDown={() => list().length > 2 && setOpen((x) => !x)}>
+        <Show when={list().length > 2}>
+          <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
+        </Show>
+        <text fg={theme().text}>
+          <b>Active Skills</b>
+        </text>
+      </box>
+      <Show when={list().length <= 2 || open()}>
+        <Show when={list().length === 0}>
+          <text fg={theme().textMuted}>No skills loaded</text>
+        </Show>
+        <For each={list()}>
+          {(item) => (
+            <box flexDirection="row" gap={1}>
+              <text
+                flexShrink={0}
+                style={{
+                  fg: theme().success,
+                }}
+              >
+                •
+              </text>
+              <text fg={theme().text} wrapMode="word">
+                {item.name}{" "}
+                <span style={{ fg: theme().textMuted }}>{source(item.location)}</span>
+              </text>
+            </box>
+          )}
+        </For>
+      </Show>
+    </box>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 250,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return <View api={api} session_id={props.session_id} />
+      },
+    },
+  })
+}
+
+const plugin: BuiltinTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -159,6 +159,9 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
           error: item.status === "failed" ? item.error : undefined,
         }))
     },
+    skills() {
+      return sync.data.skills
+    },
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #48355

### Type of change

- [x] New feature

### What does this PR do?

Adds an **Active Skills** section to the TUI session sidebar. It shows only skills that were actually loaded through the `skill` tool in the current session, rather than every discovered skill. The panel includes each skill's source (`built-in`, `project`, `global`, or `external`) and stays empty until a skill is loaded.

The harness now also adds a compact `<loaded_skills>` reminder to the system prompt on every turn. It tells the model which skills are already present in message history and not to load them again. Compaction carries the same skill list through the summary and auto-continue prompt, so the reminder survives a long session.

The skill list is permission-filtered for the session agent. If an old session refers to an agent that no longer exists, no skills are injected rather than falling back to the unfiltered list.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/plugin`, `packages/tui`, and `packages/opencode`.
- Ran `bun dev` from `packages/opencode` locally.
- Loaded the `clickcast` skill in a session: the sidebar showed only `clickcast` under **Active Skills**.
- Asked the model which skills were loaded on the next turn: it answered `clickcast` without invoking the tool again.

### Screenshots / recordings

Tested in the terminal TUI locally. The sidebar showed:

```text
Active Skills
• clickcast external
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
