### PR TITLE
fix(acp): classify provider HTTP authentication errors

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -705,7 +705,7 @@ type MessageInfo = {
 }
 
 type AssistantError = NonNullable<AssistantMessage["error"]>
-type AssistantInfo = (UsageService.AssistantTokenCost & Pick<AssistantMessage, "error">) | undefined
+type AssistantInfo = (UsageService.AssistantTokenCost & Pick<AssistantMessage, "error" | "providerID">) | undefined
 
 function request<T>(fn: () => Promise<T | SdkResponse<T>>, service?: string) {
   return Effect.tryPromise({
@@ -863,6 +863,10 @@ const promptResponse = Effect.fn("ACP.promptResponse")(function* (
 
   if (info.error.name === "ProviderAuthError") {
     return yield* new ACPError.AuthRequiredError({ providerId: info.error.data.providerID })
+  }
+
+  if (info.error.name === "APIError" && (info.error.data.statusCode === 401 || info.error.data.statusCode === 403)) {
+    return yield* new ACPError.AuthRequiredError({ providerId: info.providerID })
   }
 
   return yield* new ACPError.ServiceFailureError({

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -1144,30 +1144,59 @@ describe("ACP service sessions", () => {
     expect(order).toEqual(["update", "response"])
   })
 
-  it("maps assistant prompt errors to request errors instead of end turn", async () => {
-    const { service } = makeService([], {
-      prompt: () =>
-        Promise.resolve({
-          data: {
-            info: assistantInfo(
-              { input: 8, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-              { name: "APIError", data: { message: "Provider request failed", isRetryable: false } },
-            ),
-          },
-        }),
+  it.each([undefined, 429, 500])(
+    "maps assistant API errors with status %s to internal request errors",
+    async (statusCode) => {
+      const { service } = makeService([], {
+        prompt: () =>
+          Promise.resolve({
+            data: {
+              info: assistantInfo(
+                { input: 8, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                { name: "APIError", data: { message: "Provider request failed", statusCode, isRetryable: false } },
+              ),
+            },
+          }),
+      })
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      const error = await Effect.runPromise(
+        service
+          .prompt({ sessionId: session.sessionId, prompt: [{ type: "text", text: "hello" }] })
+          .pipe(Effect.mapError(ACPError.toRequestError), Effect.flip),
+      )
+
+      expect(error.code).toBe(-32603)
+      expect(error.message).toBe("Internal error: Provider request failed")
+      expect(error.data).toEqual({ service: "session", errorName: "APIError" })
+    },
+  )
+
+  for (const statusCode of [401, 403]) {
+    it(`maps assistant HTTP ${statusCode} errors to auth-required request errors`, async () => {
+      const { service } = makeService([], {
+        prompt: () =>
+          Promise.resolve({
+            data: {
+              info: assistantInfo(
+                { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                { name: "APIError", data: { message: "Provider request failed", statusCode, isRetryable: false } },
+              ),
+            },
+          }),
+      })
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      const error = await Effect.runPromise(
+        service
+          .prompt({ sessionId: session.sessionId, prompt: [{ type: "text", text: "hello" }] })
+          .pipe(Effect.mapError(ACPError.toRequestError), Effect.flip),
+      )
+
+      expect(error.code).toBe(-32000)
+      expect(error.data).toEqual({ providerId: "test" })
     })
-    const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
-
-    const error = await Effect.runPromise(
-      service
-        .prompt({ sessionId: session.sessionId, prompt: [{ type: "text", text: "hello" }] })
-        .pipe(Effect.mapError(ACPError.toRequestError), Effect.flip),
-    )
-
-    expect(error.code).toBe(-32603)
-    expect(error.message).toBe("Internal error: Provider request failed")
-    expect(error.data).toEqual({ service: "session", errorName: "APIError" })
-  })
+  }
 
   it("maps aborted assistant prompt errors to cancelled", async () => {
     const { service } = makeService([], {


### PR DESCRIPTION
### Issue for this PR

Closes #48297

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

An invalid provider credential can arrive as an assistant `APIError` with HTTP status 401 or 403. ACP currently reports these as internal errors, so clients cannot recognize that authentication is required.

Map these two statuses to the existing auth-required response (`-32000`) and include the assistant's provider ID. API errors without a status, rate limits, and server errors retain their existing internal-error response.

### How did you verify your code works?

The two new authentication cases fail on the original code with `-32603`. With the fix, all 132 tests under `test/acp` pass, including checks for absent status, 429 and 500. Package type checking and formatting pass; lint exits successfully with existing warnings.

Commands: `bun test test/acp` and `bun typecheck` from `packages/opencode`.

### Screenshots / recordings

Not applicable; protocol error handling only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
