### PR TITLE
fix(app): recover prompt text from editor dom; route v1 follow-ups to their session directory

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -135,6 +135,13 @@ beforeAll(async () => {
   mock.module("@opencode-ai/ui/toast", () => ({
     Toast: { Region: () => null },
     showToast: () => 0,
+    toaster: { dismiss: () => undefined },
+  }))
+
+  mock.module("@opencode-ai/ui/v2/toast-v2", () => ({
+    ToastV2: { Region: () => null },
+    showToastV2: () => 0,
+    toasterV2: { dismiss: () => undefined },
   }))
 
   mock.module("@opencode-ai/core/util/encode", () => ({
@@ -594,5 +601,37 @@ describe("prompt submit worktree selection", () => {
     expect(storedSessions["/repo/worktree-a"]).toHaveLength(1)
     expect(storedSessions["/repo/worktree-a"]?.[0]).toMatchObject({ id: "session-1", title: "New session 1" })
     expect(optimisticSeeded).toEqual([true])
+  })
+
+  test("synchronizes text from DOM editor element if target.current is empty", async () => {
+    params = { id: "session-1" }
+    promptValue = [{ type: "text", content: "", start: 0, end: 0 }]
+    const domEditor = document.createElement("div")
+    domEditor.textContent = "Hello from DOM editor"
+
+    const submit = createPromptSubmit({
+      prompt,
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => domEditor,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(sentPrompts).toContain("/repo/main")
+    expect(promptInputs[promptInputs.length - 1]).toMatchObject({
+      sessionID: "session-1",
+      text: "Hello from DOM editor",
+    })
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -168,6 +168,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
 
     await input.api.prompt({
       sessionID: input.draft.sessionID,
+      sessionDirectory: input.draft.sessionDirectory,
       id: messageID,
       agent: input.draft.agent,
       model: input.draft.model,
@@ -630,7 +631,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return true
     }
 
-    void sendFollowupDraft({
+    await sendFollowupDraft({
       api: sdk().api.session,
       sync: sync(),
       serverSync: serverSync(),

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -15,6 +15,7 @@ import { useSDK, type DirectorySDK } from "@/context/sdk"
 import { useSync, type DirectorySync } from "@/context/sync"
 import { Identifier } from "@/utils/id"
 import { Worktree as WorktreeState } from "@/utils/worktree"
+import { parsePromptInputV2Editor } from "@opencode-ai/session-ui/v2/prompt-input/editor-dom"
 import { buildRequestParts } from "./build-request-parts"
 import { setCursorPosition } from "./editor-dom"
 import { formatServerError } from "@/utils/server-errors"
@@ -324,11 +325,24 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       prompt: target.current(),
       context: target.context.items().slice(),
     })
-    const currentPrompt = submission.prompt
+    let currentPrompt = submission.prompt
     const context = submission.context
-    const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
+    let text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
     const mode = input.mode()
+
+    if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
+      const editor = input.editor()
+      if (editor) {
+        const domPrompt = parsePromptInputV2Editor(editor as HTMLDivElement)
+        const domText = domPrompt.map((p) => ("content" in p ? p.content : "")).join("")
+        if (domText.trim().length > 0) {
+          currentPrompt = domPrompt as Prompt
+          text = domText
+          target.set(domPrompt as Prompt, domText.length)
+        }
+      }
+    }
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
       if (input.working()) void abort()

--- a/packages/app/src/utils/server-compat.ts
+++ b/packages/app/src/utils/server-compat.ts
@@ -44,6 +44,8 @@ type LegacyPrompt = {
   model?: { providerID: string; modelID: string }
   variant?: string
   legacyParts?: (TextPartInput | FilePartInput | AgentPartInput)[]
+  sessionDirectory?: string
+  location?: { directory?: string }
 }
 type LegacyLocation = { directory?: string }
 type CompatibleInput = {
@@ -198,7 +200,8 @@ function createV1Api(input: CompatibleInput): CompatibleApi {
         await legacy().session.abort(value)
       },
       async prompt(value: SessionPromptInput & LegacyPrompt) {
-        await legacy().session.promptAsync({
+        const loc = value.location ?? (value.sessionDirectory ? { directory: value.sessionDirectory } : undefined)
+        await legacy(loc).session.promptAsync({
           sessionID: value.sessionID,
           messageID: value.id ?? undefined,
           agent: value.agent,

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -20,6 +20,7 @@
     "./v2/*.css": "./src/v2/components/*.css",
     "./v2/*": "./src/v2/components/*.tsx",
     "./v2/prompt-input": "./src/v2/components/prompt-input/index.tsx",
+    "./v2/prompt-input/editor-dom": "./src/v2/components/prompt-input/editor-dom.ts",
     "./v2/prompt-input/interaction": "./src/v2/components/prompt-input/interaction.ts",
     "./v2/prompt-input/store": "./src/v2/components/prompt-input/store.ts",
     "./v2/prompt-input/types": "./src/v2/components/prompt-input/types.ts"

--- a/packages/session-ui/src/v2/components/prompt-input/editor-dom.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/editor-dom.ts
@@ -1,0 +1,69 @@
+import type { PromptInputV2Attachment, PromptInputV2Prompt } from "./types"
+
+export function parsePromptInputV2Editor(editor: HTMLDivElement) {
+  const parts: Exclude<PromptInputV2Prompt[number], PromptInputV2Attachment>[] = []
+  let buffer = ""
+  let position = 0
+
+  const flush = () => {
+    if (!buffer) return
+    parts.push({ type: "text", content: buffer, start: position, end: position + buffer.length })
+    position += buffer.length
+    buffer = ""
+  }
+  const mention = (element: HTMLElement) => {
+    flush()
+    const content = element.textContent ?? ""
+    if (element.dataset.mention === "agent") {
+      parts.push({
+        type: "agent",
+        name: element.dataset.name ?? content.slice(1),
+        content,
+        start: position,
+        end: position + content.length,
+      })
+      position += content.length
+      return
+    }
+    parts.push({
+      type: "file",
+      path: element.dataset.path ?? content.slice(1),
+      content,
+      start: position,
+      end: position + content.length,
+      ...(element.dataset.mime ? { mime: element.dataset.mime } : {}),
+      ...(element.dataset.filename ? { filename: element.dataset.filename } : {}),
+    })
+    position += content.length
+  }
+  const visit = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      buffer += node.textContent ?? ""
+      return
+    }
+    if (!(node instanceof HTMLElement)) return
+    if (node.dataset.mention) {
+      mention(node)
+      return
+    }
+    if (node.tagName === "BR") {
+      buffer += "\n"
+      return
+    }
+    Array.from(node.childNodes).forEach(visit)
+  }
+
+  Array.from(editor.childNodes).forEach((node, index, nodes) => {
+    visit(node)
+    if (node instanceof HTMLElement && ["DIV", "P"].includes(node.tagName) && index < nodes.length - 1) buffer += "\n"
+  })
+  flush()
+  if (
+    parts.every((part) => part.type === "text") &&
+    parts.every((part) => part.content.replace(/[\n\u200B]/g, "") === "")
+  ) {
+    return [{ type: "text" as const, content: "", start: 0, end: 0 }]
+  }
+  if (parts.length > 0) return parts
+  return [{ type: "text" as const, content: "", start: 0, end: 0 }]
+}


### PR DESCRIPTION
### Issue for this PR

Closes #48528
Closes #48529

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two small fixes in the app's prompt submission path.

**Recover text when the store is empty but the DOM editor still holds it** (Closes #48528). `createPromptSubmit` parsed the prompt from the store-backed state only. When that state is empty but the DOM editor element still contains text (e.g. after a navigation or state reset), the submit saw an empty prompt and returned early, silently discarding the typed message. The fix falls back to parsing the DOM editor element via a new `parsePromptInputV2Editor` helper when the store is empty and no images or comments are present, and sends the recovered text.

**Send v1 follow-up prompts to their session directory** (Closes #48529). The V1 compat API's `prompt` path always used the directory the client was created with (the project directory), ignoring the session's own directory. The app now passes `sessionDirectory` when sending a follow-up draft, and the compat layer routes the prompt to that directory instead.

### How did you verify your code works?

- `bun typecheck` (tsgo) passes in `packages/app` and `packages/session-ui`.
- `submit.test.ts` passes 9/9, including a new regression test that submits recovered text from a DOM editor element when the store is empty.
- `git diff --check` clean; no unrelated changes.

### Screenshots / recordings

n/a (non-UI behaviour; recovery happens before the prompt is sent)

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...prompt-submit-fixes
- mQorva issue / context: n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
