### PR TITLE
fix(app): handle session.error events in global sync

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -613,4 +613,46 @@ describe("applyDirectoryEvent", () => {
     expect(pushes).toEqual(["/tmp"])
     expect(lspLoads).toBe(1)
   })
+
+  test("handles session.error by setting session status to idle and updating assistant error", () => {
+    const errors: Array<string | undefined> = []
+    const assistantMsg = {
+      id: "msg_2",
+      sessionID: "s1",
+      role: "assistant",
+      time: { created: 2 },
+      modelID: "gpt",
+      providerID: "openai",
+    } as Message
+    const [store, setStore] = createStore(
+      baseState({
+        session_status: { s1: { type: "busy" } },
+        message: { s1: [userMessage("msg_1", "s1"), assistantMsg] },
+      }),
+    )
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "s1",
+          error: { name: "ProviderAuthError", data: { message: "Invalid API key" } },
+        },
+      },
+      store,
+      setStore,
+      push: () => undefined,
+      directory: "/tmp",
+      loadLsp: () => undefined,
+      notifyError: (message) => errors.push(message),
+    })
+
+    expect(store.session_status.s1).toEqual({ type: "idle" })
+    const lastMsg = store.message.s1[1]
+    expect(lastMsg?.role === "assistant" ? lastMsg.error : undefined).toEqual({
+      name: "UnknownError",
+      data: { message: "Invalid API key" },
+    })
+    expect(errors).toEqual(["Invalid API key"])
+  })
 })

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -119,6 +119,7 @@ export function applyDirectoryEvent(input: {
   retainedLimit?: number
   sessionContent?: boolean
   permission?: State["permission"]
+  notifyError?: (message?: string) => void
 }) {
   const event = input.event
   if (input.sessionContent === false && SESSION_CONTENT_EVENTS.has(event.type)) return
@@ -465,6 +466,30 @@ export function applyDirectoryEvent(input: {
           draft.splice(result.index, 1)
         }),
       )
+      break
+    }
+    case "session.error": {
+      const props = event.properties as {
+        sessionID?: string
+        error?: { name?: string; data?: { message?: string }; message?: string }
+      }
+      const sessionID = props.sessionID
+      if (!sessionID) break
+      input.setStore("session_status", sessionID, { type: "idle" })
+      const errorMsg =
+        props.error?.data?.message ?? props.error?.message ?? (typeof props.error === "string" ? props.error : undefined)
+      const messages = input.store.message[sessionID]
+      if (messages && messages.length > 0) {
+        const lastMsg = messages.at(-1)
+        if (lastMsg && lastMsg.role === "assistant") {
+          input.setStore("message", sessionID, messages.length - 1, (msg) => ({
+            ...msg,
+            error: { name: "UnknownError" as const, data: { message: errorMsg ?? "" } },
+            finish: "error",
+          }))
+        }
+      }
+      input.notifyError?.(errorMsg)
       break
     }
     case "lsp.updated": {

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -608,6 +608,12 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
       retainedLimit: sessionMeta.get(key)?.limit,
       sessionContent: false,
       permission: session.data.permission,
+      notifyError: (message) =>
+        showToast({
+          variant: "error",
+          title: language.t("notification.session.error.title"),
+          description: message ?? language.t("notification.session.error.fallbackDescription"),
+        }),
       vcsCache: children.vcsCache.get(key),
       loadLsp: () => {
         if (!children.active(key)) return


### PR DESCRIPTION
### Issue for this PR

Closes #48530

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The global sync reducer now handles `session.error` events instead of ignoring them. When a session turn fails, the reducer resets the session status to idle and marks the last assistant message with an error and `finish: "error"`. A new optional `notifyError` callback is threaded into `applyDirectoryEvent`; the server-sync layer uses it to show a toast with the error message (reusing the existing `notification.session.error.*` i18n keys).

### How did you verify your code works?

- `bun typecheck` (tsgo) passes in `packages/app`.
- `event-reducer.test.ts` passes 17/17, including a new test asserting the status reset and assistant error marker on `session.error`.
- `git diff --check` clean; no unrelated changes.

### Screenshots / recordings

n/a (server/state behaviour; the toast is the only UI, using existing keys)

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...session-error-sync
- mQorva issue / context: n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
