### PR TITLE
feat(console): add batch workspace block endpoints

### DIFF
--- a/packages/console/app/src/routes/api/support/actions/block-workspaces.ts
+++ b/packages/console/app/src/routes/api/support/actions/block-workspaces.ts
@@ -1,0 +1,22 @@
+import type { APIEvent } from "@solidjs/start/server"
+import { Workspace } from "@opencode-ai/console-core/workspace.js"
+import { safeEqual } from "@opencode-ai/console-core/util/crypto.js"
+import { Resource } from "@opencode-ai/console-resource"
+import z from "zod"
+
+const Body = z.object({ workspaceIDs: z.array(z.string().startsWith("wrk_")).min(1) })
+
+export async function POST(event: APIEvent) {
+  if (!safeEqual(event.request.headers.get("authorization") ?? "", `Bearer ${Resource.SUPPORT_API_KEY.value}`)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = Body.safeParse(await event.request.json().catch(() => undefined))
+  if (!body.success) {
+    return Response.json({ error: "Invalid request", issues: body.error.issues }, { status: 400 })
+  }
+  // Missing IDs do not fail the batch; they are reported per item in the result.
+  return Workspace.blockBatch(body.data)
+    .then((result) => Response.json({ success: true, message: "Workspaces blocked", result }))
+    .catch((error) => Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 }))
+}

--- a/packages/console/app/src/routes/api/support/actions/unblock-workspaces.ts
+++ b/packages/console/app/src/routes/api/support/actions/unblock-workspaces.ts
@@ -1,0 +1,22 @@
+import type { APIEvent } from "@solidjs/start/server"
+import { Workspace } from "@opencode-ai/console-core/workspace.js"
+import { safeEqual } from "@opencode-ai/console-core/util/crypto.js"
+import { Resource } from "@opencode-ai/console-resource"
+import z from "zod"
+
+const Body = z.object({ workspaceIDs: z.array(z.string().startsWith("wrk_")).min(1) })
+
+export async function POST(event: APIEvent) {
+  if (!safeEqual(event.request.headers.get("authorization") ?? "", `Bearer ${Resource.SUPPORT_API_KEY.value}`)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const body = Body.safeParse(await event.request.json().catch(() => undefined))
+  if (!body.success) {
+    return Response.json({ error: "Invalid request", issues: body.error.issues }, { status: 400 })
+  }
+  // Missing IDs do not fail the batch; they are reported per item in the result.
+  return Workspace.unblockBatch(body.data)
+    .then((result) => Response.json({ success: true, message: "Workspaces unblocked", result }))
+    .catch((error) => Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 }))
+}

--- a/packages/console/core/src/workspace.ts
+++ b/packages/console/core/src/workspace.ts
@@ -8,7 +8,7 @@ import { BillingTable } from "./schema/billing.sql"
 import { WorkspaceTable } from "./schema/workspace.sql"
 import { AccountTable } from "./schema/account.sql"
 import { Key } from "./key"
-import { and, eq, isNull, sql } from "drizzle-orm"
+import { and, eq, inArray, isNull, sql } from "drizzle-orm"
 
 export namespace Workspace {
   export const Region = z.enum(["us", "eu", "sg", "cn"])
@@ -109,6 +109,26 @@ export namespace Workspace {
     },
   )
 
+  export const blockBatch = fn(
+    z.object({
+      workspaceIDs: z.array(Identifier.schema("workspace")).min(1),
+    }),
+    async (input) => {
+      const { applied, notFound } = await setBlockedBatch(input, true)
+      return { blocked: applied, notFound }
+    },
+  )
+
+  export const unblockBatch = fn(
+    z.object({
+      workspaceIDs: z.array(Identifier.schema("workspace")).min(1),
+    }),
+    async (input) => {
+      const { applied, notFound } = await setBlockedBatch(input, false)
+      return { unblocked: applied, notFound }
+    },
+  )
+
   export const remove = fn(z.void(), async () => {
     await Database.use((tx) =>
       tx
@@ -116,5 +136,26 @@ export namespace Workspace {
         .set({ timeDeleted: sql`now()` })
         .where(eq(WorkspaceTable.id, Actor.workspace())),
     )
+  })
+}
+
+// No size cap by design; large IN lists degrade on Vitess, so chunks stay fixed-size and
+// sequential to share one connection inside ambient transactions. Existence comes from the
+// follow-up select rather than rowsAffected, so no-op rows (already in the target state)
+// still report as applied instead of "not found".
+const setBlockedBatch = async (input: { workspaceIDs: string[] }, isBlocked: boolean) => {
+  const ids = [...new Set(input.workspaceIDs)]
+  return await Database.use(async (tx) => {
+    const applied = new Set<string>()
+    for (let index = 0; index < ids.length; index += 500) {
+      const chunk = ids.slice(index, index + 500)
+      await tx.update(WorkspaceTable).set({ is_blocked: isBlocked }).where(inArray(WorkspaceTable.id, chunk))
+      const rows = await tx.select({ id: WorkspaceTable.id }).from(WorkspaceTable).where(inArray(WorkspaceTable.id, chunk))
+      for (const row of rows) applied.add(row.id)
+    }
+    return {
+      applied: ids.filter((id) => applied.has(id)),
+      notFound: ids.filter((id) => !applied.has(id)),
+    }
   })
 }


### PR DESCRIPTION
## Summary

- Adds `Workspace.blockBatch` / `Workspace.unblockBatch` to `packages/console/core/src/workspace.ts`: set `is_blocked` for an arbitrary list of workspace IDs in one call, reporting `{ blocked | unblocked, notFound }` per item
- Adds two support routes with the usual `SUPPORT_API_KEY` bearer auth:
  - `POST /api/support/actions/block-workspaces` — body `{ "workspaceIDs": ["wrk_...", ...] }`
  - `POST /api/support/actions/unblock-workspaces` — same shape, the rollback path for a mistaken batch

## Motivation

Fraud response regularly needs to block hundreds of workspaces at once. Calling the existing single-workspace endpoint per ID means hundreds of round trips from the caller and hundreds of separate UPDATE statements. This endpoint takes the whole list in one request and reports per-item results.

## Design

- **No size cap**: the request accepts any non-empty list. Large `IN` lists degrade on Vitess, so the core chunks the work into fixed groups of 500 executed sequentially inside one `Database.use` — sequential keeps the statements on one connection inside ambient transactions.
- **Existence-based reporting, not rowsAffected**: after each chunk's UPDATE, a follow-up SELECT determines which IDs exist. MySQL reports 0 affected rows for no-op updates (no `CLIENT_FOUND_ROWS`), so `rowsAffected` cannot distinguish "already blocked" from "missing" — the select can.
- **Partial missing does not fail the batch**: unknown IDs land in `notFound` with HTTP 200 and the full result body. This deliberately differs from the single endpoints' not-found → 400; two stale IDs should not discard 298 successful blocks. The caller (the OpenCode support agent, see the companion PR) surfaces `notFound` for operator follow-up.
- Duplicate input IDs are deduplicated before the update.
- No schema change, no migration.

## Usage

```
POST /api/support/actions/block-workspaces
Authorization: Bearer <SUPPORT_API_KEY>

{ "workspaceIDs": ["wrk_...", "wrk_..."] }
```

- `200` — `{"success":true,"message":"Workspaces blocked","result":{"blocked":[...],"notFound":[...]}}`
- `400` — invalid body (empty list, non-`wrk_` IDs)
- `401` — missing/incorrect support key

## Related

- Independent of #48462 (single-workspace `block-workspace` endpoint); no shared code paths.
- Consumed by the OpenCode agent's batch block support action (`anomalyco/experiments#567`); that PR executes 404 → `failed` until this endpoint merges and deploys, so this PR should land first.
