### PR TITLE
docs(ecosystem): add opencode-cd plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -56,6 +56,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
 
+| [opencode-cd](https://github.com/artempavlov/opencode-cd)                                          | Move the current OpenCode session to another directory while preserving conversation history and child sessions across projects |
 ---
 
 ## Projects


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-cd` to the official OpenCode ecosystem Plugins table. It is a TUI plugin that lets users move the current session to another existing directory while preserving conversation history and child sessions across projects.

Repository: https://github.com/artempavlov/opencode-cd

### How did you verify your code works?

This is a documentation-only table entry. The linked repository is public, and the plugin repository passes `bun run typecheck`, `bun test`, and `npm pack --dry-run`.

### Screenshots / recordings

Not applicable: this PR only changes the documentation table.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR