### PR TITLE
docs(ecosystem): add opencode-guided-learning

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-guided-learning](https://github.com/Neverdecel/opencode-guided-learning)                 | Notices reusable procedures during work and asks before saving them as native skills               |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation addition for the community ecosystem plugins list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-guided-learning](https://github.com/Neverdecel/opencode-guided-learning) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

Independent community plugin: notices reusable procedures during work and asks before saving them as native OpenCode skills.

### How did you verify your code works?

Docs-only table row. Confirmed the entry matches existing Plugins table column alignment and that the GitHub link resolves.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR