### PR TITLE
feat(app): add file context menu with open in editor, copy path, reveal

### DIFF
--- a/packages/app/src/components/file-context-menu.test.ts
+++ b/packages/app/src/components/file-context-menu.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { resolveAbsoluteFilePath } from "./file-context-menu"
+
+describe("resolveAbsoluteFilePath", () => {
+  const root = "/repo"
+
+  test("keeps absolute paths unchanged", () => {
+    expect(resolveAbsoluteFilePath("/repo/src/a.ts", root)).toBe("/repo/src/a.ts")
+    expect(resolveAbsoluteFilePath("C:\\repo\\a.ts", root)).toBe("C:\\repo\\a.ts")
+    expect(resolveAbsoluteFilePath("D:/repo/a.ts", root)).toBe("D:/repo/a.ts")
+  })
+
+  test("joins relative paths with the worktree root", () => {
+    expect(resolveAbsoluteFilePath("src/a.ts", root)).toBe("/repo/src/a.ts")
+    expect(resolveAbsoluteFilePath("src/a.ts", "/repo/")).toBe("/repo/src/a.ts")
+  })
+
+  test("returns the input when no base directory is available", () => {
+    expect(resolveAbsoluteFilePath("src/a.ts", "")).toBe("src/a.ts")
+  })
+})

--- a/packages/app/src/components/file-context-menu.tsx
+++ b/packages/app/src/components/file-context-menu.tsx
@@ -1,0 +1,118 @@
+import { createEffect, createMemo, createSignal, Show, type JSX } from "solid-js"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
+import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
+import { useSDK } from "@/context/sdk"
+import { useSync } from "@/context/sync"
+import { showToast } from "@/utils/toast"
+import { detectOpenAppOS, type OpenAppOS } from "@/components/session/open-in-app"
+
+const VSCODE_OPEN_WITH: Record<OpenAppOS, string> = {
+  macos: "Visual Studio Code",
+  windows: "code",
+  linux: "code",
+  unknown: "code",
+}
+
+const REVEAL_LABEL: Record<OpenAppOS, string> = {
+  macos: "session.header.reveal.finder",
+  windows: "session.header.reveal.fileExplorer",
+  linux: "session.header.reveal.containingFolder",
+  unknown: "session.header.reveal.containingFolder",
+}
+
+export function resolveAbsoluteFilePath(path: string, directory: string) {
+  if (path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path)) return path
+  const base = directory.replace(/[\\/]+$/, "")
+  if (!base) return path
+  return `${base}/${path}`
+}
+
+// Right-click menu for file rows: open in VS Code, copy path, and reveal in
+// the OS file manager. Native actions need the desktop app and a local
+// server; copy works everywhere.
+export function FileContextMenu(props: { path: string; children: JSX.Element }) {
+  const platform = usePlatform()
+  const server = useServer()
+  const language = useLanguage()
+  const sdk = useSDK()
+  const sync = useSync()
+
+  const os = createMemo(() => detectOpenAppOS(platform))
+  // Diff and snapshot paths are git-worktree relative, which can differ from
+  // the session directory when the server runs in a project subdirectory.
+  const root = createMemo(() => sync().project?.worktree ?? sdk().directory)
+  const absolute = createMemo(() => resolveAbsoluteFilePath(props.path, root()))
+  const local = createMemo(() => platform.platform === "desktop" && !!platform.openPath && server.isLocal())
+
+  const [vscode, setVscode] = createSignal<boolean>()
+  createEffect(() => {
+    if (!local() || !platform.checkAppExists) return
+    const app = VSCODE_OPEN_WITH[os()]
+    Promise.resolve(platform.checkAppExists(app))
+      .then((ok) => setVscode(Boolean(ok)))
+      .catch(() => setVscode(false))
+  })
+
+  const fail = (err: unknown) =>
+    showToast({
+      variant: "error",
+      title: language.t("common.requestFailed"),
+      description: err instanceof Error ? err.message : String(err),
+    })
+
+  const openInVSCode = () => {
+    if (!platform.openPath) return
+    platform.openPath(absolute(), VSCODE_OPEN_WITH[os()]).catch(fail)
+  }
+
+  const reveal = () => {
+    if (!platform.revealPath) return
+    platform
+      .revealPath(absolute())
+      .then((ok) => {
+        if (!ok) fail(new Error(absolute()))
+      })
+      .catch(fail)
+  }
+
+  const copy = () => {
+    navigator.clipboard
+      .writeText(absolute())
+      .then(() =>
+        showToast({
+          variant: "success",
+          icon: "circle-check",
+          title: language.t("session.share.copy.copied"),
+          description: absolute(),
+        }),
+      )
+      .catch(fail)
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenu.Trigger style={{ display: "contents" }}>{props.children}</ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content>
+          <Show when={local() && vscode()}>
+            <ContextMenu.Item onSelect={openInVSCode}>
+              <ContextMenu.ItemLabel>
+                {language.t("session.file.openInApp", { app: language.t("session.header.open.app.vscode") })}
+              </ContextMenu.ItemLabel>
+            </ContextMenu.Item>
+          </Show>
+          <ContextMenu.Item onSelect={copy}>
+            <ContextMenu.ItemLabel>{language.t("session.header.open.copyPath")}</ContextMenu.ItemLabel>
+          </ContextMenu.Item>
+          <Show when={local() && platform.revealPath}>
+            <ContextMenu.Item onSelect={reveal}>
+              <ContextMenu.ItemLabel>{language.t(REVEAL_LABEL[os()])}</ContextMenu.ItemLabel>
+            </ContextMenu.Item>
+          </Show>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  )
+}

--- a/packages/app/src/components/file-tree-v2.tsx
+++ b/packages/app/src/components/file-tree-v2.tsx
@@ -14,6 +14,7 @@ import {
 import { Dynamic } from "solid-js/web"
 import type { FileNode } from "@opencode-ai/sdk/v2"
 import { Icon } from "@opencode-ai/ui/v2/icon"
+import { FileContextMenu } from "@/components/file-context-menu"
 import { pathToFileUrl, withFileDragImage, type Kind } from "@/components/file-tree"
 import { createVirtualizer, defaultRangeExtractor } from "@tanstack/solid-virtual"
 import {
@@ -240,29 +241,31 @@ export default function FileTreeV2(props: {
                     <Show
                       when={row().node.type === "directory"}
                       fallback={
-                        <FileTreeNodeV2
-                          node={row().node}
-                          level={row().level}
-                          active={active()}
-                          draggable={draggable()}
-                          kinds={props.kinds}
-                          as="button"
-                          type="button"
-                          class="relative"
-                          onFocus={() => setFocused(row().node.path)}
-                          onBlur={() => setFocused(undefined)}
-                          onClick={() => selectFile(row().node, props.onFileClick)}
-                          onDblClick={() => selectFile(row().node, props.onFileDoubleClick)}
-                        >
-                          <GuideLines level={row().level} />
-                          <Show when={row().level > 0}>
-                            <div class="w-4 shrink-0" />
-                          </Show>
-                          <span class="filetree-iconpair size-4">
-                            <FileIcon node={row().node} class="size-4 filetree-icon filetree-icon--color" />
-                            <FileIcon node={row().node} class="size-4 filetree-icon filetree-icon--mono" mono />
-                          </span>
-                        </FileTreeNodeV2>
+                        <FileContextMenu path={row().node.originalPath}>
+                          <FileTreeNodeV2
+                            node={row().node}
+                            level={row().level}
+                            active={active()}
+                            draggable={draggable()}
+                            kinds={props.kinds}
+                            as="button"
+                            type="button"
+                            class="relative"
+                            onFocus={() => setFocused(row().node.path)}
+                            onBlur={() => setFocused(undefined)}
+                            onClick={() => selectFile(row().node, props.onFileClick)}
+                            onDblClick={() => selectFile(row().node, props.onFileDoubleClick)}
+                          >
+                            <GuideLines level={row().level} />
+                            <Show when={row().level > 0}>
+                              <div class="w-4 shrink-0" />
+                            </Show>
+                            <span class="filetree-iconpair size-4">
+                              <FileIcon node={row().node} class="size-4 filetree-icon filetree-icon--color" />
+                              <FileIcon node={row().node} class="size-4 filetree-icon filetree-icon--mono" mono />
+                            </span>
+                          </FileTreeNodeV2>
+                        </FileContextMenu>
                       }
                     >
                       <FileTreeNodeV2

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -3,6 +3,7 @@ import { encodeFilePath } from "@/context/file/path"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
+import { FileContextMenu } from "@/components/file-context-menu"
 import {
   createEffect,
   createMemo,
@@ -453,52 +454,54 @@ export default function FileTree(props: {
                 </Collapsible>
               </Match>
               <Match when={node.type === "file"}>
-                <FileTreeNode
-                  node={node}
-                  level={level}
-                  active={props.active}
-                  nodeClass={props.nodeClass}
-                  draggable={draggable()}
-                  kinds={kinds()}
-                  marks={marks()}
-                  as="button"
-                  type="button"
-                  onClick={() => props.onFileClick?.(node)}
-                  onDblClick={() => props.onFileDoubleClick?.(node)}
-                >
-                  <div class="w-4 shrink-0" />
-                  <Switch>
-                    <Match when={node.ignored}>
-                      <FileIcon
-                        node={node}
-                        class="size-4 filetree-icon filetree-icon--mono"
-                        style="color: var(--icon-weak-base)"
-                        mono
-                      />
-                    </Match>
-                    <Match when={active()}>
-                      <FileIcon
-                        node={node}
-                        class="size-4 filetree-icon filetree-icon--mono"
-                        style={kindTextColor(kind()!)}
-                        mono
-                      />
-                    </Match>
-                    <Match when={!node.ignored}>
-                      <span class="filetree-iconpair size-4">
+                <FileContextMenu path={node.absolute}>
+                  <FileTreeNode
+                    node={node}
+                    level={level}
+                    active={props.active}
+                    nodeClass={props.nodeClass}
+                    draggable={draggable()}
+                    kinds={kinds()}
+                    marks={marks()}
+                    as="button"
+                    type="button"
+                    onClick={() => props.onFileClick?.(node)}
+                    onDblClick={() => props.onFileDoubleClick?.(node)}
+                  >
+                    <div class="w-4 shrink-0" />
+                    <Switch>
+                      <Match when={node.ignored}>
                         <FileIcon
                           node={node}
-                          class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
-                        />
-                        <FileIcon
-                          node={node}
-                          class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                          class="size-4 filetree-icon filetree-icon--mono"
+                          style="color: var(--icon-weak-base)"
                           mono
                         />
-                      </span>
-                    </Match>
-                  </Switch>
-                </FileTreeNode>
+                      </Match>
+                      <Match when={active()}>
+                        <FileIcon
+                          node={node}
+                          class="size-4 filetree-icon filetree-icon--mono"
+                          style={kindTextColor(kind()!)}
+                          mono
+                        />
+                      </Match>
+                      <Match when={!node.ignored}>
+                        <span class="filetree-iconpair size-4">
+                          <FileIcon
+                            node={node}
+                            class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
+                          />
+                          <FileIcon
+                            node={node}
+                            class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                            mono
+                          />
+                        </span>
+                      </Match>
+                    </Switch>
+                  </FileTreeNode>
+                </FileContextMenu>
               </Match>
             </Switch>
           )

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -767,6 +767,8 @@ export const dict = {
   "session.header.reveal.finder": "መገለጥ በFinder",
   "session.header.reveal.fileExplorer": "ፋይል ኤክስፕሎረር ውስጥ ይገለጣል",
   "session.header.reveal.containingFolder": "አቃፊን የያዘ ክፈት",
+  "session.file.openInApp": "በ{{app}} ውስጥ ክፈት",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -1102,6 +1102,8 @@ export const dict = {
   "session.header.reveal.finder": "إظهار في Finder",
   "session.header.reveal.fileExplorer": "إظهار في مستكشف الملفات",
   "session.header.reveal.containingFolder": "فتح المجلد الحاوي",
+  "session.file.openInApp": "فتح في {{app}}",
+
   "session.header.open.fileManager": "مدير الملفات",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -790,6 +790,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder-də göstər",
   "session.header.reveal.fileExplorer": "File Explorer-də göstər",
   "session.header.reveal.containingFolder": "Tərkibindəki qovluğu açın",
+  "session.file.openInApp": "{{app}} tətbiqində aç",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -786,6 +786,8 @@ export const dict = {
   "session.header.reveal.finder": "Разкриване във Finder",
   "session.header.reveal.fileExplorer": "Разкриване в File Explorer",
   "session.header.reveal.containingFolder": "Отворете съдържащата папка",
+  "session.file.openInApp": "Отворете в {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -780,6 +780,8 @@ export const dict: Record<string, string> = {
   "session.header.reveal.finder": "Finder-এ প্রকাশ করুন",
   "session.header.reveal.fileExplorer": "File Explorer-এ প্রকাশ করুন",
   "session.header.reveal.containingFolder": "ফোল্ডার ধারণকারী খুলুন",
+  "session.file.openInApp": "{{app}}-এ খুলুন",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -1110,6 +1110,8 @@ export const dict = {
   "session.header.reveal.finder": "Revelar no Finder",
   "session.header.reveal.fileExplorer": "Revelar no Explorador de Arquivos",
   "session.header.reveal.containingFolder": "Abrir pasta que contém este item",
+  "session.file.openInApp": "Abrir em {{app}}",
+
   "session.header.open.fileManager": "Gerenciador de Arquivos",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -1186,6 +1186,8 @@ export const dict = {
   "session.header.reveal.finder": "Prikaži u Finderu",
   "session.header.reveal.fileExplorer": "Prikaži u File Exploreru",
   "session.header.reveal.containingFolder": "Otvori fasciklu koja sadrži ovu stavku",
+  "session.file.openInApp": "Otvori u {{app}}",
+
   "session.header.open.fileManager": "File Manager",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -789,6 +789,8 @@ export const dict = {
   "session.header.reveal.finder": "Revela a Finder",
   "session.header.reveal.fileExplorer": "Revela a File Explorer",
   "session.header.reveal.containingFolder": "Obre la carpeta que conté",
+  "session.file.openInApp": "Obert a {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -786,6 +786,8 @@ export const dict = {
   "session.header.reveal.finder": "Odhalit v Finder",
   "session.header.reveal.fileExplorer": "Odhalit v File Explorer",
   "session.header.reveal.containingFolder": "Otevřete složku obsahující",
+  "session.file.openInApp": "Otevřít v {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -1060,6 +1060,8 @@ export const dict = {
   "session.header.reveal.finder": "Vis i Finder",
   "session.header.reveal.fileExplorer": "Vis i Stifinder",
   "session.header.reveal.containingFolder": "Åbn den overordnede mappe",
+  "session.file.openInApp": "Åbn i {{app}}",
+
   "session.header.open.fileManager": "Filhåndtering",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -1004,6 +1004,8 @@ export const dict = {
   "session.header.reveal.finder": "Im Finder anzeigen",
   "session.header.reveal.fileExplorer": "Im Datei-Explorer anzeigen",
   "session.header.reveal.containingFolder": "Übergeordneten Ordner öffnen",
+  "session.file.openInApp": "In {{app}} öffnen",
+
   "session.header.open.fileManager": "Dateimanager",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -792,6 +792,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder ގައި ހާމަކުރުން",
   "session.header.reveal.fileExplorer": "File Explorer ގައި ހާމަކުރުން",
   "session.header.reveal.containingFolder": "ކޮންޓެއިން ފޯލްޑަރ ހުޅުވާށެވެ",
+  "session.file.openInApp": "{{app}} ގައި ހުޅުވާފައި ހުރެއެވެ",
+
   "session.header.open.app.vscode": "VS Code އެވެ",
   "session.header.open.app.cursor": "Cursor އެވެ",
   "session.header.open.app.zed": "Zed އެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -793,6 +793,8 @@ export const dict: Record<string, string> = {
   "session.header.reveal.finder": "Finderནང་གསལ་སྟོན་འབད།",
   "session.header.reveal.fileExplorer": "File Explorerནང་གསལ་སྟོན་འབད།",
   "session.header.reveal.containingFolder": "སྣོད་འཛིན་ཡོད་པའི་ཁ་ཕྱེ།",
+  "session.file.openInApp": "{{app}}ནང་ཁ་ཕྱེ།",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor།",
   "session.header.open.app.zed": "Zed།",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -788,6 +788,8 @@ export const dict = {
   "session.header.reveal.finder": "Αποκάλυψη σε Finder",
   "session.header.reveal.fileExplorer": "Αποκάλυψη στην Εξερεύνηση αρχείων",
   "session.header.reveal.containingFolder": "Άνοιγμα που περιέχει φάκελο",
+  "session.file.openInApp": "Άνοιγμα σε {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -749,6 +749,7 @@ export const dict = {
   "session.header.reveal.finder": "Reveal in Finder",
   "session.header.reveal.fileExplorer": "Reveal in File Explorer",
   "session.header.reveal.containingFolder": "Open containing folder",
+  "session.file.openInApp": "Open in {{app}}",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -1194,6 +1194,8 @@ export const dict = {
   "session.header.reveal.finder": "Mostrar en Finder",
   "session.header.reveal.fileExplorer": "Mostrar en el Explorador de archivos",
   "session.header.reveal.containingFolder": "Abrir carpeta contenedora",
+  "session.file.openInApp": "Abrir en {{app}}",
+
   "session.header.open.fileManager": "Gestor de archivos",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -776,6 +776,8 @@ export const dict = {
   "session.header.reveal.finder": "Avalda Finder",
   "session.header.reveal.fileExplorer": "Avalda File Explorer",
   "session.header.reveal.containingFolder": "Ava sisaldav kaust",
+  "session.file.openInApp": "Avatud kohas {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -779,6 +779,8 @@ export const dict = {
   "session.header.reveal.finder": "در Finder آشکار کنید",
   "session.header.reveal.fileExplorer": "در File Explorer آشکار کنید",
   "session.header.reveal.containingFolder": "پوشه حاوی را باز کنید",
+  "session.file.openInApp": "در {{app}} باز کنید",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -678,6 +678,8 @@ export const dict = {
   "session.header.reveal.finder": "Näytä Finderissa",
   "session.header.reveal.fileExplorer": "Näytä Resurssienhallinnassa",
   "session.header.reveal.containingFolder": "Avaa tiedoston sisältävä kansio",
+  "session.file.openInApp": "Avaa sovelluksessa {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -780,6 +780,8 @@ export const dict = {
   "session.header.reveal.finder": "Avdúka í Finder",
   "session.header.reveal.fileExplorer": "Avdúka í File Explorer",
   "session.header.reveal.containingFolder": "Opna innihaldandi mappu",
+  "session.file.openInApp": "Opna í {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -1120,6 +1120,8 @@ export const dict = {
   "session.header.reveal.finder": "Afficher dans le Finder",
   "session.header.reveal.fileExplorer": "Afficher dans l’Explorateur de fichiers",
   "session.header.reveal.containingFolder": "Ouvrir le dossier contenant",
+  "session.file.openInApp": "Ouvrir dans {{app}}",
+
   "session.header.open.fileManager": "Gestionnaire de fichiers",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -790,6 +790,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder में प्रकट करें",
   "session.header.reveal.fileExplorer": "File Explorer में प्रकट करें",
   "session.header.reveal.containingFolder": "मूल फ़ोल्डर खोलें",
+  "session.file.openInApp": "{{app}} में खोलें",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -790,6 +790,8 @@ export const dict = {
   "session.header.reveal.finder": "Otkrij u Finder",
   "session.header.reveal.fileExplorer": "Otkrij u File Explorer",
   "session.header.reveal.containingFolder": "Otvori mapu koja sadrži",
+  "session.file.openInApp": "Otvori u {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -787,6 +787,8 @@ export const dict = {
   "session.header.reveal.finder": "Mutasd be a Finder-ben",
   "session.header.reveal.fileExplorer": "Mutasd be a File Explorer-ben",
   "session.header.reveal.containingFolder": "Nyissa meg a tartalmazó mappát",
+  "session.file.openInApp": "Nyitás {{app}}-ben",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -785,6 +785,8 @@ export const dict = {
   "session.header.reveal.finder": "Բացահայտեք Finder",
   "session.header.reveal.fileExplorer": "Հայտնաբերել File Explorer-ում",
   "session.header.reveal.containingFolder": "Բացել պարունակող թղթապանակ",
+  "session.file.openInApp": "Բացել {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -850,6 +850,8 @@ export const dict = {
   "session.header.reveal.finder": "Tampilkan di Finder",
   "session.header.reveal.fileExplorer": "Tampilkan di File Explorer",
   "session.header.reveal.containingFolder": "Buka folder yang memuatnya",
+  "session.file.openInApp": "Buka di {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -783,6 +783,8 @@ export const dict = {
   "session.header.reveal.finder": "Sýna í Finder",
   "session.header.reveal.fileExplorer": "Sýna í File Explorer",
   "session.header.reveal.containingFolder": "Opnaðu möppuna sem inniheldur",
+  "session.file.openInApp": "Opið í {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -699,6 +699,8 @@ export const dict = {
   "session.header.reveal.finder": "Mostra nel Finder",
   "session.header.reveal.fileExplorer": "Mostra in Esplora file",
   "session.header.reveal.containingFolder": "Apri la cartella contenente",
+  "session.file.openInApp": "Apri in {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -1092,6 +1092,8 @@ export const dict = {
   "session.header.reveal.finder": "Finderで表示",
   "session.header.reveal.fileExplorer": "エクスプローラーで表示",
   "session.header.reveal.containingFolder": "親フォルダーを開く",
+  "session.file.openInApp": "{{app}}で開く",
+
   "session.header.open.fileManager": "ファイルマネージャー",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -780,6 +780,8 @@ export const dict = {
   "session.header.reveal.finder": "გამოვლენა Finder",
   "session.header.reveal.fileExplorer": "გამოვლენა File Explorer-ში",
   "session.header.reveal.containingFolder": "გახსენით შემცველი საქაღალდე",
+  "session.file.openInApp": "გახსენით {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -777,6 +777,8 @@ export const dict = {
   "session.header.reveal.finder": "បង្ហាញនៅក្នុង Finder",
   "session.header.reveal.fileExplorer": "បង្ហាញនៅក្នុង File Explorer",
   "session.header.reveal.containingFolder": "បើកថតដែលមាន",
+  "session.file.openInApp": "បើកក្នុង {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -817,6 +817,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder에서 보기",
   "session.header.reveal.fileExplorer": "파일 탐색기에서 보기",
   "session.header.reveal.containingFolder": "이 항목이 있는 폴더 열기",
+  "session.file.openInApp": "{{app}}에서 열기",
+
   "session.header.open.fileManager": "파일 관리자",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -775,6 +775,8 @@ export const dict = {
   "session.header.reveal.finder": "ເປີດເຜີຍໃນ Finder",
   "session.header.reveal.fileExplorer": "ເປີດເຜີຍໃນ File Explorer",
   "session.header.reveal.containingFolder": "ເປີດໂຟນເດີທີ່ບັນຈຸ",
+  "session.file.openInApp": "ເປີດໃນ {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -793,6 +793,8 @@ export const dict = {
   "session.header.reveal.finder": "Atskleiskite Finder",
   "session.header.reveal.fileExplorer": "Atskleiskite File Explorer",
   "session.header.reveal.containingFolder": "Atidarykite aplanką, kuriame yra",
+  "session.file.openInApp": "Atidaryti {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -785,6 +785,8 @@ export const dict = {
   "session.header.reveal.finder": "Parādīt Finder",
   "session.header.reveal.fileExplorer": "Parādīt failu pārlūkā",
   "session.header.reveal.containingFolder": "Atvērt saturējošo mapi",
+  "session.file.openInApp": "Atvērt ar {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -784,6 +784,8 @@ export const dict = {
   "session.header.reveal.finder": "Откријте во Пронаоѓач",
   "session.header.reveal.fileExplorer": "Откријте во File Explorer",
   "session.header.reveal.containingFolder": "Отворете ја папката што содржи",
+  "session.file.openInApp": "Отвори во {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -786,6 +786,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder дээр харуулах",
   "session.header.reveal.fileExplorer": "File Explorer-д харуулах",
   "session.header.reveal.containingFolder": "Фолдер агуулсан фолдерыг нээх",
+  "session.file.openInApp": "{{app}}-д нээх",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -778,6 +778,8 @@ export const dict = {
   "session.header.reveal.finder": "Tunjuk dalam Finder",
   "session.header.reveal.fileExplorer": "Tunjuk dalam Penjelajah Fail",
   "session.header.reveal.containingFolder": "Buka folder mengandungi",
+  "session.file.openInApp": "Buka dalam {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -788,6 +788,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder တွင် ထုတ်ပြပါ။",
   "session.header.reveal.fileExplorer": "File Explorer တွင် ထုတ်ပြပါ။",
   "session.header.reveal.containingFolder": "ပါဝင်သောဖိုင်တွဲကိုဖွင့်ပါ။",
+  "session.file.openInApp": "{{app}} တွင် ဖွင့်ပါ။",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -782,6 +782,8 @@ export const dict: Record<string, string> = {
   "session.header.reveal.finder": "Finder मा प्रकट गर्नुहोस्",
   "session.header.reveal.fileExplorer": "File Explorer मा प्रकट गर्नुहोस्",
   "session.header.reveal.containingFolder": "समावेश भएको फोल्डर खोल्नुहोस्",
+  "session.file.openInApp": "{{app}} मा खोल्नुहोस्",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -788,6 +788,8 @@ export const dict = {
   "session.header.reveal.finder": "Tonen in Finder",
   "session.header.reveal.fileExplorer": "Weergeven in Verkenner",
   "session.header.reveal.containingFolder": "Bijbehorende map openen",
+  "session.file.openInApp": "Openen in {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -1013,6 +1013,8 @@ export const dict = {
   "session.header.reveal.finder": "Vis i Finder",
   "session.header.reveal.fileExplorer": "Vis i Filutforsker",
   "session.header.reveal.containingFolder": "Åpne mappen som inneholder dette elementet",
+  "session.file.openInApp": "Åpne i {{app}}",
+
   "session.header.open.fileManager": "Filbehandler",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -789,6 +789,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder وچ ظاہر کرو",
   "session.header.reveal.fileExplorer": "File Explorer وچ ظاہر کرو",
   "session.header.reveal.containingFolder": "فائل والا فولڈر کھولو",
+  "session.file.openInApp": "{{app}} وچ کھولو",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -1112,6 +1112,8 @@ export const dict = {
   "session.header.reveal.finder": "Pokaż w Finderze",
   "session.header.reveal.fileExplorer": "Pokaż w Eksploratorze plików",
   "session.header.reveal.containingFolder": "Otwórz folder zawierający",
+  "session.file.openInApp": "Otwórz w {{app}}",
+
   "session.header.open.fileManager": "Menedżer plików",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -785,6 +785,8 @@ export const dict = {
   "session.header.reveal.finder": "Afișează în Finder",
   "session.header.reveal.fileExplorer": "Afișează în Explorer de fișiere",
   "session.header.reveal.containingFolder": "Deschide folderul conținător",
+  "session.file.openInApp": "Deschide în {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -1191,6 +1191,8 @@ export const dict = {
   "session.header.reveal.finder": "Показать в Finder",
   "session.header.reveal.fileExplorer": "Показать в Проводнике",
   "session.header.reveal.containingFolder": "Открыть папку расположения",
+  "session.file.openInApp": "Открыть в {{app}}",
+
   "session.header.open.fileManager": "Файловый менеджер",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -777,6 +777,8 @@ export const dict: Record<string, string> = {
   "session.header.reveal.finder": "Finder තුළ හෙළි කරන්න",
   "session.header.reveal.fileExplorer": "File Explorer හි හෙළි කරන්න",
   "session.header.reveal.containingFolder": "අඩංගු ෆෝල්ඩරය විවෘත කරන්න",
+  "session.file.openInApp": "{{app}} හි විවෘත කරන්න",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -784,6 +784,8 @@ export const dict = {
   "session.header.reveal.finder": "Zobraziť vo Finderi",
   "session.header.reveal.fileExplorer": "Zobraziť v Prieskumníku súborov",
   "session.header.reveal.containingFolder": "Otvoriť obsahujúci priečinok",
+  "session.file.openInApp": "Otvoriť v {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -786,6 +786,8 @@ export const dict = {
   "session.header.reveal.finder": "Razkrij v Finder",
   "session.header.reveal.fileExplorer": "Razkrij v File Explorer",
   "session.header.reveal.containingFolder": "Odpri mapo, ki vsebuje",
+  "session.file.openInApp": "Odpri v {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -783,6 +783,8 @@ export const dict = {
   "session.header.reveal.finder": "Zbulojeni në Finder",
   "session.header.reveal.fileExplorer": "Zbulojeni në File Explorer",
   "session.header.reveal.containingFolder": "Hap dosjen që përmban",
+  "session.file.openInApp": "Hapni në {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -784,6 +784,8 @@ export const dict = {
   "session.header.reveal.finder": "Откриј у Финдер-у",
   "session.header.reveal.fileExplorer": "Откриј у File Explorer",
   "session.header.reveal.containingFolder": "Отворите фасциклу која садржи",
+  "session.file.openInApp": "Отвори у {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -785,6 +785,8 @@ export const dict = {
   "session.header.reveal.finder": "Visa i Finder",
   "session.header.reveal.fileExplorer": "Visa i Utforskaren",
   "session.header.reveal.containingFolder": "Öppna överordnad mapp",
+  "session.file.openInApp": "Öppna i {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -783,6 +783,8 @@ export const dict = {
   "session.header.reveal.finder": "Дар Finder ошкор кунед",
   "session.header.reveal.fileExplorer": "Дар File Explorer ошкор кунед",
   "session.header.reveal.containingFolder": "Папкаи дорои ҷузвдонро кушоед",
+  "session.file.openInApp": "Кушодан дар {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -1167,6 +1167,8 @@ export const dict = {
   "session.header.reveal.finder": "แสดงใน Finder",
   "session.header.reveal.fileExplorer": "แสดงใน File Explorer",
   "session.header.reveal.containingFolder": "เปิดโฟลเดอร์ที่มีรายการนี้",
+  "session.file.openInApp": "เปิดใน {{app}}",
+
   "session.header.open.fileManager": "File Manager",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -780,6 +780,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder-de açyň",
   "session.header.reveal.fileExplorer": "File Explorer-de açyň",
   "session.header.reveal.containingFolder": "Içindäki bukjany açyň",
+  "session.file.openInApp": "{{app}}-de açyň",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -827,6 +827,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder'da göster",
   "session.header.reveal.fileExplorer": "Dosya Gezgini'nde göster",
   "session.header.reveal.containingFolder": "İçeren klasörü aç",
+  "session.file.openInApp": "{{app}} ile aç",
+
 
   "status.popover.trigger": "Durum",
   "status.popover.ariaLabel": "Sunucu yapılandırmaları",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -859,6 +859,8 @@ export const dict = {
   "session.header.reveal.finder": "Показати у Finder",
   "session.header.reveal.fileExplorer": "Показати у Файловому провіднику",
   "session.header.reveal.containingFolder": "Відкрити папку розташування",
+  "session.file.openInApp": "Відкрити в {{app}}",
+
   "session.header.open.fileManager": "Файловий менеджер",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -792,6 +792,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder میں ظاہر کریں۔",
   "session.header.reveal.fileExplorer": "File Explorer میں ظاہر کریں۔",
   "session.header.reveal.containingFolder": "متعلقہ فولڈر کھولیں",
+  "session.file.openInApp": "{{app}} میں کھولیں۔",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -785,6 +785,8 @@ export const dict = {
   "session.header.reveal.finder": "Finder da oshkor qiling",
   "session.header.reveal.fileExplorer": "File Explorer da oshkor qiling",
   "session.header.reveal.containingFolder": "O'z ichiga olgan jildni oching",
+  "session.file.openInApp": "{{app}} da oching",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -790,6 +790,8 @@ export const dict = {
   "session.header.reveal.finder": "Hiển thị trong Finder",
   "session.header.reveal.fileExplorer": "Hiển thị trong File Explorer",
   "session.header.reveal.containingFolder": "Mở thư mục chứa",
+  "session.file.openInApp": "Mở trong {{app}}",
+
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",
   "session.header.open.app.zed": "Zed",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1158,6 +1158,8 @@ export const dict = {
   "session.header.reveal.finder": "在访达中显示",
   "session.header.reveal.fileExplorer": "在文件资源管理器中显示",
   "session.header.reveal.containingFolder": "打开所在文件夹",
+  "session.file.openInApp": "在 {{app}} 中打开",
+
   "session.header.open.fileManager": "文件管理器",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -1154,6 +1154,8 @@ export const dict = {
   "session.header.reveal.finder": "在 Finder 中顯示",
   "session.header.reveal.fileExplorer": "在檔案總管中顯示",
   "session.header.reveal.containingFolder": "開啟所在的檔案夾",
+  "session.file.openInApp": "在 {{app}} 中開啟",
+
   "session.header.open.fileManager": "檔案管理員",
   "session.header.open.app.vscode": "VS Code",
   "session.header.open.app.cursor": "Cursor",

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -60,6 +60,7 @@ import { normalize } from "@opencode-ai/session-ui/session-diff"
 import { useFileComponent } from "@opencode-ai/ui/context/file"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
+import { FileContextMenu } from "@/components/file-context-menu"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
@@ -185,24 +186,26 @@ function TimelineDiffSummaryRow(props: { diffs: SummaryDiff[] }) {
               return (
                 <Accordion.Item value={diff.file}>
                   <StickyAccordionHeader>
-                    <Accordion.Trigger>
-                      <div data-slot="session-turn-diff-trigger">
-                        <span data-slot="session-turn-diff-path">
-                          <Show when={diff.file.includes("/")}>
-                            <span data-slot="session-turn-diff-directory">{`\u202A${getDirectory(diff.file)}\u202C`}</span>
-                          </Show>
-                          <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
-                        </span>
-                        <div data-slot="session-turn-diff-meta">
-                          <span data-slot="session-turn-diff-changes">
-                            <DiffChanges changes={diff} />
+                    <FileContextMenu path={diff.file}>
+                      <Accordion.Trigger>
+                        <div data-slot="session-turn-diff-trigger">
+                          <span data-slot="session-turn-diff-path">
+                            <Show when={diff.file.includes("/")}>
+                              <span data-slot="session-turn-diff-directory">{`\u202A${getDirectory(diff.file)}\u202C`}</span>
+                            </Show>
+                            <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
                           </span>
-                          <span data-slot="session-turn-diff-chevron">
-                            <Icon name="chevron-down" size="small" />
-                          </span>
+                          <div data-slot="session-turn-diff-meta">
+                            <span data-slot="session-turn-diff-changes">
+                              <DiffChanges changes={diff} />
+                            </span>
+                            <span data-slot="session-turn-diff-chevron">
+                              <Icon name="chevron-down" size="small" />
+                            </span>
+                          </div>
                         </div>
-                      </div>
-                    </Accordion.Trigger>
+                      </Accordion.Trigger>
+                    </FileContextMenu>
                   </StickyAccordionHeader>
                   <Accordion.Content>
                     <Show when={opened()}>


### PR DESCRIPTION
### Issue for this PR

N/A - file rows in the session UI have no context menu; quickly acting on changed files (open in editor, copy path, reveal) requires leaving the app.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `FileContextMenu` wrapper for file rows with three actions:

- **Open in VS Code** - desktop app + local server only, detected through the existing `checkAppExists` IPC (same app-detection the session header's "Open in" menu already uses)
- **Copy path** - works everywhere, copies the absolute path with the same toast as the existing header copy action
- **Reveal in Finder** - desktop + local server, label follows the OS (Finder / File Explorer / containing folder) using the existing `session.header.reveal.*` keys

Wired into the session diff summary rows, the v1 side-panel file tree, and the v2 file tree.

Two things worth noting:

- Relative diff/snapshot paths resolve against the project **worktree**, not the session directory. They differ when the server runs in a project subdirectory (joining with the session directory produced a doubled path); the resolution mirrors the existing `session-new-view` project-root pattern.
- The single new i18n key ("Open in {{app}}") reuses each locale's reviewed translation from `session.header.open.ariaLabel`, so all 62 locale files stay in parity without inventing new translations.

### How did you verify your code works?

- New unit test for the path resolution (3 tests pass; full app suite passes except one pre-existing i18n failure that also fails on `dev`).
- Verified interactively against `bun dev` (web) and the packaged Electron app:
  - Right-clicking a diff row or a file in either tree opens the menu; web shows only "Copy path", desktop shows all three.
  - "Copy path" writes the correct absolute path to the system clipboard, including for a server running in a project subdirectory.
  - `checkAppExists('Visual Studio Code')` returns true on a macOS machine with VS Code installed, via the existing IPC.

### Screenshots / recordings

Happy to attach a recording on request; verified interactively as described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR