### PR TITLE
fix(session): keep loop exit and part ordering robust to id wrap

### DIFF
--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -15,7 +15,9 @@ const prefixes = {
 
 const LENGTH = 26
 
-// State for monotonic ID generation
+// State for ordering IDs generated in the same millisecond. The six-byte
+// encoding retains only the low 36 bits of the millisecond timestamp, so IDs
+// are not globally monotonic across the 2^36 ms rollover.
 let lastTimestamp = 0
 let counter = 0
 
@@ -69,7 +71,7 @@ export function create(prefix: string, direction: "descending" | "ascending", ti
   return prefix + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12)
 }
 
-/** Extract timestamp from an ascending ID. Does not work with descending IDs. */
+/** Extract the low 36 timestamp bits from an ascending ID, not a full epoch timestamp. */
 export function timestamp(id: string): number {
   const prefix = id.split("_")[0]
   const hex = id.slice(prefix.length + 1, prefix.length + 13)

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -104,7 +104,7 @@ function hydrate(db: Database.Interface["db"], rows: (typeof MessageTable.$infer
         .select()
         .from(PartTable)
         .where(inArray(PartTable.message_id, ids))
-        .orderBy(PartTable.message_id, PartTable.id)
+        .orderBy(PartTable.message_id, PartTable.time_created, PartTable.id)
         .all()
         .pipe(Effect.orDie)
       for (const row of partRows) {
@@ -496,7 +496,7 @@ export function parts(messageID: MessageID) {
       .select()
       .from(PartTable)
       .where(eq(PartTable.message_id, messageID))
-      .orderBy(PartTable.id)
+      .orderBy(PartTable.time_created, PartTable.id)
       .all()
       .pipe(Effect.orDie)
     return rows.map(part)
@@ -601,6 +601,12 @@ function isAfter(info: Info, other?: Info) {
   if (!other) return true
   if (info.time.created !== other.time.created) return info.time.created > other.time.created
   return info.id > other.id
+}
+
+export function compareChronology(left: Info, right: Info) {
+  if (left.time.created !== right.time.created) return left.time.created < right.time.created ? -1 : 1
+  if (left.id === right.id) return 0
+  return left.id < right.id ? -1 : 1
 }
 
 export function fromError(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1097,6 +1097,13 @@ const layer = Layer.effect(
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 
+          // A terminal assistant normally parents the latest user turn, but
+          // transcripts written across the ID rollover can hold an assistant
+          // that settles the latest turn while keeping an older parent.
+          const lastAssistantBelongsToLatestTurn =
+            lastAssistant !== undefined &&
+            (lastAssistant.parentID === lastUser.id || MessageV2.compareChronology(lastUser, lastAssistant) < 0)
+
           const lastAssistantMsg = msgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
           )
@@ -1112,7 +1119,7 @@ const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastAssistant.parentID === lastUser.id
+            lastAssistantBelongsToLatestTurn
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -5,7 +5,11 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { Effect, Option } from "effect"
 import { Session as SessionNs } from "@/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
+import { Identifier } from "../../src/id/id"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { Database } from "@opencode-ai/core/database/database"
+import { PartTable } from "@opencode-ai/core/session/sql"
+import { eq } from "drizzle-orm"
 
 import { NotFoundError } from "@/storage/storage"
 import { testEffect } from "../lib/effect"
@@ -428,6 +432,58 @@ describe("MessageV2.parts", () => {
         expect((result[0] as SessionV1.TextPart).text).toBe("m0")
         expect((result[1] as SessionV1.TextPart).text).toBe("second")
         expect((result[2] as SessionV1.TextPart).text).toBe("third")
+      }),
+    ),
+  )
+
+  it.instance("orders parts by persisted creation time across the ID rollover", () =>
+    withSession(({ session, sessionID }) =>
+      Effect.gen(function* () {
+        const messageID = yield* addUser(sessionID)
+        // Parts of one message persisted on both sides of the rollover:
+        // ascending part IDs restart from zero, so raw ID order inverts the
+        // order the parts were actually written in.
+        const rollover = 2 ** 36
+        const earlyID = PartID.make(Identifier.create("prt", "ascending", rollover - 1))
+        const lateID = PartID.make(Identifier.create("prt", "ascending", rollover + 1))
+        yield* session.updatePart({
+          id: earlyID,
+          sessionID,
+          messageID,
+          type: "text",
+          text: "early",
+        })
+        yield* session.updatePart({
+          id: lateID,
+          sessionID,
+          messageID,
+          type: "text",
+          text: "late",
+        })
+        const { db } = yield* Database.Service
+        yield* db
+          .update(PartTable)
+          .set({ time_created: rollover - 1 })
+          .where(eq(PartTable.id, earlyID))
+          .run()
+          .pipe(Effect.orDie)
+        yield* db
+          .update(PartTable)
+          .set({ time_created: rollover + 1 })
+          .where(eq(PartTable.id, lateID))
+          .run()
+          .pipe(Effect.orDie)
+
+        expect(earlyID > lateID).toBe(true)
+
+        const parts = yield* MessageV2.parts(messageID)
+        expect(parts.map((part) => part.id)).toEqual([earlyID, lateID])
+        expect((parts[0] as SessionV1.TextPart).text).toBe("early")
+        expect((parts[1] as SessionV1.TextPart).text).toBe("late")
+
+        const hydrated = yield* MessageV2.page({ sessionID, limit: 1 })
+        expect(hydrated.items[0]?.info.id).toBe(messageID)
+        expect(hydrated.items[0]?.parts.map((part) => part.id)).toEqual([earlyID, lateID])
       }),
     ),
   )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -37,6 +37,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
+import { Identifier } from "../../src/id/id"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionV2 } from "@opencode-ai/core/session"
@@ -496,6 +497,81 @@ noLLMServer.instance(
       const result = yield* prompt.loop({ sessionID: chat.id })
 
       expect(result.info.id).toBe(assistantID)
+    }),
+  { config: cfg },
+)
+
+it.instance(
+  "loop exits without an LLM request when the terminal assistant kept a pre-rollover parent",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      // Ascending IDs only carry the low bits of the epoch, so a transcript
+      // written across the rollover holds post-rollover IDs that sort before
+      // the pre-rollover ones. The assistant that settles the post-rollover
+      // user turn can therefore keep a pre-rollover user as parent.
+      const rollover = 2 ** 36
+      const preUserID = MessageID.make(Identifier.create("msg", "ascending", rollover - 3))
+      const preAssistantID = MessageID.make(Identifier.create("msg", "ascending", rollover - 2))
+      const postUserID = MessageID.make(Identifier.create("msg", "ascending", rollover + 1))
+      const postAssistantID = MessageID.make(Identifier.create("msg", "ascending", rollover + 2))
+      yield* sessions.updateMessage({
+        id: preUserID,
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: rollover - 3 },
+      })
+      yield* sessions.updateMessage({
+        id: preAssistantID,
+        role: "assistant",
+        parentID: preUserID,
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: rollover - 2 },
+        finish: "tool-calls",
+      })
+      yield* sessions.updateMessage({
+        id: postUserID,
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: rollover + 1 },
+      })
+      yield* sessions.updateMessage({
+        id: postAssistantID,
+        role: "assistant",
+        parentID: preUserID,
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: rollover + 2 },
+        finish: "stop",
+      })
+
+      // The post-rollover pair sorts before every pre-rollover ID.
+      expect(preUserID > postAssistantID).toBe(true)
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+
+      expect(yield* llm.hits).toHaveLength(0)
+      expect(result.info.id).toBe(postAssistantID)
     }),
   { config: cfg },
 )


### PR DESCRIPTION
### Issue for this PR

Fixes #42816 — specifically the completion-gate fallback item. The part-ordering gap below is new (not in that issue). Items 1 and 2 of #42816 (revert cleanup ordering, localeCompare collation) are intentionally left to #42819.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two ordering gaps survive the August rollover fixes:

1. **The completion gate has no chronological fallback.** It requires `lastAssistant.parentID === lastUser.id`. For histories written before the parentID gate landed — or with synthetic users carrying legacy short ids — the chronologically latest assistant stays parented to an older user, the equality never holds, and every run issues one spurious provider request. #42816 measured 31 of 251k sessions in that shape. Add a fallback: the turn is also complete when the assistant precedes the latest user by `time.created` (id tiebreak) — `compareChronology`, the same ordering the pagination cursor already uses. The `parentID` arm is unchanged, so well-formed histories behave identically.

2. **Message parts were still ordered by raw part id** (`hydrate`, `parts()`). Parts of one message whose ids straddle the wrap sort backwards. Order them by persisted `time_created` with the id tiebreak, matching the message-level cursor. (Client stores still key parts by id — follow-up.)

Two comment corrections in `id.ts`: the encoding keeps the low 36 timestamp bits, so ids are not globally monotonic across the 2^36 ms period.

Known tradeoff, stated openly: with the fallback, a run whose latest assistant predates a later concurrent user (assistant parented to the earlier user) exits before answering the newer user; `parentID` alone answers the newer user but never exits stale-parent histories. We chose exit — the same choice the issue reporter made.

Related work: earlier attempts at this family — #39806 (full ordering rework), #42640 (time.created in `latest()`/runLoop), #42684 (numeric compare in `isAfter`) — were closed unmerged, two of them on the description-compliance window rather than on merit; the message-level half they targeted has since landed via #40990. This PR covers the two gaps none of them reached, with two differences: both fixes are pinned to **reproductions on current dev** (one request on dev, zero here; wrong part order flipping to correct), and it deliberately stays out of the domains already owned by open work — revert cleanup/collation (#42819, #46974), TUI redo/child ordering (#42590, #42907, #43035), and the app store sort that #42816 raised as wanting a shared comparator — so nothing here competes with those.

### How did you verify your code works?

- `bun run typecheck` in `packages/opencode`
- `bun test test/session/` — 423 tests, 0 fail, including two new fixtures: one reproducing the spurious request across a pinned rollover boundary (one request on dev, zero here), one seeding parts across the wrap boundary (order flips from wrong to correct)

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
