### PR TITLE
fix(tui): route console output to log file to protect TUI display

### DIFF
--- a/packages/opencode/src/cli/cmd/attach.ts
+++ b/packages/opencode/src/cli/cmd/attach.ts
@@ -3,6 +3,7 @@ import { UI } from "@/cli/ui"
 import { errorMessage } from "@opencode-ai/tui/util/error"
 import { validateSession } from "../tui/validate-session"
 import { ServerAuth } from "@/server/auth"
+import { installConsoleGuard } from "@/util/console-guard"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -60,6 +61,8 @@ export const AttachCommand = cmd({
         describe: "cap visible mini replay to the newest N messages",
       }),
   handler: async (args) => {
+    // The TUI renders on the alternate screen; console output must go to the log file.
+    installConsoleGuard()
     if (args.replay === true) {
       UI.error("--replay is not supported; replay is enabled by default")
       process.exitCode = 1

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -261,6 +261,9 @@ export const RunCommand = effectCmd({
         describe: "enable direct interactive demo slash commands; pass one as the message to run it immediately",
       }),
   handler: Effect.fn("Cli.run")(function* (args) {
+    const { installConsoleGuard } = yield* Effect.promise(() => import("@/util/console-guard"))
+    // The TUI renders on the alternate screen; console output must go to the log file.
+    installConsoleGuard()
     const { Agent } = yield* Effect.promise(() => import("@/agent/agent"))
     const { RuntimeFlags } = yield* Effect.promise(() => import("@/effect/runtime-flags"))
     const { InstanceRef } = yield* Effect.promise(() => import("@/effect/instance-ref"))

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -14,6 +14,7 @@ import { writeHeapSnapshot } from "v8"
 import { ServerAuth } from "@/server/auth"
 import { validateSession } from "../tui/validate-session"
 import { win32InstallCtrlCGuard } from "@opencode-ai/tui/terminal-win32"
+import { installConsoleGuard } from "@/util/console-guard"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -142,6 +143,8 @@ export const TuiThreadCommand = cmd({
         hidden: true,
       }),
   handler: async (args) => {
+    // The TUI renders on the alternate screen; console output must go to the log file.
+    installConsoleGuard()
     if (args.replay === true) {
       UI.error("--replay is not supported; replay is enabled by default")
       process.exitCode = 1

--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -10,8 +10,12 @@ import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
+import { installConsoleGuard } from "@/util/console-guard"
 
 Heap.start()
+
+// The worker shares the TUI terminal; library console output must never reach it.
+installConsoleGuard()
 
 const onUnhandledRejection = (_error: unknown) => {}
 

--- a/packages/opencode/src/util/console-guard.ts
+++ b/packages/opencode/src/util/console-guard.ts
@@ -1,0 +1,44 @@
+import path from "node:path"
+import { appendFile } from "node:fs/promises"
+import { inspect } from "node:util"
+import { Global } from "@opencode-ai/core/global"
+import { Logging } from "@opencode-ai/core/observability/logging"
+
+// The TUI renders on the alternate screen while the server worker shares the
+// same terminal. Any library that calls console.* (Ajv compiling third-party
+// MCP schemas, plugin dependencies, ...) would write raw lines straight into
+// the TUI and corrupt it. In TUI mode the console methods are redirected into
+// the opencode log file instead of the terminal, so no output can ever break
+// the display. Non-TUI entrypoints (serve, mcp list, ...) never install this.
+// https://github.com/anomalyco/opencode/issues/31002
+
+const LEVELS = { Debug: 0, Info: 1, Warn: 2, Error: 3 } as const
+
+function installConsole() {
+  const format = (...args: unknown[]) => {
+    try {
+      return args.map((arg) => (typeof arg === "string" ? arg : inspect(arg, { depth: 3 }))).join(" ")
+    } catch {
+      return "<unformattable console output>"
+    }
+  }
+
+  const write = (level: keyof typeof LEVELS, args: unknown[]) => {
+    if (LEVELS[level] < LEVELS[Logging.minimumLogLevel()]) return
+    const line = `timestamp=${new Date().toISOString()} level=${level.toLowerCase()} service=console message=${JSON.stringify(format(...args))}\n`
+    void appendFile(path.join(Global.Path.log, "opencode.log"), line).catch(() => {})
+  }
+
+  console.debug = (...args: unknown[]) => write("Debug", args)
+  console.info = (...args: unknown[]) => write("Info", args)
+  console.log = (...args: unknown[]) => write("Info", args)
+  console.warn = (...args: unknown[]) => write("Warn", args)
+  console.error = (...args: unknown[]) => write("Error", args)
+}
+
+/** Redirect all console output to the log file. For TUI mode only. */
+export function installConsoleGuard() {
+  installConsole()
+}
+
+export * as ConsoleGuard from "./console-guard"

--- a/packages/opencode/test/util/console-guard.test.ts
+++ b/packages/opencode/test/util/console-guard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { Global } from "@opencode-ai/core/global"
+import { ConsoleGuard } from "../../src/util/console-guard"
+
+function logFile() {
+  return path.join(Global.Path.log, "opencode.log")
+}
+
+async function readLog() {
+  const file = Bun.file(logFile())
+  return (await file.exists()) ? await file.text() : ""
+}
+
+const original = {
+  debug: console.debug,
+  info: console.info,
+  log: console.log,
+  warn: console.warn,
+  error: console.error,
+}
+
+describe("ConsoleGuard.installConsoleGuard", () => {
+  test("routes console output to the log file instead of the terminal", async () => {
+    try {
+      ConsoleGuard.installConsoleGuard()
+      console.warn("unknown format ignored in schema at path", { format: "uint64" })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      const log = await readLog()
+      expect(log).toContain('service=console message="unknown format ignored in schema at path')
+      expect(log).toContain("level=warn")
+    } finally {
+      restoreConsole()
+    }
+  })
+
+  test("suppresses entries below the configured minimum level", async () => {
+    const previous = process.env.OPENCODE_LOG_LEVEL
+    process.env.OPENCODE_LOG_LEVEL = "ERROR"
+    try {
+      ConsoleGuard.installConsoleGuard()
+      console.warn("guard should suppress this warn")
+      console.error("guard should keep this error")
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      const log = await readLog()
+      expect(log).toContain("guard should keep this error")
+      expect(log).not.toContain("guard should suppress this warn")
+    } finally {
+      restoreConsole()
+      process.env.OPENCODE_LOG_LEVEL = previous
+    }
+  })
+})
+
+function restoreConsole() {
+  console.debug = original.debug
+  console.info = original.info
+  console.log = original.log
+  console.warn = original.warn
+  console.error = original.error
+}


### PR DESCRIPTION
### Issue for this PR

Fixes #48520

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#31002 reports Ajv's `unknown format "uint64" ignored` warnings from Rust/schemars MCP schemas reaching the terminal via `console.warn` and polluting the TUI. PR #48331 fixes that specific source by disabling Ajv's logger through the MCP SDK's `ClientOptions` seam.

This PR is a complementary, systemic guardrail for the same problem: *any* library `console.*` output — Ajv today, plugin dependencies or anything else tomorrow — writes raw lines straight into the TUI's alternate screen and corrupts the display. A small `ConsoleGuard` is installed in every TUI entrypoint (`tui`, `attach`, `run`) and the server worker, redirecting `console.debug/info/log/warn/error` into the opencode log file while respecting the minimum log level (`OPENCODE_LOG_LEVEL`). Non-TUI entrypoints (`serve`, `mcp list`, ...) keep normal console behavior.

The two fixes are orthogonal: #48331 removes the Ajv warning at its source; this PR guarantees the TUI survives stray console output no matter where it comes from. Neither alone covers the full class of bug behind #31002.

### How did you verify your code works?

- Two unit tests in `packages/opencode/test/util/console-guard.test.ts`: console output lands in the log file as a `service=console` line, and entries below the minimum level are suppressed while errors still get logged.
- `bun test` and `bun typecheck` pass in `packages/opencode`.
- Manual repro: start the TUI with an MCP server whose schemas contain `uint32`/`uint64` formats. Before: Ajv warnings overwrite the display. After: they only appear in `opencode.log`.

### Screenshots / recordings

Before:

<img width="1709" height="1347" alt="grafik" src="https://github.com/user-attachments/assets/9a0f19c9-5f7a-483c-ab7b-072247cc9a7c" />

After:

<img width="1709" height="1343" alt="grafik" src="https://github.com/user-attachments/assets/282ac616-28b2-492a-a9f8-dbe4858bb628" />

Log file:

<img width="1514" height="926" alt="grafik" src="https://github.com/user-attachments/assets/4f8dd410-8626-4d3b-8586-5901537e2c9f" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
