### PR TITLE
feat(app): add find bar to session timeline

### DIFF
--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -24,6 +24,16 @@
   }
 }
 
+/* Timeline find matches (CSS Custom Highlight API). The pierre file viewer
+   defines the same names for its shadow roots. */
+::highlight(opencode-find) {
+  background-color: rgb(from var(--surface-warning-base) r g b / 0.35);
+}
+
+::highlight(opencode-find-current) {
+  background-color: rgb(from var(--surface-warning-strong) r g b / 0.55);
+}
+
 @layer components {
   [data-component="getting-started"] {
     container-type: inline-size;

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2112,6 +2112,7 @@ export default function Page() {
                     restoreHistoryAnchor = handlers.restore
                   }}
                   anchor={anchor}
+                  onPauseScroll={autoScroll.pause}
                   setRevealMessage={(fn) => {
                     revealMessage = fn
                   }}

--- a/packages/app/src/pages/session/timeline/find.test.ts
+++ b/packages/app/src/pages/session/timeline/find.test.ts
@@ -52,6 +52,15 @@ describe("rowSearchText", () => {
     expect(rowSearchText(row, getParts, getPart)).toBe("hello\nagain")
   })
 
+  test("includes projected message text for user rows", () => {
+    reset({ user1: [textPart("p1", "part text")] })
+    const row = new TimelineRow.UserMessage({ userMessageID: "user1", anchor: true })
+    const getUserText = (id: string) => (id === "user1" ? "projected prompt" : undefined)
+    expect(rowSearchText(row, getParts, getPart, getUserText)).toBe("projected prompt\npart text")
+    reset({})
+    expect(rowSearchText(row, getParts, getPart, getUserText)).toBe("projected prompt")
+  })
+
   test("reads text and reasoning for single-part assistant groups", () => {
     reset({ asst1: [textPart("p1", "answer"), reasoningPart("p2", "thinking")] })
     const text = new TimelineRow.AssistantPart({

--- a/packages/app/src/pages/session/timeline/find.test.ts
+++ b/packages/app/src/pages/session/timeline/find.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import type { Part } from "@opencode-ai/sdk/v2"
+import { TimelineRow } from "./timeline-row"
+import { matchRowKeys, rowSearchText } from "./find"
+
+function textPart(id: string, text: string, synthetic = false): Part {
+  return {
+    id,
+    messageID: "msg",
+    sessionID: "ses",
+    type: "text",
+    text,
+    synthetic,
+  } as Part
+}
+
+function reasoningPart(id: string, text: string): Part {
+  return {
+    id,
+    messageID: "msg",
+    sessionID: "ses",
+    type: "reasoning",
+    text,
+  } as Part
+}
+
+function toolPart(id: string, input?: unknown): Part {
+  return {
+    id,
+    messageID: "msg",
+    sessionID: "ses",
+    type: "tool",
+    tool: "bash",
+    state: input === undefined ? { status: "running" } : { status: "completed", input },
+  } as Part
+}
+
+const partsByMessage = new Map<string, Part[]>()
+
+const getParts = (messageID: string) => partsByMessage.get(messageID) ?? []
+const getPart = (messageID: string, partID: string) => getParts(messageID).find((part) => part.id === partID)
+
+function reset(parts: Record<string, Part[]>) {
+  partsByMessage.clear()
+  for (const [id, list] of Object.entries(parts)) partsByMessage.set(id, list)
+}
+
+describe("rowSearchText", () => {
+  test("joins non-synthetic user text parts", () => {
+    reset({ user1: [textPart("p1", "hello"), textPart("p2", "world", true), textPart("p3", "again")] })
+    const row = new TimelineRow.UserMessage({ userMessageID: "user1", anchor: true })
+    expect(rowSearchText(row, getParts, getPart)).toBe("hello\nagain")
+  })
+
+  test("reads text and reasoning for single-part assistant groups", () => {
+    reset({ asst1: [textPart("p1", "answer"), reasoningPart("p2", "thinking")] })
+    const text = new TimelineRow.AssistantPart({
+      userMessageID: "user1",
+      group: { type: "part", key: "part:asst1:p1", ref: { messageID: "asst1", partID: "p1" } },
+      previousAssistantPart: false,
+    })
+    expect(rowSearchText(text, getParts, getPart)).toBe("answer")
+    const reasoning = new TimelineRow.AssistantPart({
+      userMessageID: "user1",
+      group: { type: "part", key: "part:asst1:p2", ref: { messageID: "asst1", partID: "p2" } },
+      previousAssistantPart: true,
+    })
+    expect(rowSearchText(reasoning, getParts, getPart)).toBe("thinking")
+  })
+
+  test("skips tool groups and tool parts without input", () => {
+    reset({ asst1: [toolPart("p1")] })
+    const tool = new TimelineRow.AssistantPart({
+      userMessageID: "user1",
+      group: { type: "part", key: "part:asst1:p1", ref: { messageID: "asst1", partID: "p1" } },
+      previousAssistantPart: false,
+    })
+    expect(rowSearchText(tool, getParts, getPart)).toBe("")
+    const context = new TimelineRow.AssistantPart({
+      userMessageID: "user1",
+      group: { type: "context", key: "context:p1", refs: [{ messageID: "asst1", partID: "p1" }] },
+      previousAssistantPart: false,
+    })
+    expect(rowSearchText(context, getParts, getPart)).toBe("")
+  })
+
+  test("searches tool input values", () => {
+    reset({ asst1: [toolPart("p1", { command: "echo findmarker", timeout: 30 })] })
+    const tool = new TimelineRow.AssistantPart({
+      userMessageID: "user1",
+      group: { type: "part", key: "part:asst1:p1", ref: { messageID: "asst1", partID: "p1" } },
+      previousAssistantPart: false,
+    })
+    expect(rowSearchText(tool, getParts, getPart)).toBe("echo findmarker")
+  })
+
+  test("uses error row text and ignores structural rows", () => {
+    const error = new TimelineRow.Error({ userMessageID: "user1", text: "boom" })
+    expect(rowSearchText(error, getParts, getPart)).toBe("boom")
+    const gap = new TimelineRow.TurnGap({ userMessageID: "user1" })
+    expect(rowSearchText(gap, getParts, getPart)).toBe("")
+  })
+})
+
+describe("matchRowKeys", () => {
+  test("matches rows case-insensitively in timeline order", () => {
+    reset({
+      user1: [textPart("p1", "Deploy the App")],
+      asst1: [textPart("p2", "done")],
+      user2: [textPart("p3", "another app mention")],
+    })
+    const rows = [
+      new TimelineRow.UserMessage({ userMessageID: "user1", anchor: true }),
+      new TimelineRow.AssistantPart({
+        userMessageID: "user1",
+        group: { type: "part", key: "part:asst1:p2", ref: { messageID: "asst1", partID: "p2" } },
+        previousAssistantPart: false,
+      }),
+      new TimelineRow.UserMessage({ userMessageID: "user2", anchor: true }),
+    ]
+    expect(matchRowKeys(rows, "app", getParts, getPart)).toEqual(["user-message:user1", "user-message:user2"])
+  })
+
+  test("returns empty for blank or unmatched queries", () => {
+    reset({ user1: [textPart("p1", "hello")] })
+    const rows = [new TimelineRow.UserMessage({ userMessageID: "user1", anchor: true })]
+    expect(matchRowKeys(rows, "   ", getParts, getPart)).toEqual([])
+    expect(matchRowKeys(rows, "zzz", getParts, getPart)).toEqual([])
+  })
+})

--- a/packages/app/src/pages/session/timeline/find.ts
+++ b/packages/app/src/pages/session/timeline/find.ts
@@ -12,17 +12,28 @@ import { TimelineRow } from "./timeline-row"
 
 type GetParts = (messageID: string) => Part[]
 type GetPart = (messageID: string, partID: string) => Part | undefined
+type GetUserText = (messageID: string) => string | undefined
 
 // Searchable text mirrors what the row renders: user/assistant text and
 // reasoning parts, plus tool call input values shown in tool triggers.
-// Tool outputs stay collapsed, so their content is excluded.
-export function rowSearchText(row: TimelineRow.TimelineRow, getParts: GetParts, getPart: GetPart): string {
+// Tool outputs stay collapsed, so their content is excluded. User rows also
+// include the projected session message text because V2 sessions carry the
+// prompt on the message rather than only in parts.
+export function rowSearchText(
+  row: TimelineRow.TimelineRow,
+  getParts: GetParts,
+  getPart: GetPart,
+  getUserText?: GetUserText,
+): string {
   switch (row._tag) {
-    case "UserMessage":
-      return getParts(row.userMessageID)
+    case "UserMessage": {
+      const texts = getParts(row.userMessageID)
         .filter((part): part is Extract<Part, { type: "text" }> => part.type === "text" && !part.synthetic)
         .map((part) => part.text)
-        .join("\n")
+      const direct = getUserText?.(row.userMessageID)
+      if (direct) texts.unshift(direct)
+      return texts.join("\n")
+    }
     case "AssistantPart": {
       if (row.group.type !== "part") return ""
       const part = getPart(row.group.ref.messageID, row.group.ref.partID)
@@ -55,11 +66,12 @@ export function matchRowKeys(
   query: string,
   getParts: GetParts,
   getPart: GetPart,
+  getUserText?: GetUserText,
 ): string[] {
   const needle = query.trim().toLowerCase()
   if (!needle) return []
   return rows.flatMap((row) => {
-    const text = rowSearchText(row, getParts, getPart)
+    const text = rowSearchText(row, getParts, getPart, getUserText)
     if (!text.toLowerCase().includes(needle)) return []
     return [TimelineRow.key(row)]
   })
@@ -105,6 +117,7 @@ export function createTimelineFind(input: {
   content: () => HTMLElement | undefined
   getParts: GetParts
   getPart: GetPart
+  getUserText?: GetUserText
   headerOffset: () => number
   scrollToIndex: (index: number) => void
   onNavigate?: () => void
@@ -122,7 +135,7 @@ export function createTimelineFind(input: {
 
   const matches = createMemo(() => {
     if (!state.open) return []
-    return matchRowKeys(input.rows(), state.query, input.getParts, input.getPart)
+    return matchRowKeys(input.rows(), state.query, input.getParts, input.getPart, input.getUserText)
   })
 
   // Keep the active match valid while messages stream in.

--- a/packages/app/src/pages/session/timeline/find.ts
+++ b/packages/app/src/pages/session/timeline/find.ts
@@ -1,0 +1,308 @@
+import { createEffect, createMemo, onCleanup } from "solid-js"
+import { createStore } from "solid-js/store"
+import { makeEventListener } from "@solid-primitives/event-listener"
+import {
+  activateFindHost,
+  registerFindHost,
+  targetFindHost,
+  type FindHost,
+} from "@opencode-ai/session-ui/pierre/file-find"
+import type { Part } from "@opencode-ai/sdk/v2"
+import { TimelineRow } from "./timeline-row"
+
+type GetParts = (messageID: string) => Part[]
+type GetPart = (messageID: string, partID: string) => Part | undefined
+
+// Searchable text mirrors what the row renders: user/assistant text and
+// reasoning parts, plus tool call input values shown in tool triggers.
+// Tool outputs stay collapsed, so their content is excluded.
+export function rowSearchText(row: TimelineRow.TimelineRow, getParts: GetParts, getPart: GetPart): string {
+  switch (row._tag) {
+    case "UserMessage":
+      return getParts(row.userMessageID)
+        .filter((part): part is Extract<Part, { type: "text" }> => part.type === "text" && !part.synthetic)
+        .map((part) => part.text)
+        .join("\n")
+    case "AssistantPart": {
+      if (row.group.type !== "part") return ""
+      const part = getPart(row.group.ref.messageID, row.group.ref.partID)
+      if (!part) return ""
+      if (part.type === "text" || part.type === "reasoning") return part.text
+      if (part.type === "tool") return toolInputText(part.state)
+      return ""
+    }
+    case "Error":
+      return row.text
+    default:
+      return ""
+  }
+}
+
+function toolInputText(state: unknown): string {
+  if (!state || typeof state !== "object" || !("input" in state)) return ""
+  return stringLeaves(state.input).join("\n")
+}
+
+function stringLeaves(value: unknown): string[] {
+  if (typeof value === "string") return [value]
+  if (Array.isArray(value)) return value.flatMap(stringLeaves)
+  if (value && typeof value === "object") return Object.values(value).flatMap(stringLeaves)
+  return []
+}
+
+export function matchRowKeys(
+  rows: TimelineRow.TimelineRow[],
+  query: string,
+  getParts: GetParts,
+  getPart: GetPart,
+): string[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return []
+  return rows.flatMap((row) => {
+    const text = rowSearchText(row, getParts, getPart)
+    if (!text.toLowerCase().includes(needle)) return []
+    return [TimelineRow.key(row)]
+  })
+}
+
+function supportsHighlights() {
+  const g = globalThis as unknown as { CSS?: { highlights?: unknown }; Highlight?: unknown }
+  return typeof g.Highlight === "function" && g.CSS?.highlights != null
+}
+
+function clearHighlights() {
+  const api = (globalThis as { CSS?: { highlights?: { delete: (name: string) => void } } }).CSS?.highlights
+  if (!api) return
+  api.delete("opencode-find")
+  api.delete("opencode-find-current")
+}
+
+function textRanges(root: HTMLElement, needle: string): Range[] {
+  const ranges: Range[] = []
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  let node = walker.nextNode()
+  while (node) {
+    if (node instanceof Text) {
+      const hay = node.data.toLowerCase()
+      let at = hay.indexOf(needle)
+      while (at !== -1) {
+        const range = document.createRange()
+        range.setStart(node, at)
+        range.setEnd(node, at + needle.length)
+        ranges.push(range)
+        at = hay.indexOf(needle, at + needle.length)
+      }
+    }
+    node = walker.nextNode()
+  }
+  return ranges
+}
+
+export function createTimelineFind(input: {
+  rows: () => TimelineRow.TimelineRow[]
+  renderedKeys: () => string[]
+  scrollElement: () => HTMLElement | undefined
+  content: () => HTMLElement | undefined
+  getParts: GetParts
+  getPart: GetPart
+  headerOffset: () => number
+  scrollToIndex: (index: number) => void
+  onNavigate?: () => void
+}) {
+  let inputEl: HTMLInputElement | undefined
+  let frame: number | undefined
+  let pendingScroll = false
+
+  const [state, setState] = createStore({
+    open: false,
+    query: "",
+    index: 0,
+    pos: { top: 8, right: 8 },
+  })
+
+  const matches = createMemo(() => {
+    if (!state.open) return []
+    return matchRowKeys(input.rows(), state.query, input.getParts, input.getPart)
+  })
+
+  // Keep the active match valid while messages stream in.
+  createEffect(() => {
+    const total = matches().length
+    if (state.index >= total) setState("index", Math.max(0, total - 1))
+  })
+
+  const position = () => {
+    if (typeof window === "undefined") return
+    const el = input.scrollElement()
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    setState("pos", {
+      top: Math.round(rect.top) + input.headerOffset() + 8,
+      right: Math.round(window.innerWidth - rect.right) + 8,
+    })
+  }
+
+  const apply = () => {
+    frame = undefined
+    if (!state.open) return
+    const value = state.query.trim().toLowerCase()
+    if (!value) {
+      clearHighlights()
+      return
+    }
+    const root = input.content()
+    if (!root || !supportsHighlights()) {
+      clearHighlights()
+      return
+    }
+    const keys = new Set(matches())
+    const currentKey = matches()[state.index]
+    // Mid-scroll the active row can be unmounted; leave previous highlights
+    // in place and retry on the next scroll/render pass.
+    if (currentKey && !root.querySelector(`[data-timeline-key="${CSS.escape(currentKey)}"]`)) return
+    const current: Range[] = []
+    const rest: Range[] = []
+    for (const el of root.querySelectorAll<HTMLElement>("[data-timeline-key]")) {
+      const key = el.dataset.timelineKey
+      if (!key || !keys.has(key)) continue
+      const ranges = textRanges(el, value)
+      if (key === currentKey) current.push(...ranges)
+      else rest.push(...ranges)
+    }
+    const g = globalThis as unknown as {
+      CSS: { highlights: { set: (name: string, value: unknown) => void; delete: (name: string) => void } }
+      Highlight: new (...ranges: Range[]) => unknown
+    }
+    g.CSS.highlights.delete("opencode-find")
+    g.CSS.highlights.delete("opencode-find-current")
+    if (current.length) g.CSS.highlights.set("opencode-find-current", new g.Highlight(...current))
+    if (rest.length) g.CSS.highlights.set("opencode-find", new g.Highlight(...rest))
+
+    // The target row may only render after scrollToIndex, so consume the
+    // pending precision scroll on the first apply that sees its ranges.
+    if (pendingScroll && current.length) {
+      pendingScroll = false
+      const start = current[0].startContainer
+      const el = start instanceof Element ? start : start.parentElement
+      el?.scrollIntoView({ block: "center", inline: "center" })
+    }
+  }
+
+  const schedule = () => {
+    if (frame !== undefined) return
+    frame = requestAnimationFrame(apply)
+  }
+
+  // Re-highlight when the query, active match, or rendered rows change.
+  createEffect(() => {
+    if (!state.open) return
+    state.query
+    state.index
+    matches()
+    input.renderedKeys()
+    schedule()
+  })
+
+  const navigate = () => {
+    const key = matches()[state.index]
+    if (!key) return
+    const rowIndex = input.rows().findIndex((row) => TimelineRow.key(row) === key)
+    if (rowIndex < 0) return
+    pendingScroll = true
+    input.onNavigate?.()
+    input.scrollToIndex(rowIndex)
+    schedule()
+  }
+
+  const next = (dir: 1 | -1) => {
+    const total = matches().length
+    if (!state.open || total <= 0) return
+    setState("index", (state.index + dir + total) % total)
+    navigate()
+  }
+
+  const close = () => {
+    setState("open", false)
+    setState("query", "")
+    setState("index", 0)
+    pendingScroll = false
+    clearHighlights()
+  }
+
+  const focus = () => {
+    activateFindHost(host)
+    if (!state.open) setState("open", true)
+    position()
+    if (matches().length > 0) navigate()
+    requestAnimationFrame(() => {
+      inputEl?.focus()
+      inputEl?.select()
+    })
+  }
+
+  const host: FindHost = {
+    element: input.scrollElement,
+    isOpen: () => state.open,
+    next,
+    open: focus,
+    close,
+  }
+
+  const unregister = registerFindHost(host)
+
+  createEffect(() => {
+    if (!state.open) return
+    position()
+    makeEventListener(window, "resize", position, { passive: true })
+  })
+
+  createEffect(() => {
+    const el = input.scrollElement()
+    if (!el) return
+    makeEventListener(el, "pointerdown", () => targetFindHost(host), { passive: true, capture: true })
+  })
+
+  // Virtualized rows mount and unmount while scrolling, so highlights must be
+  // rebuilt as the viewport moves.
+  createEffect(() => {
+    const el = input.scrollElement()
+    if (!el || !state.open) return
+    makeEventListener(el, "scroll", schedule, { passive: true })
+  })
+
+  onCleanup(() => {
+    unregister()
+    if (frame !== undefined) cancelAnimationFrame(frame)
+    clearHighlights()
+  })
+
+  return {
+    open: () => state.open,
+    query: () => state.query,
+    index: () => state.index,
+    count: () => matches().length,
+    pos: () => state.pos,
+    focus,
+    close,
+    next,
+    setInput: (el: HTMLInputElement) => {
+      inputEl = el
+    },
+    setQuery: (value: string) => {
+      setState("query", value)
+      setState("index", 0)
+      if (state.open && matches().length > 0) navigate()
+      else schedule()
+    },
+    onInputKeyDown: (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        close()
+        return
+      }
+      if (event.key !== "Enter") return
+      event.preventDefault()
+      next(event.shiftKey ? -1 : 1)
+    },
+  }
+}

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -81,6 +81,8 @@ import { createTimelineFind } from "./find"
 import { FileSearchBar } from "@opencode-ai/session-ui/file-search"
 import { makeEventListener } from "@solid-primitives/event-listener"
 
+const IS_MAC = typeof navigator === "object" && /(Mac|iPod|iPhone|iPad)/.test(navigator.platform)
+
 const emptyMessages: MessageType[] = []
 const emptyParts: PartType[] = []
 const emptyTools: ToolPart[] = []
@@ -524,12 +526,15 @@ export function MessageTimeline(props: {
 
   // The global find-host shortcuts ignore editable targets, so mod+f / mod+g
   // are handled here as well to work while the composer is focused. File tab
-  // find claims the keys first via defaultPrevented.
+  // find claims the keys first via defaultPrevented. Mod follows the platform
+  // convention: Cmd on macOS, Ctrl elsewhere — plain Ctrl+F keeps its native
+  // cursor-forward behavior on macOS.
   createEffect(() => {
     if (typeof window === "undefined") return
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return
-      if (!(event.metaKey || event.ctrlKey) || event.altKey) return
+      const mod = IS_MAC ? event.metaKey : event.ctrlKey
+      if (!mod || event.altKey) return
       const key = event.key.toLowerCase()
       if (key === "f") {
         if (event.shiftKey) return

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -77,6 +77,9 @@ import { observeElementOffsetReconnectAware } from "./observe-element-offset"
 import { createTimelineProjection } from "./projection"
 import { MessageComment, SummaryDiff, TimelineRow, TimelineRowMap } from "./rows"
 import { filterVirtualIndexes } from "./virtual-items"
+import { createTimelineFind } from "./find"
+import { FileSearchBar } from "@opencode-ai/session-ui/file-search"
+import { makeEventListener } from "@solid-primitives/event-listener"
 
 const emptyMessages: MessageType[] = []
 const emptyParts: PartType[] = []
@@ -255,6 +258,7 @@ export function MessageTimeline(props: {
   setRevealMessage?: (fn: (id: string) => void) => void
   setScrollToEnd?: (fn: () => void) => void
   setHistoryAnchor?: (handlers: { capture: () => void; restore: (done: boolean) => void }) => void
+  onPauseScroll?: () => void
 }) {
   let touchGesture: number | undefined
 
@@ -497,6 +501,46 @@ export function MessageTimeline(props: {
     () => new Map(virtualizer.getVirtualItems().map((item) => [item.key, item] as const)),
   )
   const virtualRowKeys = createMemo(() => virtualizer.getVirtualItems().map((item) => item.key as string))
+
+  const find = createTimelineFind({
+    rows: timelineRows,
+    renderedKeys: virtualRowKeys,
+    scrollElement: listRoot,
+    content: () => virtualContent,
+    getParts: getMsgParts,
+    getPart: getMsgPart,
+    headerOffset: () => (showHeader() ? 48 : 0),
+    scrollToIndex: (index) => virtualizer.scrollToIndex(index, { align: "center" }),
+    // Pause bottom-follow synchronously before navigating, otherwise the
+    // anchor-bottom resize handlers race the find scroll and win.
+    onNavigate: () => props.onPauseScroll?.(),
+  })
+
+  // The global find-host shortcuts ignore editable targets, so mod+f / mod+g
+  // are handled here as well to work while the composer is focused. File tab
+  // find claims the keys first via defaultPrevented.
+  createEffect(() => {
+    if (typeof window === "undefined") return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) return
+      const key = event.key.toLowerCase()
+      if (key === "f") {
+        if (event.shiftKey) return
+        event.preventDefault()
+        event.stopPropagation()
+        find.focus()
+        return
+      }
+      if (key === "g") {
+        if (!find.open()) return
+        event.preventDefault()
+        event.stopPropagation()
+        find.next(event.shiftKey ? -1 : 1)
+      }
+    }
+    makeEventListener(window, "keydown", onKeyDown, { capture: true })
+  })
   createEffect(() => {
     props.setRevealMessage?.((id) => {
       const index = messageRowIndex().get(id)
@@ -1842,6 +1886,20 @@ export function MessageTimeline(props: {
           </Show>
         </div>
       </ScrollView>
+      <Show when={find.open()}>
+        <FileSearchBar
+          pos={find.pos}
+          query={find.query}
+          index={find.index}
+          count={find.count}
+          setInput={find.setInput}
+          onInput={find.setQuery}
+          onKeyDown={find.onInputKeyDown}
+          onClose={find.close}
+          onPrev={() => find.next(-1)}
+          onNext={() => find.next(1)}
+        />
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -509,6 +509,12 @@ export function MessageTimeline(props: {
     content: () => virtualContent,
     getParts: getMsgParts,
     getPart: getMsgPart,
+    getUserText: (messageID) => {
+      const message = projectedMessages().find((item) => item.id === messageID)
+      if (!message) return
+      if (message.type === "user") return message.text
+      if (message.type === "shell") return [message.command, message.output].filter(Boolean).join("\n")
+    },
     headerOffset: () => (showHeader() ? 48 : 0),
     scrollToIndex: (index) => virtualizer.scrollToIndex(index, { align: "center" }),
     // Pause bottom-follow synchronously before navigating, otherwise the

--- a/packages/session-ui/src/pierre/file-find.ts
+++ b/packages/session-ui/src/pierre/file-find.ts
@@ -16,6 +16,36 @@ let target: FindHost | undefined
 let current: FindHost | undefined
 let installed = false
 
+// Lets non-file find surfaces (e.g. the session timeline) join the shared
+// mod+f / mod+g routing so only one find bar is active at a time.
+export function registerFindHost(host: FindHost) {
+  installShortcuts()
+  hosts.add(host)
+  if (!target) target = host
+  return () => {
+    hosts.delete(host)
+    if (current === host) {
+      current = undefined
+      clearHighlightFind()
+    }
+    if (target === host) target = undefined
+  }
+}
+
+export function activateFindHost(host: FindHost) {
+  if (current && current !== host) current.close()
+  current = host
+  target = host
+}
+
+export function targetFindHost(host: FindHost) {
+  target = host
+}
+
+export function anyFindHostOpen() {
+  return !!current?.isOpen()
+}
+
 function isEditable(node: unknown): boolean {
   if (!(node instanceof HTMLElement)) return false
   if (node.closest("[data-prevent-autofocus]")) return true

--- a/packages/session-ui/src/pierre/file-find.ts
+++ b/packages/session-ui/src/pierre/file-find.ts
@@ -53,6 +53,8 @@ function isEditable(node: unknown): boolean {
   return /^(INPUT|TEXTAREA|SELECT|BUTTON)$/.test(node.tagName)
 }
 
+const IS_MAC = typeof navigator === "object" && /(Mac|iPod|iPhone|iPad)/.test(navigator.platform)
+
 function hostForNode(node: unknown) {
   if (!(node instanceof Node)) return
   for (const host of hosts) {
@@ -72,7 +74,9 @@ function installShortcuts() {
       if (event.defaultPrevented) return
       if (isEditable(event.target)) return
 
-      const mod = event.metaKey || event.ctrlKey
+      // Platform convention: Cmd on macOS, Ctrl elsewhere. Plain Ctrl+F
+      // keeps its native cursor-forward behavior on macOS.
+      const mod = IS_MAC ? event.metaKey : event.ctrlKey
       if (!mod) return
 
       const key = event.key.toLowerCase()


### PR DESCRIPTION
### Issue for this PR

N/A - small UX gap: the session transcript has no in-page search. (Resubmission of #48088, which was auto-closed for a template issue; this version also fixes two things found after the first submission.)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `mod+f` in-page search to the session timeline (app and desktop UI).

The timeline is virtualized, so matches are computed from row data (user/assistant text, reasoning, tool call inputs, error rows, plus the projected message text that V2 sessions carry on the message itself) instead of the DOM. The active match scrolls into view through the virtualizer, and rendered hits are highlighted with the CSS Custom Highlight API under the same `opencode-find` names and colors the pierre file viewer already uses. Highlights rebuild as rows mount and unmount while scrolling.

The timeline registers as a find host in the existing pierre `file-find` registry (new `registerFindHost` / `activateFindHost` exports), so `mod+f` / `mod+g` routing is shared with the file viewer and only one find bar is active at a time; file tabs keep their existing behavior and win via `defaultPrevented`. The bar is the existing `FileSearchBar` component with the existing `ui.fileSearch.*` i18n keys, so no new strings. Shortcuts follow the platform convention (Cmd on macOS, Ctrl elsewhere) so plain Ctrl+F keeps its native cursor-forward behavior.

One non-obvious fix: bottom-follow is paused synchronously (new `onPauseScroll` prop wired to `autoScroll.pause`) before navigating to a match, otherwise anchor-bottom resize handlers race the find scroll and pull the viewport back down.

### How did you verify your code works?

- New `find.test.ts` covers search-text extraction and match computation. Full app unit suite passes except one pre-existing i18n failure that also fails on `dev`.
- Interactive verification in Chromium against `bun dev` + a local server with seeded sessions:
  - `mod+f` opens the bar even while the composer is focused; counts show `n/m`, `0/0` on no match.
  - `Enter` / `shift+Enter` cycle with wrap-around; `mod+g` / `mod+shift+g` navigate while open.
  - In a 77-row session, searching an off-screen match scrolled from the bottom to the exact row with the hit highlighted in view.
  - Ctrl+F on macOS does not open the bar (cursor-forward preserved); Cmd+F opens it, Cmd+G navigates.
  - `Escape` closes the bar and clears all highlights.

### Screenshots / recordings

Happy to attach a recording on request; verified interactively as described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR