### PR TITLE
fix(tui): display slash command aliases

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -821,7 +821,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         title: "Switch model",
         suggested: true,
         category: "Agent",
-        slash: { name: "models", aliases: ["mo"] },
+        slash: { name: "models" },
         run: () => {
           dialog.replace(() => <DialogModel />)
         },
@@ -902,7 +902,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         title: "Switch model variant",
         category: "Agent",
         palette: local.model.variant.list().length === 0 ? undefined : (true as const),
-        slash: { name: "variants" },
+        slash: { name: "variants", aliases: ["thinking"] },
         run: () => {
           if (local.model.variant.list().length === 0) {
             return toast.show({

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -503,12 +503,11 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = keymapCommands().flatMap((command) => {
       const slash = command.slash
       if (!slash) return []
-      return {
-        display: `/${slash.name}`,
+      return [slash.name, ...(slash.aliases ?? [])].map((name) => ({
+        display: `/${name}`,
         description: command.description ?? command.title,
-        aliases: slash.aliases?.map((alias) => `/${alias}`),
-        onSelect: slash.arguments ? () => insertSlash(slash.name) : command.run,
-      }
+        onSelect: slash.arguments ? () => insertSlash(name) : command.run,
+      }))
     })
     const commandNames = new Set<string>()
 

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -619,7 +619,7 @@ export function Prompt(props: PromptProps) {
         desc: "Manage workspaces",
         name: "session.move",
         category: "Session",
-        slash: { name: "worktrees", aliases: ["move", "mov"] },
+        slash: { name: "worktrees" },
         run: () => {
           move.open()
         },

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -946,10 +946,6 @@ export function Session(props: {
       id: "session.toggle.thinking",
       group: "Session",
       palette: undefined,
-      slash: {
-        name: "thinking",
-        aliases: ["toggle-thinking"],
-      },
       run: () => {
         void configState
           .update((draft) => {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shows slash aliases as their own autocomplete entries, so typing `/web` displays `/web` instead of the canonical `/pair` label while still running the same command.

It also removes the noisy `/mo`, `/move`, `/mov`, and `/toggle-thinking` aliases, and maps `/thinking` to the model variants picker.

### How did you verify your code works?

- `bun typecheck` in `packages/tui`
- Repository pre-push typecheck: 35 packages passed
- Live TUI smoke test for `/web` and `/thinking`
- `bun test` in `packages/tui`: 1,357 passed; two existing shell-output cases timed out

### Screenshots / recordings

Not included; verified the terminal autocomplete interactively with Terminal Control.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
