### PR TITLE
fix(mcp): pass tool name and args to permission ask

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -405,7 +405,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             { args },
           )
           const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
-            yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
+            yield* ctx.ask({ permission: key, metadata: args, patterns: [key], always: [key] })
             return yield* Effect.promise(() => execute(args, opts))
           }).pipe(
             Effect.withSpan("Tool.execute", {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -10,6 +10,9 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
 import { fileURLToPath } from "url"
 import { NamedError } from "@opencode-ai/core/util/error"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import type { Tool } from "@modelcontextprotocol/sdk/types.js"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
 import { Command } from "../../src/command"
@@ -221,12 +224,16 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   return LayerNode.compile(promptRoot, replacements)
 }
 
-function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttp(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking"
+  mcp?: Layer.Layer<MCP.Service>
+}) {
   const root = LayerNode.group([promptRoot, testLLMServerNode])
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
-    [MCP.node, makeMcp(input?.mcpInstructions)],
+    [MCP.node, input?.mcp ?? makeMcp(input?.mcpInstructions)],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
   if (input?.processor === "blocking") {
@@ -2467,4 +2474,105 @@ noLLMServer.instance(
       }
     }),
   30_000,
+)
+
+// MCP wrapper permission payload — see packages/opencode/src/session/tools.ts.
+// The wrapper must forward the tool name as the permission key/pattern and the
+// raw tool arguments as metadata so SDK consumers can reason about the call.
+const mcpEchoCalls: Array<{ name: string; arguments: Record<string, unknown> | undefined }> = []
+const mcpEchoToolDef = {
+  name: "say",
+  description: "echo back the greeting",
+  inputSchema: {
+    type: "object",
+    properties: { greeting: { type: "string" } },
+    required: ["greeting"],
+    additionalProperties: false,
+  },
+} satisfies Tool
+const mcpEchoClient = {
+  callTool: async (request: { name: string; arguments?: Record<string, unknown> }) => {
+    mcpEchoCalls.push({ name: request.name, arguments: request.arguments })
+    return { content: [{ type: "text" as const, text: "ok" }] }
+  },
+} as unknown as Client
+const mcpWithEchoTool = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    instructions: () => Effect.succeed([]),
+    tools: () =>
+      Effect.succeed({
+        echo_say: { def: mcpEchoToolDef, client: mcpEchoClient },
+      }),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    resourceTemplates: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const mcpIt = testEffect(makeHttp({ mcp: mcpWithEchoTool }))
+
+mcpIt.instance("mcp tool ask publishes tool name and args (regression: #19549)", () =>
+  Effect.gen(function* () {
+    mcpEchoCalls.length = 0
+    const { llm } = yield* useServerConfig(providerCfg)
+    const events = yield* EventV2Bridge.Service
+    const seen = yield* Deferred.make<PermissionV1.Request>()
+    const unsub = yield* events.listen((event) => {
+      if (event.type === Permission.Event.Asked.type)
+        Deferred.doneUnsafe(seen, Effect.succeed(event.data as PermissionV1.Request))
+      return Effect.void
+    })
+    yield* Effect.addFinalizer(() => unsub)
+
+    const prompt = yield* SessionPrompt.Service
+    const permission = yield* Permission.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "MCP wrapper ask",
+      permission: [{ permission: "*", pattern: "*", action: "ask" }],
+    })
+
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "say hi" }],
+    })
+    yield* llm.tool("echo_say", { greeting: "hi" })
+    yield* llm.text("done")
+
+    const fiber = yield* prompt.loop({ sessionID: session.id }).pipe(Effect.forkChild)
+
+    const request = yield* Deferred.await(seen).pipe(
+      Effect.timeoutOrElse({
+        duration: Duration.seconds(5),
+        orElse: () => Effect.fail(new Error("timed out waiting for permission.asked")),
+      }),
+    )
+    expect(request.permission).toBe("echo_say")
+    expect(request.patterns).toEqual(["echo_say"])
+    expect(request.always).toEqual(["echo_say"])
+    expect(request.metadata).toEqual({ greeting: "hi" })
+
+    yield* permission.reply({ requestID: request.id, reply: "once" })
+
+    const exit = yield* Fiber.await(fiber)
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(mcpEchoCalls).toEqual([{ name: "say", arguments: { greeting: "hi" } }])
+  }),
 )


### PR DESCRIPTION
### Issue for this PR

Fixes #19549. Reroll of #39057, closed by automated cleanup rather than review, rebased onto `dev`.

### Type of change

- [x] Bug fix

### What does this PR do?

The MCP tool wrapper called `ctx.ask` with hardcoded wildcards, so permission dialogs showed `*` instead of the tool name and carried no arguments:

```ts
ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
```

This aligns the MCP wrapper with the convention every other tool uses (`bash`, `webfetch`, `task`, `read`, `edit`): forward the action key as `permission` and `patterns`/`always`, and pass the tool input as `metadata`.

```ts
ctx.ask({ permission: key, metadata: args, patterns: [key], always: [key] })
```

| File | Change |
| --- | --- |
| `session/tools.ts` | Pass the real tool name and args to the permission ask. |
| `test/session/prompt.test.ts` | Assert the payload the MCP wrapper hands to `ctx.ask`. |

### How did you verify your code works?

| Check | Result |
| --- | --- |
| `bun test test/session/prompt.test.ts` | 59 pass, 0 fail |
| `bun turbo typecheck` | 30/30 tasks pass |

### Screenshots / recordings

No UI changes — only the data the existing dock already renders.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
