### PR TITLE
fix(session-ui): keep permission actions inside the dock prompt shell

### DIFF
--- a/packages/app/src/pages/session/composer/session-permission-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-permission-dock.tsx
@@ -22,6 +22,7 @@ export function SessionPermissionDock(props: {
   return (
     <DockPrompt
       kind="permission"
+      footerInside
       header={
         <div data-slot="permission-row" data-variant="header">
           <span data-slot="permission-icon">

--- a/packages/session-ui/src/components/dock-prompt.stories.tsx
+++ b/packages/session-ui/src/components/dock-prompt.stories.tsx
@@ -9,7 +9,7 @@ Use with form controls or confirmation buttons in the footer.
 
 ### API
 - Required: \`kind\` (question | permission), \`header\`, \`children\`, \`footer\`.
-- Optional: \`ref\` for measuring or focus management.
+- Optional: \`ref\` for measuring or focus management and \`footerInside\` to keep actions in the shell.
 
 ### Variants and states
 - Question and permission layouts (data attributes).
@@ -55,6 +55,7 @@ export const Basic = story.Basic
 export const Permission = {
   args: {
     kind: "permission",
+    footerInside: true,
     header: "Allow access?",
     children: "This action needs permission to proceed.",
     footer: "Approve or deny",

--- a/packages/session-ui/src/components/dock-prompt.tsx
+++ b/packages/session-ui/src/components/dock-prompt.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "solid-js"
+import { Show, type JSX } from "solid-js"
 import { DockShell, DockTray } from "@opencode-ai/ui/dock-surface"
 
 export function DockPrompt(props: {
@@ -6,6 +6,7 @@ export function DockPrompt(props: {
   header: JSX.Element
   children: JSX.Element
   footer: JSX.Element
+  footerInside?: boolean
   ref?: (el: HTMLDivElement) => void
   onKeyDown?: JSX.EventHandlerUnion<HTMLDivElement, KeyboardEvent>
 }) {
@@ -16,8 +17,13 @@ export function DockPrompt(props: {
       <DockShell data-slot={slot("body")}>
         <div data-slot={slot("header")}>{props.header}</div>
         <div data-slot={slot("content")}>{props.children}</div>
+        <Show when={props.footerInside}>
+          <div data-slot={slot("footer")}>{props.footer}</div>
+        </Show>
       </DockShell>
-      <DockTray data-slot={slot("footer")}>{props.footer}</DockTray>
+      <Show when={!props.footerInside}>
+        <DockTray data-slot={slot("footer")}>{props.footer}</DockTray>
+      </Show>
     </div>
   )
 }

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -738,7 +738,7 @@
     gap: 16px;
     flex: 1;
     min-height: 0;
-    padding: 12px 12px 0;
+    padding: 12px;
   }
 
   [data-slot="permission-header"] {
@@ -818,21 +818,17 @@
   [data-slot="permission-footer"] {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     flex-shrink: 0;
-    padding: 32px 8px 8px;
-    margin-top: -24px;
+    padding: 0;
   }
 
   [data-slot="permission-footer-actions"] {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
-
-    [data-component="button"] {
-      padding-left: 12px;
-      padding-right: 12px;
-    }
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #48532

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an opt-in `footerInside` prop to `DockPrompt` so permission actions can live inside the dock shell instead of a detached bottom tray, and tightens the permission footer layout for narrow widths.

`DockPrompt` renders the footer in a separate `DockTray` below the shell. On narrow composer widths the permission buttons overflow and the footer looks detached from the content. The new `footerInside` prop keeps the actions inside the shell, wrapped and right-aligned; the default behaviour (footer in the tray) is unchanged, so question docks are not affected. `SessionPermissionDock` opts in via `footerInside`, and the storybook story documents the permission variant.

### How did you verify your code works?

- `bun typecheck` (tsgo) passes in `packages/app` and `packages/session-ui`.
- Manual observation of the permission dock at narrow composer widths, with the footer wrapped inside the shell; question docks render unchanged (footer stays in the tray).
- `git diff --check` clean; no unrelated changes.

### Screenshots / recordings

n/a — will add a Storybook screenshot if a maintainer requests one.

### Fork

- Source fork: https://github.com/mQorva/OpenCode
- Diff against this fork's dev: https://github.com/mQorva/OpenCode/compare/dev...permission-dock-layout
- mQorva issue / context: n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR