### PR TITLE
fix(cli): preserve ACP reasoning boundaries and effort selections

### DIFF
--- a/packages/cli/src/acp/config-option.ts
+++ b/packages/cli/src/acp/config-option.ts
@@ -76,7 +76,10 @@ export function buildEffortSelectOption(input: {
     category: "thought_level",
     type: "select",
     currentValue: selectVariant(input.currentVariant, input.variants),
-    options: input.variants.map((variant) => ({ value: variant, name: formatVariantName(variant) })),
+    options: [...new Set([...input.variants, DEFAULT_VARIANT_VALUE])].map((variant) => ({
+      value: variant,
+      name: formatVariantName(variant),
+    })),
   }
 }
 
@@ -125,6 +128,7 @@ export function formatVariantName(variant: string) {
 }
 
 function selectVariant(variant: string | undefined, variants: readonly string[]) {
+  if (!variant || variant === DEFAULT_VARIANT_VALUE) return DEFAULT_VARIANT_VALUE
   if (variant && variants.includes(variant)) return variant
   if (variants.includes(DEFAULT_VARIANT_VALUE)) return DEFAULT_VARIANT_VALUE
   return variants[0] ?? DEFAULT_VARIANT_VALUE

--- a/packages/cli/src/acp/event.ts
+++ b/packages/cli/src/acp/event.ts
@@ -201,7 +201,7 @@ export async function streamTurn(input: {
         if (!child) assistantMessageID = event.data.assistantMessageID
         await send({
           sessionUpdate: "agent_thought_chunk",
-          messageId: event.data.assistantMessageID,
+          messageId: `${event.data.assistantMessageID}:reasoning:${event.data.ordinal}`,
           content: { type: "text", text: event.data.delta },
         })
         continue
@@ -455,6 +455,8 @@ async function replayMessage(
     return
   }
   if (message.type !== "assistant") return
+  // Live reasoning ordinals count only reasoning parts, not the mixed content array.
+  let reasoningOrdinal = 0
   for (const part of message.content) {
     if (part.type === "text") {
       await connection.sessionUpdate({
@@ -472,7 +474,7 @@ async function replayMessage(
         sessionId: sessionID,
         update: {
           sessionUpdate: "agent_thought_chunk",
-          messageId: message.id,
+          messageId: `${message.id}:reasoning:${reasoningOrdinal++}`,
           content: { type: "text", text: part.text },
         },
       })

--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -41,7 +41,12 @@ import type {
 } from "@agentclientprotocol/sdk"
 import { OPENCODE_VERSION } from "../version"
 import { SessionMessage } from "@opencode/schema/session-message"
-import { buildConfigOptions, parseModelSelection, type ConfigOptionProvider } from "./config-option"
+import {
+  buildConfigOptions,
+  DEFAULT_VARIANT_VALUE,
+  parseModelSelection,
+  type ConfigOptionProvider,
+} from "./config-option"
 import { promptContentToParts } from "./content"
 import {
   ChildSessionUpdateMethod,
@@ -275,7 +280,7 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
       if (typeof params.value !== "string") throw new ACPError.InvalidConfigOptionError({ configId: params.configId })
       switch (params.configId) {
         case "model": {
-          const selected = requireModel(state.catalog, params.value)
+          const selected = requireModel(state.catalog, params.value, state.model)
           state.model = selected
           await input.client.session.switchModel({ sessionID: state.id, model: selected })
           break
@@ -284,7 +289,10 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
           const model = state.catalog.models.find(
             (item) => item.providerID === state.model.providerID && item.id === state.model.id,
           )
-          if (!model?.variants.some((variant) => variant.id === params.value))
+          if (
+            !model ||
+            (params.value !== DEFAULT_VARIANT_VALUE && !model.variants.some((variant) => variant.id === params.value))
+          )
             throw new ACPError.InvalidEffortError({ effort: params.value })
           state.model = { ...state.model, variant: params.value }
           await input.client.session.switchModel({ sessionID: state.id, model: state.model })
@@ -453,7 +461,7 @@ function providers(models: readonly ModelInfo[]): ConfigOptionProvider[] {
     }))
 }
 
-function requireModel(catalog: Catalog, modelID: string): ModelRef {
+function requireModel(catalog: Catalog, modelID: string, current: ModelRef): ModelRef {
   const selected = parseModelSelection(modelID, catalog.providers)
   const model = catalog.models.find(
     (item) => item.providerID === selected.model.providerID && item.id === selected.model.modelID,
@@ -461,7 +469,14 @@ function requireModel(catalog: Catalog, modelID: string): ModelRef {
   if (!model) throw new ACPError.InvalidModelError({ providerId: selected.model.providerID, modelId: modelID })
   if (selected.variant && !model.variants.some((variant) => variant.id === selected.variant))
     throw new ACPError.InvalidEffortError({ effort: selected.variant })
-  return { providerID: model.providerID, id: model.id, variant: selected.variant }
+  const variant =
+    selected.variant ??
+    (current.providerID === model.providerID &&
+    current.id === model.id &&
+    (current.variant === DEFAULT_VARIANT_VALUE || model.variants.some((variant) => variant.id === current.variant))
+      ? current.variant
+      : undefined)
+  return { providerID: model.providerID, id: model.id, variant }
 }
 
 async function selectMode(client: OpenCodeClient, state: Attached, modeID: string) {

--- a/packages/cli/test/acp/config-option.test.ts
+++ b/packages/cli/test/acp/config-option.test.ts
@@ -64,6 +64,17 @@ describe("acp config options", () => {
     )
   })
 
+  test.each([undefined, "default"])("represents %s effort as default without a provider variant", (variant) => {
+    expect(buildEffortSelectOption({ variants: ["low", "medium"], currentVariant: variant })).toMatchObject({
+      currentValue: "default",
+      options: [
+        { value: "low", name: "Low" },
+        { value: "medium", name: "Medium" },
+        { value: "default", name: "Default" },
+      ],
+    })
+  })
+
   test("builds the mode select option with descriptions when present", () => {
     expect(
       buildModeSelectOption({

--- a/packages/cli/test/acp/config-option.test.ts
+++ b/packages/cli/test/acp/config-option.test.ts
@@ -64,17 +64,6 @@ describe("acp config options", () => {
     )
   })
 
-  test.each([undefined, "default"])("represents %s effort as default without a provider variant", (variant) => {
-    expect(buildEffortSelectOption({ variants: ["low", "medium"], currentVariant: variant })).toMatchObject({
-      currentValue: "default",
-      options: [
-        { value: "low", name: "Low" },
-        { value: "medium", name: "Medium" },
-        { value: "default", name: "Default" },
-      ],
-    })
-  })
-
   test("builds the mode select option with descriptions when present", () => {
     expect(
       buildModeSelectOption({

--- a/packages/cli/test/acp/config-options.subprocess.test.ts
+++ b/packages/cli/test/acp/config-options.subprocess.test.ts
@@ -50,11 +50,11 @@ describe("acp config option subprocess", () => {
     const effort = requireSelectOption((await newSession(acp, fixture.home)).configOptions, "effort")
 
     expect(effort.category).toBe("thought_level")
-    expect(effort.currentValue).toBe("low")
-    expect(flattenSelectOptions(effort).map((option) => option.value)).toEqual(["low", "high"])
+    expect(effort.currentValue).toBe("default")
+    expect(flattenSelectOptions(effort).map((option) => option.value)).toEqual(["low", "high", "default"])
   }, 60_000)
 
-  test("effort switch updates currentValue", async () => {
+  test("effort survives model synchronization and can be reset to default", async () => {
     await using fixture = await createAcpFixture()
     const acp = fixture.spawn()
     await initialize(acp)
@@ -70,5 +70,23 @@ describe("acp config option subprocess", () => {
     )
 
     expect(selectConfigOption(updated.configOptions, "effort")?.currentValue).toBe(nextEffort)
+
+    const synchronized = expectOk(
+      await acp.request<SetSessionConfigOptionResponse>("session/set_config_option", {
+        sessionId: session.sessionId,
+        configId: "model",
+        value: requireSelectOption(session.configOptions, "model").currentValue,
+      }),
+    )
+    expect(selectConfigOption(synchronized.configOptions, "effort")?.currentValue).toBe(nextEffort)
+
+    const reset = expectOk(
+      await acp.request<SetSessionConfigOptionResponse>("session/set_config_option", {
+        sessionId: session.sessionId,
+        configId: "effort",
+        value: "default",
+      }),
+    )
+    expect(selectConfigOption(reset.configOptions, "effort")?.currentValue).toBe("default")
   }, 60_000)
 })

--- a/packages/cli/test/acp/event-behavior.test.ts
+++ b/packages/cli/test/acp/event-behavior.test.ts
@@ -91,7 +91,7 @@ describe("acp event behavior", () => {
     }
   })
 
-  test("preserves text and reasoning order before returning the terminal response", async () => {
+  test("preserves reasoning boundaries and update order during streaming and replay", async () => {
     const firstUpdate = Promise.withResolvers<void>()
     const releaseUpdate = Promise.withResolvers<void>()
     const allUpdates = Promise.withResolvers<void>()
@@ -109,6 +109,14 @@ describe("acp event behavior", () => {
           }),
         )
         send(
+          ephemeralEvent("session.reasoning.delta", {
+            sessionID: "ses_order",
+            assistantMessageID: "msg_order",
+            ordinal: 0,
+            delta: " continued",
+          }),
+        )
+        send(
           ephemeralEvent("session.text.delta", {
             sessionID: "ses_order",
             assistantMessageID: "msg_order",
@@ -120,7 +128,7 @@ describe("acp event behavior", () => {
           ephemeralEvent("session.reasoning.delta", {
             sessionID: "ses_order",
             assistantMessageID: "msg_order",
-            ordinal: 2,
+            ordinal: 1,
             delta: "think-2",
           }),
         )
@@ -144,7 +152,7 @@ describe("acp event behavior", () => {
           firstUpdate.resolve()
           await releaseUpdate.promise
         }
-        if (updates.length === 3) allUpdates.resolve()
+        if (updates.length === 4) allUpdates.resolve()
       },
       requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
     } satisfies Connection
@@ -171,18 +179,48 @@ describe("acp event behavior", () => {
           ) {
             return [
               item.update.sessionUpdate,
+              item.update.messageId,
               item.update.content.type === "text" ? item.update.content.text : undefined,
             ]
           }
           return [item.update.sessionUpdate, undefined]
         }),
       ).toEqual([
-        ["agent_thought_chunk", "think-1"],
-        ["agent_message_chunk", "answer"],
-        ["agent_thought_chunk", "think-2"],
+        ["agent_thought_chunk", "msg_order:reasoning:0", "think-1"],
+        ["agent_thought_chunk", "msg_order:reasoning:0", " continued"],
+        ["agent_message_chunk", "msg_order", "answer"],
+        ["agent_thought_chunk", "msg_order:reasoning:1", "think-2"],
       ])
       expect(fixture.requests.at(-1)?.path).toBe("/api/session/ses_order/message/msg_order")
       expect(response).toMatchObject({ stopReason: "end_turn", usage: { totalTokens: 2 } })
+
+      const replayed: SessionUpdateParams[] = []
+      await replayMessages(recordingConnection(replayed), "ses_order", "/workspace", [
+        {
+          id: "msg_order",
+          type: "assistant",
+          agent: "build",
+          model: { providerID: "test", id: "test-model" },
+          time: { created: 1 },
+          content: [
+            { type: "reasoning", text: "think-1 continued" },
+            { type: "text", text: "answer" },
+            { type: "reasoning", text: "think-2" },
+          ],
+        },
+      ])
+      expect(replayed).toEqual([
+        {
+          sessionId: "ses_order",
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            messageId: "msg_order:reasoning:0",
+            content: { type: "text", text: "think-1 continued" },
+          },
+        },
+        updates[2],
+        updates[3],
+      ])
     } finally {
       releaseUpdate.resolve()
       releaseSubmit.resolve()

--- a/packages/cli/test/acp/service-directory.test.ts
+++ b/packages/cli/test/acp/service-directory.test.ts
@@ -222,7 +222,7 @@ describe("acp service directory behavior", () => {
     await fixture.service.setSessionMode({ sessionId: session.sessionId, modeId: "build" })
 
     expect(currentValue(selectedModel, "model")).toBe("test/second-model")
-    expect(currentValue(selectedModel, "effort")).toBe("low")
+    expect(currentValue(selectedModel, "effort")).toBe("default")
     expect(currentValue(selectedEffort, "effort")).toBe("medium")
     expect(currentValue(selectedMode, "mode")).toBe("plan")
     expect(
@@ -264,6 +264,56 @@ describe("acp service directory behavior", () => {
     expect(invalidEffort).toMatchObject({ _tag: "ACPInvalidEffortError" })
     expect(invalidMode).toMatchObject({ _tag: "ACPInvalidModeError" })
     expect(invalidConfig).toMatchObject({ _tag: "ACPInvalidConfigOptionError" })
+  })
+
+  test.each(["medium", "default", undefined])("same-model sync preserves %s effort", async (variant) => {
+    await using fixture = makeACPFixture({
+      fetch(request) {
+        if (request.method === "GET" && request.path === "/api/session/ses_restored") {
+          return Response.json({
+            data: makeSession("ses_restored", { model: { providerID: "test", id: secondModel.id, variant } }),
+          })
+        }
+        if (request.method === "POST" && request.path === "/api/session/ses_restored/model") {
+          return new Response(null, { status: 204 })
+        }
+        return undefined
+      },
+    })
+    const restored = await fixture.service.resumeSession({ cwd: "/workspace", sessionId: "ses_restored" })
+    const synchronized = await fixture.service.setSessionConfigOption({
+      sessionId: "ses_restored",
+      configId: "model",
+      value: "test/second-model",
+    })
+
+    expect(currentValue(restored, "effort")).toBe(variant ?? "default")
+    expect(currentValue(synchronized, "effort")).toBe(variant ?? "default")
+    expect(fixture.requests.filter((request) => request.path.endsWith("/model") && request.method === "POST")).toEqual([
+      {
+        method: "POST",
+        path: "/api/session/ses_restored/model",
+        query: {},
+        body: { model: { providerID: "test", id: secondModel.id, ...(variant ? { variant } : {}) } },
+      },
+    ])
+
+    const explicit = await fixture.service.setSessionConfigOption({
+      sessionId: "ses_restored",
+      configId: "model",
+      value: "test/second-model/low",
+    })
+    expect(currentValue(explicit, "effort")).toBe("low")
+
+    const reset = await fixture.service.setSessionConfigOption({
+      sessionId: "ses_restored",
+      configId: "effort",
+      value: "default",
+    })
+    expect(currentValue(reset, "effort")).toBe("default")
+    expect(fixture.requests.at(-1)?.body).toEqual({
+      model: { providerID: "test", id: secondModel.id, variant: "default" },
+    })
   })
 
   test("converts MCP configs and deduplicates registrations per session and config", async () => {

--- a/packages/cli/test/acp/service-directory.test.ts
+++ b/packages/cli/test/acp/service-directory.test.ts
@@ -266,56 +266,6 @@ describe("acp service directory behavior", () => {
     expect(invalidConfig).toMatchObject({ _tag: "ACPInvalidConfigOptionError" })
   })
 
-  test.each(["medium", "default", undefined])("same-model sync preserves %s effort", async (variant) => {
-    await using fixture = makeACPFixture({
-      fetch(request) {
-        if (request.method === "GET" && request.path === "/api/session/ses_restored") {
-          return Response.json({
-            data: makeSession("ses_restored", { model: { providerID: "test", id: secondModel.id, variant } }),
-          })
-        }
-        if (request.method === "POST" && request.path === "/api/session/ses_restored/model") {
-          return new Response(null, { status: 204 })
-        }
-        return undefined
-      },
-    })
-    const restored = await fixture.service.resumeSession({ cwd: "/workspace", sessionId: "ses_restored" })
-    const synchronized = await fixture.service.setSessionConfigOption({
-      sessionId: "ses_restored",
-      configId: "model",
-      value: "test/second-model",
-    })
-
-    expect(currentValue(restored, "effort")).toBe(variant ?? "default")
-    expect(currentValue(synchronized, "effort")).toBe(variant ?? "default")
-    expect(fixture.requests.filter((request) => request.path.endsWith("/model") && request.method === "POST")).toEqual([
-      {
-        method: "POST",
-        path: "/api/session/ses_restored/model",
-        query: {},
-        body: { model: { providerID: "test", id: secondModel.id, ...(variant ? { variant } : {}) } },
-      },
-    ])
-
-    const explicit = await fixture.service.setSessionConfigOption({
-      sessionId: "ses_restored",
-      configId: "model",
-      value: "test/second-model/low",
-    })
-    expect(currentValue(explicit, "effort")).toBe("low")
-
-    const reset = await fixture.service.setSessionConfigOption({
-      sessionId: "ses_restored",
-      configId: "effort",
-      value: "default",
-    })
-    expect(currentValue(reset, "effort")).toBe("default")
-    expect(fixture.requests.at(-1)?.body).toEqual({
-      model: { providerID: "test", id: secondModel.id, variant: "default" },
-    })
-  })
-
   test("converts MCP configs and deduplicates registrations per session and config", async () => {
     const local: McpServer = {
       name: "tools",

--- a/packages/cli/test/acp/service-lifecycle.test.ts
+++ b/packages/cli/test/acp/service-lifecycle.test.ts
@@ -32,7 +32,7 @@ describe("acp service lifecycle", () => {
         model: { providerID: "test", id: "second-model" },
       },
     })
-    expect(currentValue(created, "effort")).toBe("none")
+    expect(currentValue(created, "effort")).toBe("default")
   })
 
   test("loads and forks with paginated replay while resume does not replay", async () => {


### PR DESCRIPTION
## Summary
- Give each reasoning part a consistent ACP message ID during streaming and transcript replay.
- Preserve effort when synchronizing the same model, while honoring explicit variant changes.
- Display unset or explicit default effort as Default and allow selecting it without a named provider variant.

V2 follow-up to #48225. Related to #31961.

## Testing
- Extend existing streaming/replay and real ACP subprocess tests; no additional test cases.
- `bun test test/acp --timeout 30000 --only-failures` in `packages/cli`: 96 passed.
- Pre-push workspace typecheck: all 35 tasks passed.
- Prettier and `git diff --check` passed.