### PR TITLE
feat(ai): always send interleaved thinking beta for Anthropic

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -1708,7 +1708,10 @@ export const transport = <
 }
 
 function requiredBetaHeaders(body: Pick<AnthropicMessagesBody, "messages" | "context_management" | "thinking">) {
-  const betas: string[] = []
+  // Always request interleaved thinking. The API accepts the header on any
+  // model and ignores it where unsupported, while manual-thinking models need
+  // it for thinking between tool calls.
+  const betas: string[] = ["interleaved-thinking-2025-05-14"]
   const requestsCompaction = (body.context_management?.edits.length ?? 0) > 0
   const replaysCompaction = body.messages.some((message) =>
     message.content.some((block) => block.type === "compaction"),

--- a/packages/ai/test/provider/anthropic-compaction.test.ts
+++ b/packages/ai/test/provider/anthropic-compaction.test.ts
@@ -69,7 +69,9 @@ for (const model of [
       dynamicResponse(({ request, text, respond }) =>
         Effect.sync(() => {
           const body = JSON.parse(text)
-          expect(request.headers["anthropic-beta"]).toBe("existing-beta,compact-2026-01-12")
+          expect(request.headers["anthropic-beta"]).toBe(
+            "existing-beta,interleaved-thinking-2025-05-14,compact-2026-01-12",
+          )
           if (body.messages.length === 1) {
             expect(body.context_management.edits).toEqual([
               {

--- a/packages/ai/test/provider/anthropic-thinking-binding.test.ts
+++ b/packages/ai/test/provider/anthropic-thinking-binding.test.ts
@@ -32,7 +32,9 @@ for (const [id, enabled] of [
         enabled ? { type: "adaptive", block_binding: { prefix_mismatch_behavior: "drop_block" } } : undefined,
       )
       expect(prepared.request.headers["anthropic-beta"]).toBe(
-        enabled ? "existing-beta,thinking-binding-controls-2026-08-01" : "existing-beta",
+        enabled
+          ? "existing-beta,interleaved-thinking-2025-05-14,thinking-binding-controls-2026-08-01"
+          : "existing-beta,interleaved-thinking-2025-05-14",
       )
     }),
   )
@@ -53,7 +55,9 @@ it.effect("preserves explicit thinking settings and combines required beta heade
       const prepared = yield* AnthropicMessages.route.prepareTransport(compiled.body, request)
       expect(compiled.body.thinking).toEqual(thinking)
       expect(prepared.request.headers["anthropic-beta"]).toBe(
-        thinking.type === "disabled" ? "compact-2026-01-12" : "compact-2026-01-12,thinking-binding-controls-2026-08-01",
+        thinking.type === "disabled"
+          ? "interleaved-thinking-2025-05-14,compact-2026-01-12"
+          : "interleaved-thinking-2025-05-14,compact-2026-01-12,thinking-binding-controls-2026-08-01",
       )
     }
   }),


### PR DESCRIPTION
## Summary

The native Anthropic Messages protocol never sent `interleaved-thinking-2025-05-14`. The only source of that header was the core Anthropic plugin's catalog transform, so every native Anthropic request without catalog headers went out without it — losing thinking between tool calls on manual-thinking models.

`requiredBetaHeaders` now always includes `interleaved-thinking-2025-05-14`. The API accepts the header on any model and ignores it where unsupported (adaptive-thinking models interleave automatically), so unconditional is safe.

## Changes

- `packages/ai/src/protocols/anthropic-messages.ts`: always include the interleaved thinking beta in required headers.
- Updated `anthropic-thinking-binding` and `anthropic-compaction` test expectations.

## Validation

- `packages/ai`: `bun test test/provider/anthropic-thinking-binding.test.ts` — 13 passed.
- `test/provider/anthropic-compaction.test.ts` cannot load in this worktree (`aws4fetch` unresolvable); verified it fails identically on the clean tree, so unrelated to this change. Its expectation was updated the same way.