### PR TITLE
fix(tui): select first row when opening terminals tab

### DIFF
--- a/packages/tui/src/routes/session/composer/terminals-tab.tsx
+++ b/packages/tui/src/routes/session/composer/terminals-tab.tsx
@@ -24,7 +24,7 @@ export function TerminalsTab(props: { sessionID: string; visibleTerminalID?: str
   createEffect(() => {
     if (!composer.active("terminals")) return
     const index = entries().findIndex((terminal) => terminal.id === props.visibleTerminalID)
-    setSelected(index < 0 ? undefined : index)
+    setSelected(index < 0 ? 0 : index)
   })
 
   const select = () => {


### PR DESCRIPTION
## Why

Opening the Terminals tab with no visible terminal leaves every row unselected. When the list is empty, even the only action, **+ New terminal**, requires an arrow key before Enter does anything.

## What Changes

Fall back to the first row when there is no matching visible terminal.

| State on opening | Selection |
| --- | --- |
| No terminals | **+ New terminal** |
| Existing terminals, none visible | First terminal |
| A listed terminal is visible | That terminal |

## Demo

https://github.com/user-attachments/assets/04a59c0e-ebee-42f2-b7be-b3401b16a523

Matched OpenCode Drive runs of the production TUI: **before** `cd504dc66a`, **after** `bc784ff718`. Both use the same isolated project, simulated model response, 90×24 terminal viewport, and interaction: open the picker, switch to Terminals, then press Enter. The clips play sequentially at native resolution for legibility, with equal-duration holds and no acceleration. Before, Enter leaves the picker open; after, it opens the terminal pane.

## Scope

One-line change to the Terminals tab's initial-selection fallback.

## Verification

```sh
# packages/tui
bun typecheck

# Same script, two development checkouts
opencode-drive check terminal-focus-demo.ts
opencode-drive start --name terminal-focus-before --record --script terminal-focus-demo.ts --dev ../opencode-terminal-tab-before
opencode-drive start --name terminal-focus-after --record --script terminal-focus-demo.ts --dev ../opencode-terminal-tab-focus

git diff --check
```

All passed. Both recorded runs completed and their frames were inspected. The pre-push hook also passed all 33 typecheck tasks using Bun 1.4.2 (27 cached).
