### PR TITLE
refactor(codemode): make functions program objects with name and length

### DIFF
--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -121,7 +121,10 @@ ultimate source of truth. Upstream test262 files run verbatim from `test/test262
 - [ ] User-defined constructor calls.
 - [ ] `Function.prototype.call`, `apply`, and `bind` for CodeMode functions.
 - [ ] Classes and private fields.
-- [ ] `name` and `length` properties of functions, including names inferred from bindings and destructuring defaults.
+- [x] Functions are objects: they hold own properties (`fn.count = 1`), enumerate them, and expose read-only `name`
+      and `length`. Names follow JavaScript's NamedEvaluation: declarations, named expressions, bindings,
+      assignments, object literal keys, and destructuring or parameter defaults.
+- [ ] `name` and `length` of built-in functions such as `Math.max` or `"a".includes`.
 - [ ] A named function expression's name is not bound inside its own body.
 - [ ] Redeclaring a function in the same scope is rejected; in JavaScript the last declaration wins.
 - [ ] A line terminator between `async function` and the function name.

--- a/packages/codemode/src/data.ts
+++ b/packages/codemode/src/data.ts
@@ -1,7 +1,14 @@
 export * as Data from "./data.js"
 
 import type { DiagnosticKind } from "./codemode.js"
-import { ownEntries, parseArrayIndex, ProgramArray, ProgramObject, set } from "./interpreter/objects.js"
+import {
+  ownEntries,
+  parseArrayIndex,
+  ProgramArray,
+  ProgramFunction,
+  ProgramObject,
+  set,
+} from "./interpreter/objects.js"
 import { Values } from "./values.js"
 
 const MAX_VALUE_DEPTH = 32
@@ -60,6 +67,9 @@ const copy = (value: unknown, label: string, mode: Mode, depth: number, seen: Se
       "InvalidDataValue",
       `${label} contains an un-awaited Promise; await tool calls (e.g. \`const result = await tools.ns.tool(...)\`) before using their results.`,
     )
+  }
+  if (value instanceof ProgramFunction && mode !== "program") {
+    throw new ToolRuntimeError("InvalidDataValue", `${label} must contain data only.`)
   }
 
   const plain = mode === "program" || mode === "data"

--- a/packages/codemode/src/interpreter/model.ts
+++ b/packages/codemode/src/interpreter/model.ts
@@ -1,4 +1,4 @@
-import type { BlockStatement, Expression, Node, Pattern } from "acorn"
+import type { Node } from "acorn"
 import type { Effect } from "effect"
 import type { DiagnosticKind } from "../codemode.js"
 import type { ProgramObject } from "./objects.js"
@@ -22,16 +22,6 @@ export type StatementResult =
 export type MemberReference = {
   target: ProgramObject | Values.RegExp | Values.URL
   key: PropertyKey
-}
-
-export class CodeModeFunction {
-  constructor(
-    readonly parameters: ReadonlyArray<Pattern>,
-    readonly body: BlockStatement | Expression,
-    readonly capturedScopes: ReadonlyArray<Map<string, Binding>>,
-    readonly async: boolean,
-    readonly generator: boolean,
-  ) {}
 }
 
 export type GeneratorRequestKind = "next" | "return" | "throw"

--- a/packages/codemode/src/interpreter/objects.ts
+++ b/packages/codemode/src/interpreter/objects.ts
@@ -1,4 +1,5 @@
-import { AsyncIteratorSymbol, IteratorSymbol } from "./model.js"
+import type { BlockStatement, Expression, Pattern } from "acorn"
+import { AsyncIteratorSymbol, type Binding, IteratorSymbol } from "./model.js"
 
 /** An object owned by the program: own properties plus a prototype link. */
 export class ProgramObject {
@@ -18,6 +19,22 @@ export class ProgramError extends ProgramObject {
   }
 }
 
+export class ProgramFunction extends ProgramObject {
+  readonly length: number
+  constructor(
+    readonly name: string,
+    readonly parameters: ReadonlyArray<Pattern>,
+    readonly body: BlockStatement | Expression,
+    readonly capturedScopes: ReadonlyArray<Map<string, Binding>>,
+    readonly async: boolean,
+    readonly generator: boolean,
+  ) {
+    super()
+    const optional = parameters.findIndex((p) => p.type === "AssignmentPattern" || p.type === "RestElement")
+    this.length = optional === -1 ? parameters.length : optional
+  }
+}
+
 const MAX_ARRAY_LENGTH = 4_294_967_295
 
 export const parseArrayIndex = (key: string | number): number | undefined => {
@@ -32,19 +49,25 @@ const canonical = (key: PropertyKey): string | symbol => (typeof key === "symbol
 const index = (target: ProgramObject, key: string | symbol): number | undefined =>
   target instanceof ProgramArray && typeof key === "string" ? parseArrayIndex(key) : undefined
 
+// Non-enumerable built-in properties: array length, function name and length.
+const builtin = (target: ProgramObject, name: string | symbol): boolean =>
+  (name === "length" && target instanceof ProgramArray) ||
+  ((name === "name" || name === "length") && target instanceof ProgramFunction)
+
 export const hasOwn = (target: ProgramObject, key: PropertyKey): boolean => {
   const name = canonical(key)
   const at = index(target, name)
   if (at !== undefined) return at in (target as ProgramArray).items
-  if (name === "length" && target instanceof ProgramArray) return true
-  return target.props.has(name)
+  return builtin(target, name) || target.props.has(name)
 }
 
 export const getOwn = (target: ProgramObject, key: PropertyKey): unknown => {
   const name = canonical(key)
   const at = index(target, name)
   if (at !== undefined) return (target as ProgramArray).items[at]
-  if (name === "length" && target instanceof ProgramArray) return target.items.length
+  if (target instanceof ProgramArray && name === "length") return target.items.length
+  if (target instanceof ProgramFunction && name === "name") return target.name
+  if (target instanceof ProgramFunction && name === "length") return target.length
   return target.props.get(name)
 }
 
@@ -75,6 +98,7 @@ export const set = (target: ProgramObject, key: PropertyKey, value: unknown): bo
     target.items.length = length
     return true
   }
+  if (builtin(target, name)) return false
   target.props.set(name, value)
   return true
 }
@@ -84,6 +108,7 @@ export const remove = (target: ProgramObject, key: PropertyKey): boolean => {
   const at = index(target, name)
   if (at !== undefined) return delete (target as ProgramArray).items[at]
   if (name === "length" && target instanceof ProgramArray) return false
+  if (builtin(target, name)) return true
   target.props.delete(name)
   return true
 }

--- a/packages/codemode/src/interpreter/promises.ts
+++ b/packages/codemode/src/interpreter/promises.ts
@@ -1,13 +1,7 @@
 import { Cause, Deferred, Effect, Exit, Fiber, Scope } from "effect"
 import type { Diagnostic } from "../codemode.js"
-import {
-  type AstNode,
-  CodeModeFunction,
-  InterpreterRuntimeError,
-  ProgramThrow,
-  PromiseInstanceMethodReference,
-} from "./model.js"
-import { get, ProgramArray, ProgramObject, record } from "./objects.js"
+import { type AstNode, InterpreterRuntimeError, ProgramThrow, PromiseInstanceMethodReference } from "./model.js"
+import { get, ProgramArray, ProgramFunction, ProgramObject, record } from "./objects.js"
 import { HostFunction, requiresNew, sync } from "./host.js"
 import { caughtErrorValue, normalizeError } from "./errors.js"
 import { typeofValue } from "./references.js"
@@ -250,7 +244,7 @@ const constructPromise = <R>(
   executor: unknown,
   node: AstNode,
 ): Effect.Effect<Values.Promise, unknown, R> => {
-  if (!(executor instanceof CodeModeFunction)) {
+  if (!(executor instanceof ProgramFunction)) {
     throw new InterpreterRuntimeError(
       "new Promise(...) expects an executor function (e.g. new Promise((resolve, reject) => { ... })).",
       node,

--- a/packages/codemode/src/interpreter/references.ts
+++ b/packages/codemode/src/interpreter/references.ts
@@ -3,19 +3,18 @@ import { Values } from "../values.js"
 import { HostFunction, HostNamespace } from "./host.js"
 import {
   type AstNode,
-  CodeModeFunction,
   CodeModeGenerator,
   GeneratorMethodReference,
   InterpreterRuntimeError,
   IntrinsicReference,
   PromiseInstanceMethodReference,
 } from "./model.js"
-import { getOwn, ownKeys, ProgramArray, ProgramObject } from "./objects.js"
+import { getOwn, ownKeys, ProgramArray, ProgramFunction, ProgramObject } from "./objects.js"
 
 export const isRuntimeReference = (value: unknown): boolean =>
   value instanceof HostFunction ||
   value instanceof HostNamespace ||
-  value instanceof CodeModeFunction ||
+  value instanceof ProgramFunction ||
   value instanceof CodeModeGenerator ||
   value instanceof GeneratorMethodReference ||
   value instanceof ToolReference ||
@@ -93,7 +92,7 @@ export const describeValue = (value: unknown): string => {
 export const typeofValue = (value: unknown): string => {
   if (
     value instanceof HostFunction ||
-    value instanceof CodeModeFunction ||
+    value instanceof ProgramFunction ||
     value instanceof GeneratorMethodReference ||
     value instanceof IntrinsicReference ||
     value instanceof PromiseInstanceMethodReference

--- a/packages/codemode/src/interpreter/runner.ts
+++ b/packages/codemode/src/interpreter/runner.ts
@@ -2,8 +2,8 @@ import { Effect, Exit } from "effect"
 import { Values } from "../values.js"
 import { coerceToString } from "../stdlib/value.js"
 import { HostFunction } from "./host.js"
-import { type AstNode, CodeModeFunction, InterpreterRuntimeError, IntrinsicReference } from "./model.js"
-import { get, has, ProgramObject } from "./objects.js"
+import { type AstNode, InterpreterRuntimeError, IntrinsicReference } from "./model.js"
+import { get, has, ProgramFunction, ProgramObject } from "./objects.js"
 import { typeofValue } from "./references.js"
 
 export type IteratorCursor<R> = {
@@ -13,7 +13,7 @@ export type IteratorCursor<R> = {
 
 /** Everything a host function needs to call back into the program. */
 export type Runner<R> = {
-  readonly invokeFunction: (fn: CodeModeFunction, args: Array<unknown>) => Effect.Effect<unknown, unknown, R>
+  readonly invokeFunction: (fn: ProgramFunction, args: Array<unknown>) => Effect.Effect<unknown, unknown, R>
   readonly invokeCallable: (
     callable: unknown,
     args: Array<unknown>,
@@ -61,10 +61,10 @@ export const toPrimitive = <R>(
 // Array.from mappers, and promise reactions all admit exactly these callables.
 // Admission means dispatchable, not necessarily invocable: new-requiring
 // constructors pass the gate and throw a TypeError on call, like JS.
-export type SupportedCallback = CodeModeFunction | HostFunction<unknown> | IntrinsicReference
+export type SupportedCallback = ProgramFunction | HostFunction<unknown> | IntrinsicReference
 
 export const isSupportedCallback = (value: unknown): value is SupportedCallback =>
-  value instanceof CodeModeFunction ||
+  value instanceof ProgramFunction ||
   (value instanceof HostFunction && value.callback) ||
   value instanceof IntrinsicReference
 

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -1,6 +1,7 @@
 import type {
   ArrayExpression,
   ArrayPattern,
+  AssignmentPattern,
   ArrowFunctionExpression,
   AssignmentExpression,
   AssignmentProperty,
@@ -47,7 +48,6 @@ import {
   type AstNode,
   AsyncIteratorSymbol,
   type Binding,
-  CodeModeFunction,
   CodeModeGenerator,
   ComputedValue,
   GeneratorMethodReference,
@@ -74,6 +74,7 @@ import {
   ownKeys,
   parseArrayIndex,
   ProgramArray,
+  ProgramFunction,
   ProgramObject,
   record,
   remove,
@@ -139,7 +140,7 @@ const constructorName = (value: unknown): string | undefined => {
   if (value instanceof Values.URL) return "URL"
   if (value instanceof Values.URLSearchParams) return "URLSearchParams"
   if (value instanceof Values.Promise) return "Promise"
-  if (!(value instanceof ProgramObject)) return undefined
+  if (!(value instanceof ProgramObject) || value instanceof ProgramFunction) return undefined
   return errorBrandName(value) ?? "Object"
 }
 
@@ -434,8 +435,19 @@ class Frame<R> {
     }).pipe(Effect.ensuring(Effect.sync(() => self.scopes.pop())))
   }
 
-  private createFunction(node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression): CodeModeFunction {
-    return new CodeModeFunction(node.params, node.body, this.scopes.capture(), node.async, node.generator)
+  private createFunction(
+    node: FunctionDeclaration | FunctionExpression | ArrowFunctionExpression,
+    name = node.type === "ArrowFunctionExpression" ? "" : (node.id?.name ?? ""),
+  ): ProgramFunction {
+    return new ProgramFunction(name, node.params, node.body, this.scopes.capture(), node.async, node.generator)
+  }
+
+  // NamedEvaluation: an anonymous function definition takes the name of what it is assigned to.
+  private evaluateNamed(node: Expression, name: string): Effect.Effect<unknown, unknown, R> {
+    if (node.type === "ArrowFunctionExpression" || (node.type === "FunctionExpression" && !node.id)) {
+      return Effect.sync(() => this.createFunction(node, name))
+    }
+    return this.evaluateExpression(node)
   }
 
   private hoistFunctions(statements: ReadonlyArray<Statement | ModuleDeclaration>): void {
@@ -1023,11 +1035,14 @@ class Frame<R> {
 
         const init = declaration.init
         // `var x` alone is a no-op: the binding was hoisted on function entry.
+        const id = declaration.id
+        const evaluate = (init: Expression) =>
+          id.type === "Identifier" ? self.evaluateNamed(init, id.name) : self.evaluateExpression(init)
         if (kind === "var") {
-          if (init) yield* self.assignPattern(declaration.id, yield* self.evaluateExpression(init), declaration)
+          if (init) yield* self.assignPattern(id, yield* evaluate(init), declaration)
           continue
         }
-        const value = init ? yield* self.evaluateExpression(init) : undefined
+        const value = init ? yield* evaluate(init) : undefined
         yield* self.declarePattern(declaration.id, value, kind !== "const", declaration, true)
       }
     })
@@ -1050,7 +1065,7 @@ class Frame<R> {
       }
 
       if (pattern.type === "AssignmentPattern") {
-        const resolved = value === undefined ? yield* self.evaluateExpression(pattern.right) : value
+        const resolved = value === undefined ? yield* self.evaluateDefault(pattern) : value
         yield* self.declarePattern(pattern.left, resolved, mutable, node, initialize)
         return
       }
@@ -1110,7 +1125,7 @@ class Frame<R> {
       }
 
       if (pattern.type === "AssignmentPattern") {
-        const resolved = value === undefined ? yield* self.evaluateExpression(pattern.right) : value
+        const resolved = value === undefined ? yield* self.evaluateDefault(pattern) : value
         yield* self.assignPattern(pattern.left, resolved, node)
         return
       }
@@ -1147,6 +1162,12 @@ class Frame<R> {
 
       throw new InterpreterRuntimeError(`Unsupported assignment pattern '${pattern.type}'.`, node)
     })
+  }
+
+  private evaluateDefault(pattern: AssignmentPattern): Effect.Effect<unknown, unknown, R> {
+    return pattern.left.type === "Identifier"
+      ? this.evaluateNamed(pattern.right, pattern.left.name)
+      : this.evaluateExpression(pattern.right)
   }
 
   private destructureArrayPattern(
@@ -1288,7 +1309,7 @@ class Frame<R> {
         // otherwise; say `new` is unsupported for them and point at the plain call.
         const name = calleeDescription(node.callee)
         const message =
-          callee instanceof CodeModeFunction
+          callee instanceof ProgramFunction
             ? `${name} cannot be constructed: user-defined constructors and classes are not supported. Call it as a function that returns a plain object instead.`
             : callee instanceof HostFunction
               ? `new ${name}(...) is not supported; call ${name}(...) without new instead.`
@@ -1316,6 +1337,9 @@ class Frame<R> {
   private applyBinaryOperator(operator: string, lhs: unknown, rhs: unknown, node: AstNode): unknown {
     if (operator === "===") return lhs === rhs
     if (operator === "!==") return lhs !== rhs
+    if (operator === "in" && rhs instanceof ProgramObject && !containsOpaqueReference(lhs)) {
+      return has(rhs, lhs !== null && typeof lhs === "object" ? coerceToString(lhs) : (lhs as PropertyKey))
+    }
     if (containsOpaqueReference(lhs) || containsOpaqueReference(rhs)) {
       throw new InterpreterRuntimeError("Binary operators require data values.", node, "InvalidDataValue")
     }
@@ -1448,7 +1472,7 @@ class Frame<R> {
           const next = toProgram(self.applyCompoundAssignment(operator, current, rightValue, node), "Assignment result")
           return self.scopes.set(name, next, left)
         }
-        const rightValue = yield* self.evaluateExpression(node.right)
+        const rightValue = yield* self.evaluateNamed(node.right, name)
         return self.scopes.set(name, rightValue, left)
       }
       if (left.type === "MemberExpression") {
@@ -1480,7 +1504,7 @@ class Frame<R> {
       return Effect.gen(function* () {
         const current = self.scopes.get(name, left)
         if (!shouldAssign(current)) return current
-        const rightValue = yield* self.evaluateExpression(node.right)
+        const rightValue = yield* self.evaluateNamed(node.right, name)
         return self.scopes.set(name, rightValue, left)
       })
     }
@@ -1569,7 +1593,7 @@ class Frame<R> {
         }
         return yield* self.createToolCallPromise(callable.path, args)
       }
-      if (callable instanceof CodeModeFunction) {
+      if (callable instanceof ProgramFunction) {
         return yield* self.invokeFunction(callable, args)
       }
       if (callable instanceof GeneratorMethodReference) {
@@ -1620,7 +1644,7 @@ class Frame<R> {
     })
   }
 
-  invokeFunction(fn: CodeModeFunction, args: Array<unknown>): Effect.Effect<unknown, unknown, R> {
+  invokeFunction(fn: ProgramFunction, args: Array<unknown>): Effect.Effect<unknown, unknown, R> {
     const invocation = new Frame(this.runtime, new ScopeStack([...fn.capturedScopes, new Map()]))
     const run = Effect.gen(function* () {
       // Seed all parameters first so defaults cannot fall through to same-named outer bindings.
@@ -1934,7 +1958,13 @@ class Frame<R> {
           throw new InterpreterRuntimeError("Unsupported object property key shape.", keyNode)
         }
 
-        set(objectValue, key, yield* self.evaluateExpression(property.value))
+        const name =
+          key === IteratorSymbol
+            ? "[Symbol.iterator]"
+            : key === AsyncIteratorSymbol
+              ? "[Symbol.asyncIterator]"
+              : String(key)
+        set(objectValue, key, yield* self.evaluateNamed(property.value, name))
       }
 
       return objectValue
@@ -2138,6 +2168,8 @@ class Frame<R> {
         return new ComputedValue(undefined)
       }
 
+      if (objectValue instanceof ProgramObject) return { target: objectValue, key }
+
       if (isRuntimeReference(objectValue)) {
         throw new InterpreterRuntimeError(
           `Cannot read properties of ${describeValue(objectValue)}; only data values expose properties.`,
@@ -2145,12 +2177,7 @@ class Frame<R> {
           "InvalidDataValue",
         )
       }
-
-      if (!(objectValue instanceof ProgramObject)) {
-        throw new InterpreterRuntimeError("Cannot access a property on a non-object value.", objectNode)
-      }
-
-      return { target: objectValue, key }
+      throw new InterpreterRuntimeError("Cannot access a property on a non-object value.", objectNode)
     })
   }
 
@@ -2257,7 +2284,9 @@ class Frame<R> {
       target instanceof ProgramArray ? "Array assignment result" : "Object assignment result",
       node,
     )
-    if (!set(target, key, next)) throw new InterpreterRuntimeError("Invalid array length", node).as("RangeError")
+    if (set(target, key, next)) return
+    if (target instanceof ProgramArray) throw new InterpreterRuntimeError("Invalid array length", node).as("RangeError")
+    throw new InterpreterRuntimeError(`Cannot assign to read only property '${String(key)}'.`, node).as("TypeError")
   }
 
   private toPropertyKey(value: unknown, node: AstNode): PropertyKey {

--- a/packages/codemode/test/enumeration.test.ts
+++ b/packages/codemode/test/enumeration.test.ts
@@ -98,7 +98,7 @@ describe("Object.keys over arrays", () => {
     )
     expect((await error(`const { a } = new Map(); return a`)).message).toContain("received a Map.")
     expect((await error(`return Array.from(7)`)).message).toContain("received a number.")
-    expect((await error(`return (() => 1).x`)).message).toContain("Cannot read properties of a function")
+    expect(await value(`return [(() => 1).x, Object.keys(() => 1)]`)).toEqual([null, []])
   })
 })
 

--- a/packages/codemode/test/parity.test.ts
+++ b/packages/codemode/test/parity.test.ts
@@ -913,3 +913,48 @@ describe("coercion parity: unknown static members read as undefined", () => {
     ])
   })
 })
+
+describe("functions are objects", () => {
+  test("name follows NamedEvaluation and length counts required parameters", async () => {
+    expect(
+      await value(`
+        function decl(a, b = 1, ...rest) {}
+        const arrow = () => {}
+        const named = function inner() {}
+        let assigned
+        assigned = (a, b) => {}
+        const { fromDefault = () => {} } = {}
+        const [fromArray = function () {}] = []
+        const obj = { method() {}, key: () => {}, [Symbol.iterator]: () => {} }
+        const passthrough = (0, () => {})
+        return [
+          [decl.name, decl.length],
+          [arrow.name, named.name, assigned.name, assigned.length],
+          [fromDefault.name, fromArray.name],
+          [obj.method.name, obj.key.name, obj[Symbol.iterator].name],
+          passthrough.name,
+        ]
+      `),
+    ).toEqual([
+      ["decl", 1],
+      ["arrow", "inner", "assigned", 2],
+      ["fromDefault", "fromArray"],
+      ["method", "key", "[Symbol.iterator]"],
+      "",
+    ])
+  })
+
+  test("functions hold own properties; name and length are read-only", async () => {
+    expect(
+      await value(`
+        const fn = () => 1
+        fn.count = 2
+        fn.count += 1
+        let renamed = false
+        try { fn.name = "other" } catch (error) { renamed = error instanceof TypeError }
+        const { name, count } = fn
+        return [fn.count, Object.keys(fn), "count" in fn, "name" in fn, name, count, renamed, delete fn.count, fn.count]
+      `),
+    ).toEqual([3, ["count"], true, true, "fn", 3, true, true, null])
+  })
+})

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -1101,7 +1101,7 @@ describe("CodeMode values at intra-CodeMode checkpoints", () => {
     const diagnostic = await error(`return Array.from(Promise.resolve([1]))`)
     expect(diagnostic.kind).toBe("InvalidDataValue")
     expect(diagnostic.message).toContain("await")
-    expect((await error(`return Array.from(() => 1)`)).kind).toBe("InvalidDataValue")
+    expect(await value(`return Array.from((a, b) => 1)`)).toEqual([null, null])
   })
 
   test("regexes stay callable through Object.values", async () => {

--- a/packages/codemode/test/test262/skipped.txt
+++ b/packages/codemode/test/test262/skipped.txt
@@ -87,20 +87,12 @@ built-ins/Array/prototype/toString/S15.4.4.2_A1_T3.js  # .toString is not a func
 built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js  # .toString is not a function.
 built-ins/Array/prototype/values/iteration-mutable.js  # .next is not a function.
 built-ins/Array/prototype/values/iteration.js  # .next is not a function.
-language/statements/async-function/dflt-params-trailing-comma.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-function/params-trailing-comma-multiple.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-function/params-trailing-comma-single.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-function/rest-params-trailing-comma-early-error.js  # expected SyntaxError but the program ran
 language/statements/async-generator/dflt-params-abrupt.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dflt-params-ref-later.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/async-generator/dflt-params-ref-self.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
-language/statements/async-generator/dflt-params-trailing-comma.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-generator/dstr/ary-init-iter-get-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/ary-ptrn-elem-ary-val-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-generator/dstr/ary-ptrn-elem-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/ary-ptrn-elem-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/ary-ptrn-elem-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -111,10 +103,6 @@ language/statements/async-generator/dstr/ary-ptrn-rest-id-elision-next-err.js  #
 language/statements/async-generator/dstr/ary-ptrn-rest-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-ary-init-iter-get-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-ary-ptrn-elem-ary-val-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -125,10 +113,6 @@ language/statements/async-generator/dstr/dflt-ary-ptrn-rest-id-elision-next-err.
 language/statements/async-generator/dstr/dflt-ary-ptrn-rest-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-obj-init-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-obj-init-undefined.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/dflt-obj-ptrn-list-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -140,10 +124,6 @@ language/statements/async-generator/dstr/dflt-obj-ptrn-prop-obj-value-null.js  #
 language/statements/async-generator/dstr/dflt-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/obj-init-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/obj-init-undefined.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-generator/dstr/obj-ptrn-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/obj-ptrn-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/obj-ptrn-list-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -153,22 +133,12 @@ language/statements/async-generator/dstr/obj-ptrn-prop-id-init-throws.js  # Expe
 language/statements/async-generator/dstr/obj-ptrn-prop-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/async-generator/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/async-generator/params-trailing-comma-multiple.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/async-generator/params-trailing-comma-single.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/async-generator/rest-params-trailing-comma-early-error.js  # expected SyntaxError but the program ran
 language/statements/async-generator/return-undefined-implicit-and-explicit.js  # Actual ["tick 1", "tick 2", "g1 ret", "g2 ret", "g3 ret", "g4 ret"] and expected ["tick 1", "g1 ret"
-language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/const/dstr/ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/const/dstr/ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/const/dstr/obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/const/dstr/obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/const/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/const/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/const/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/const/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/const/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/const/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
 language/statements/for-await-of/async-func-decl-dstr-array-elem-init-in.js  # Failed to parse TypeScript: '…' expected.
@@ -190,10 +160,6 @@ language/statements/for-await-of/async-func-decl-dstr-obj-rest-number.js  # Obje
 language/statements/for-await-of/async-func-decl-dstr-obj-rest-str-val.js  # Object destructuring requires a data object or array value, received a string.
 language/statements/for-await-of/async-func-dstr-const-ary-init-iter-get-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-ary-val-null.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -202,20 +168,8 @@ language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-obj-val-und
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elision-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-elision-next-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
-language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-const-obj-init-null.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-func-dstr-const-obj-init-undefined.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-func-dstr-const-obj-ptrn-list-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -227,10 +181,6 @@ language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-obj-value-n
 language/statements/for-await-of/async-func-dstr-const-obj-ptrn-prop-obj-value-undef.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-func-dstr-let-ary-init-iter-get-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-ary-val-null.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -239,20 +189,8 @@ language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-obj-val-undef
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elision-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-elision-next-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
-language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-let-obj-init-null.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-func-dstr-let-obj-init-undefined.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-func-dstr-let-obj-ptrn-list-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -264,10 +202,6 @@ language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-obj-value-nul
 language/statements/for-await-of/async-func-dstr-let-obj-ptrn-prop-obj-value-undef.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-func-dstr-var-ary-init-iter-get-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-ary-val-null.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -276,20 +210,8 @@ language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-obj-val-undef
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elision-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-elision-next-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
-language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-var-obj-init-null.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-func-dstr-var-obj-init-undefined.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-func-dstr-var-obj-ptrn-list-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -325,10 +247,6 @@ language/statements/for-await-of/async-gen-decl-dstr-obj-rest-number.js  # Objec
 language/statements/for-await-of/async-gen-decl-dstr-obj-rest-str-val.js  # Object destructuring requires a data object or array value, received a string.
 language/statements/for-await-of/async-gen-dstr-const-ary-init-iter-get-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-ary-val-null.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -337,20 +255,8 @@ language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-obj-val-unde
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elision-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-elision-next-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
-language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-const-obj-init-null.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-gen-dstr-const-obj-init-undefined.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-list-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -362,10 +268,6 @@ language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-obj-value-nu
 language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-obj-value-undef.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-gen-dstr-let-ary-init-iter-get-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-ary-val-null.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -374,20 +276,8 @@ language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-obj-val-undef.
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elision-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-elision-next-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
-language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-let-obj-init-null.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-gen-dstr-let-obj-init-undefined.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-list-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -399,10 +289,6 @@ language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-obj-value-null
 language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-obj-value-undef.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-gen-dstr-var-ary-init-iter-get-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-ary-val-null.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -411,20 +297,8 @@ language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-obj-val-undef.
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elision-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-elision-next-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-id-iter-step-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
-language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-var-obj-init-null.js  # Expected SameValue(«undefined», «TypeError») to be true
 language/statements/for-await-of/async-gen-dstr-var-obj-init-undefined.js  # Expected SameValue(«undefined», «TypeError») to be true
-language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-throws.js  # Expected SameValue(«undefined», «Test262Error») to be true
 language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-unresolvable.js  # Expected SameValue(«undefined», «ReferenceError») to be true
 language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-list-err.js  # Expected SameValue(«undefined», «Test262Error») to be true
@@ -455,32 +329,16 @@ language/statements/for-of/dstr/array-rest-iter-rtrn-close-err.js  # Iterator ne
 language/statements/for-of/dstr/array-rest-iter-rtrn-close-null.js  # Iterator next must be a function.
 language/statements/for-of/dstr/array-rest-iter-thrw-close-err.js  # Expected SameValue(«11», «0») to be true
 language/statements/for-of/dstr/array-rest-lref-err.js  # Expected SameValue(«1», «0») to be true
-language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-of/dstr/const-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/const-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/const-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/const-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-of/dstr/const-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/const-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
-language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-of/dstr/let-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/let-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/let-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/let-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-of/dstr/let-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/let-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/obj-empty-bool.js  # Object destructuring requires a data object or array value, received a boolean.
@@ -496,118 +354,60 @@ language/statements/for-of/dstr/obj-rest-number.js  # Object destructuring requi
 language/statements/for-of/dstr/obj-rest-str-val.js  # Object destructuring requires a data object or array value, received a string.
 language/statements/for-of/dstr/obj-rest-val-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/obj-rest-val-undefined.js  # Expected a TypeError but got a Error
-language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-of/dstr/var-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/var-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/var-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/var-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for-of/dstr/var-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/for-of/dstr/var-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
 language/statements/for-of/throw-from-catch.js  # … cannot be constructed: user-defined constructors and classes are not supported. Call it as a funct
 language/statements/for-of/throw-from-finally.js  # … cannot be constructed: user-defined constructors and classes are not supported. Call it as a funct
 language/statements/for-of/throw.js  # … cannot be constructed: user-defined constructors and classes are not supported. Call it as a funct
-language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for/dstr/const-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/const-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/const-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/const-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for/dstr/const-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/const-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
-language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for/dstr/let-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/let-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/let-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/let-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for/dstr/let-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/let-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
-language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for/dstr/var-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/var-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/var-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/var-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/for/dstr/var-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/for/dstr/var-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
-language/statements/function/13.2-19-b-3gs.js  # Expected a TypeError but got a Error
-language/statements/function/13.2-2-s.js  # Expected a TypeError but got a Error
+language/statements/function/13.2-19-b-3gs.js  # Expected a TypeError to be thrown but no exception was thrown at all
+language/statements/function/13.2-2-s.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/function/S13.2.1_A5_T1.js  # .toString is not a function.
-language/statements/function/S13.2_A3.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/S13.2_A7_T1.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/S13.2_A8_T1.js  # Binary operators require data values.
+language/statements/function/S13.2_A7_T1.js  # The called value is not a function.
 language/statements/function/S13_A3_T1.js  # Unknown identifier '…'.
 language/statements/function/S13_A6_T1.js  # Identifier '…' has already been declared.
 language/statements/function/S14_A2.js  # Unknown identifier '…'.
 language/statements/function/S14_A5_T1.js  # Identifier '…' has already been declared.
 language/statements/function/S14_A5_T2.js  # Identifier '…' has already been declared.
-language/statements/function/dflt-params-trailing-comma.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/function/dstr/ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
-language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/function/dstr/dflt-ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/dflt-ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/dflt-obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/dflt-obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/function/dstr/dflt-obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/dflt-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/function/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/function/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/function/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
-language/statements/function/params-trailing-comma-multiple.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/function/params-trailing-comma-single.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/function/rest-params-trailing-comma-early-error.js  # expected SyntaxError but the program ran
 language/statements/generators/dflt-params-abrupt.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dflt-params-ref-later.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/generators/dflt-params-ref-self.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
-language/statements/generators/dflt-params-trailing-comma.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/generators/dstr/ary-init-iter-get-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/ary-ptrn-elem-ary-val-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/generators/dstr/ary-ptrn-elem-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/ary-ptrn-elem-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/ary-ptrn-elem-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -618,10 +418,6 @@ language/statements/generators/dstr/ary-ptrn-rest-id-elision-next-err.js  # Expe
 language/statements/generators/dstr/ary-ptrn-rest-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-ary-init-iter-get-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-ary-ptrn-elem-ary-val-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-ary-ptrn-elem-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -632,10 +428,6 @@ language/statements/generators/dstr/dflt-ary-ptrn-rest-id-elision-next-err.js  #
 language/statements/generators/dstr/dflt-ary-ptrn-rest-id-iter-step-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-obj-init-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-obj-init-undefined.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/generators/dstr/dflt-obj-ptrn-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-obj-ptrn-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/dflt-obj-ptrn-list-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -647,10 +439,6 @@ language/statements/generators/dstr/dflt-obj-ptrn-prop-obj-value-null.js  # Expe
 language/statements/generators/dstr/dflt-obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/obj-init-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/obj-init-undefined.js  # Expected a TypeError to be thrown but no exception was thrown at all
-language/statements/generators/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/generators/dstr/obj-ptrn-id-init-throws.js  # Expected a Test262Error to be thrown but no exception was thrown at all
 language/statements/generators/dstr/obj-ptrn-id-init-unresolvable.js  # Expected a ReferenceError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/obj-ptrn-list-err.js  # Expected a Test262Error to be thrown but no exception was thrown at all
@@ -661,23 +449,13 @@ language/statements/generators/dstr/obj-ptrn-prop-id-init-unresolvable.js  # Exp
 language/statements/generators/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/generators/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError to be thrown but no exception was thrown at all
 language/statements/generators/has-instance.js  # The right-hand side of '…' must be a supported constructor: Error (or a specific error type like Typ
-language/statements/generators/params-trailing-comma-multiple.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/generators/params-trailing-comma-single.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/generators/rest-params-trailing-comma-early-error.js  # expected SyntaxError but the program ran
 language/statements/labeled/value-await-non-module-escaped.js  # Failed to parse TypeScript: Keywords cannot contain escape characters.
 language/statements/labeled/value-await-non-module.js  # Failed to parse TypeScript: Expression expected.
-language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/let/dstr/ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/let/dstr/ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/let/dstr/obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/let/dstr/obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/let/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/let/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/let/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/let/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/let/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/let/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
 language/statements/return/S12.9_A1_T1.js  # expected SyntaxError but the program ran
@@ -694,31 +472,15 @@ language/statements/switch/S12.11_A1_T4.js  # Switch discriminants must be data 
 language/statements/switch/scope-lex-open-dflt.js  # Switch discriminants must be data values.
 language/statements/try/S12.14_A19_T1.js  # .toString is not a function.
 language/statements/try/S12.14_A19_T2.js  # .toString is not a function.
-language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/try/dstr/ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/try/dstr/ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/try/dstr/obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/try/dstr/obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/try/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/try/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/try/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/try/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/try/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/try/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error
-language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/variable/dstr/ary-ptrn-elem-obj-val-null.js  # Expected a TypeError but got a Error
 language/statements/variable/dstr/ary-ptrn-elem-obj-val-undef.js  # Expected a TypeError but got a Error
 language/statements/variable/dstr/obj-init-null.js  # Expected a TypeError but got a Error
 language/statements/variable/dstr/obj-init-undefined.js  # Expected a TypeError but got a Error
-language/statements/variable/dstr/obj-ptrn-id-init-fn-name-arrow.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/variable/dstr/obj-ptrn-id-init-fn-name-cover.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/variable/dstr/obj-ptrn-id-init-fn-name-fn.js  # Cannot read properties of a function; only data values expose properties.
-language/statements/variable/dstr/obj-ptrn-id-init-fn-name-gen.js  # Cannot read properties of a function; only data values expose properties.
 language/statements/variable/dstr/obj-ptrn-prop-obj-value-null.js  # Expected a TypeError but got a Error
 language/statements/variable/dstr/obj-ptrn-prop-obj-value-undef.js  # Expected a TypeError but got a Error

--- a/packages/codemode/test/tool-paths.test.ts
+++ b/packages/codemode/test/tool-paths.test.ts
@@ -192,9 +192,10 @@ describe("blocked member names on tool paths", () => {
       `,
       ),
     ).toEqual([true, true, true, null, true, null, null, null, true, null, null, "undefined"])
-    expect((await failure(runtime, `return (() => 1).constructor`)).message).toContain(
-      "Cannot read properties of a function",
-    )
+    expect(await value(runtime, `return [(() => 1).constructor, typeof (() => 1).__proto__]`)).toEqual([
+      null,
+      "undefined",
+    ])
     const escape = await failure(runtime, `return ({}).constructor.constructor.constructor("return 1")()`)
     expect(escape.message).toContain("Cannot access a property on a non-object value")
     const poisoned = await failure(runtime, `const o = {}; o.__proto__.constructor("return 1")`)


### PR DESCRIPTION
Second step of the value-model rewrite (after #48527): program functions are now program objects. They hold own properties, enumerate them, and expose read-only `name` and `length`, with names inferred the way JavaScript's NamedEvaluation does.

## The model

```diff
-CodeModeFunction                          # opaque: "Cannot read properties of a function"
-  parameters, body, capturedScopes, async, generator
+ProgramFunction extends ProgramObject     # src/interpreter/objects.ts
+  name: string                            # read-only, non-enumerable
+  length: number                          # parameters before the first default or rest
+  parameters, body, capturedScopes, async, generator
+  props: Map                              # fn.count = 1 lives here
```

`objects.ts` treats `name`/`length` on functions like `length` on arrays: visible to `get`/`has`/`in`/destructuring, excluded from `ownKeys`, rejected by `set`.

## Where names come from

```text
createFunction(node, name)
  FunctionDeclaration            ← node.id.name
  FunctionExpression with id     ← node.id.name
  anonymous, via evaluateNamed:
    const f = …  /  let f; f = …  /  f ??= …          ← binding name
    { f: … }  /  { f() {} }  /  { [k]: … }             ← property key
    function g(f = …)  /  const { f = … } = …          ← default's target
  anything else (e.g. `(0, () => {})`)                  ← ""
```

`evaluateNamed` only fires when the expression is *syntactically* an anonymous function, so a parenthesized or comma-wrapped function stays unnamed, as in JS.

## What moved

```diff
 src/interpreter/
 ├── model.ts            −CodeModeFunction
-├── objects.ts
+├── objects.ts          +ProgramFunction; name/length in hasOwn/getOwn/set/remove
 ├── runtime.ts          createFunction(node, name), evaluateNamed, evaluateDefault;
 │                       member access lets ProgramObject through before the opaque-reference check
 └── references.ts, runner.ts, promises.ts   rename only
 src/data.ts             functions still rejected at the host boundary ("must contain data only")
```

## Behavior that changed

```diff
 const fn = (a, b = 1) => {}
-fn.name                  // error: Cannot read properties of a function
+fn.name                  // "fn"
+fn.length                // 1
-fn.count = 1             // error: Only data fields may be assigned
+fn.count = 1             // ok; Object.keys(fn) → ["count"]
+"name" in fn             // true
+fn.name = "x"            // TypeError: Cannot assign to read only property 'name'
-Array.from(fn)           // InvalidDataValue
+Array.from(fn)           // [] — a function is array-like with length 0, as in JS
 fn.constructor           // undefined (no Function global); unchanged
```

Three existing tests that asserted the old "functions are opaque" errors now assert JS behavior; two new tests in `test/parity.test.ts` cover naming and own properties.

## Results

| | before | after |
|---|---|---|
| existing suite + typecheck | green | green |
| test262, vendored `Array/prototype` + `language/statements` | 724 skipped | 486 skipped, 0 new failures |
| test262, wider local baseline (10 311 files) | 1845 skipped | 1432 skipped, 413 recovered, 0 new failures |

Built-in functions (`Math.max.name`, `"a".includes.length`) are not covered here and are recorded as a `[ ]` item; one test262 file depends on it.

## Next

```text
1  program-objects      #48527
2  function-objects     ← this PR
3  error-objects        Error.prototype → TypeError.prototype chain; typed interpreter errors
4  prototype-methods    built-ins move onto real prototypes; drop the .prototype test262 boundary
```