### PR TITLE
feat(console): add workspace block support action

### DIFF
--- a/packages/console/app/src/routes/api/support/actions/block-workspace.ts
+++ b/packages/console/app/src/routes/api/support/actions/block-workspace.ts
@@ -1,0 +1,21 @@
+import type { APIEvent } from "@solidjs/start/server"
+import { Workspace } from "@opencode-ai/console-core/workspace.js"
+import { safeEqual } from "@opencode-ai/console-core/util/crypto.js"
+import { Resource } from "@opencode-ai/console-resource"
+import z from "zod"
+
+const Body = z.object({ workspaceID: z.string().startsWith("wrk_") })
+
+export async function POST(event: APIEvent) {
+  if (!safeEqual(event.request.headers.get("authorization") ?? "", `Bearer ${Resource.SUPPORT_API_KEY.value}`)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = Body.safeParse(await event.request.json().catch(() => undefined))
+  if (!body.success) {
+    return Response.json({ error: "Invalid request", issues: body.error.issues }, { status: 400 })
+  }
+  return Workspace.block(body.data)
+    .then(() => Response.json({ success: true, message: "Workspace blocked" }))
+    .catch((error) => Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 }))
+}

--- a/packages/console/core/src/workspace.ts
+++ b/packages/console/core/src/workspace.ts
@@ -97,6 +97,28 @@ export namespace Workspace {
     },
   )
 
+  export const block = fn(
+    z.object({
+      workspaceID: Identifier.schema("workspace"),
+    }),
+    async (input) => {
+      await Database.use(async (tx) => {
+        const result = await tx
+          .update(WorkspaceTable)
+          .set({ is_blocked: true })
+          .where(eq(WorkspaceTable.id, input.workspaceID))
+        // MySQL reports 0 affected rows for a no-op update, so an already-blocked
+        // workspace lands here too. Distinguish it from a missing one.
+        if (result.rowsAffected === 1) return
+        const matches = await tx
+          .select({ id: WorkspaceTable.id })
+          .from(WorkspaceTable)
+          .where(eq(WorkspaceTable.id, input.workspaceID))
+        if (matches.length === 0) throw new Error("Workspace not found")
+      })
+    },
+  )
+
   export const unblock = fn(
     z.object({
       workspaceID: Identifier.schema("workspace"),


### PR DESCRIPTION
## Summary

- Adds `Workspace.block` to `packages/console/core/src/workspace.ts`, mirroring the existing `Workspace.unblock` (sets `is_blocked = true`, throws if the workspace does not exist)
- Adds `POST /api/support/actions/block-workspace`, mirroring `unblock-workspace.ts` (bearer auth via `SUPPORT_API_KEY`, body `{ "workspaceID": "wrk_..." }`)

## Motivation

The console already supports *unblocking* a workspace through the support API, and `zen/util/handler.ts` enforces `is_blocked` on every Zen API request, but there is no code path that sets `is_blocked = true` — operators currently have to flip the flag by hand in the database. This adds the missing inverse operation so block/unblock are both first-class support actions.

## Usage

```
POST /api/support/actions/block-workspace
Authorization: Bearer <SUPPORT_API_KEY>

{ "workspaceID": "wrk_xxx" }
```

- `200` — `{"success":true,"message":"Workspace blocked"}`
- `400` — invalid body or workspace not found
- `401` — missing/incorrect support key

Blocking is idempotent: an already-blocked workspace still returns 200. Since MySQL reports 0 affected rows for no-op updates, `Workspace.block` falls back to a select to distinguish "already blocked" (success) from "workspace not found" (400).

Note that enforcement happens at the Zen API auth boundary — in-flight streaming responses continue until they finish; only new requests are rejected.

## Testing

- `bun run typecheck` in `packages/console/core` and `packages/console/app`: no new errors from these files (both packages have pre-existing implicit-any noise from drizzle type inference in this environment)
- No tests added — existing support actions (`unblock-workspace`, `delete-account`, `reset-quota`) have no test coverage either
