### PR TITLE
fix(core): omit undefined permission metadata

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -168,7 +168,9 @@ const layer = Layer.effect(
         action: input.action,
         resources: input.resources,
         save: input.save,
-        metadata: input.metadata,
+        metadata: input.metadata
+          ? Object.fromEntries(Object.entries(input.metadata).filter(([, value]) => value !== undefined))
+          : undefined,
         source: input.source,
       }
     }

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -118,6 +118,33 @@ describe("PermissionV2", () => {
     }),
   )
 
+  it.effect("omits undefined permission metadata fields", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      yield* service.ask(
+        assertion({
+          metadata: {
+            root: ".",
+            path: undefined,
+            limit: undefined,
+            enabled: false,
+            count: 0,
+            nullable: null,
+          },
+        }),
+      )
+
+      const request = yield* service.get(PermissionV2.ID.create("per_test"))
+      expect(request?.metadata).toEqual({
+        root: ".",
+        enabled: false,
+        count: 0,
+        nullable: null,
+      })
+    }),
+  )
+
   it.effect("evaluates against an explicit provider-turn agent", () =>
     Effect.gen(function* () {
       yield* setup([{ action: "read", resource: "*", effect: "allow" }])


### PR DESCRIPTION
### Issue for this PR

Closes #37650

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pending permissions can contain optional metadata values set to `undefined`. The metadata is JSON-encoded when pending requests are listed, so those values cause the response encoding to fail.

This change removes only `undefined` metadata entries when `PermissionV2` builds a request. It applies at the shared `ask`/`assert` boundary and keeps valid values such as `false`, `0`, and `null`.

PRs #46964 and #46906 address the same bug pattern in the older `Permission` implementation on `v2`. This PR applies the fix to the current `PermissionV2` implementation on `dev`; the normalization strategy is intentionally the same, not a separate algorithm.

### How did you verify your code works?

- `bun --version` -> `1.3.14`
- `bun turbo typecheck --concurrency=2` -> 30 successful tasks
- `cd packages/core && bun test test/permission.test.ts` -> 12 passed, 0 failed

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR