### PR TITLE
feat(tui): configure session permission handling

### DIFF
--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -423,24 +423,24 @@ test("updates effective duplicate canonical keybinds", async () => {
   const file = path.join(directory.path, "cli.json")
   await Bun.write(
     file,
-    `{"keybinds":{"session.delete":"first","session.delete":"last","permission.mode":"off","permission.mode":"on"}}`,
+    `{"keybinds":{"session.delete":"first","session.delete":"last","opencode.settings":"off","opencode.settings":"on"}}`,
   )
 
   const config = await run(
     directory.path,
     Effect.gen(function* () {
       const service = yield* Config.Service
-      expect((yield* service.get()).keybinds).toEqual({ "session.delete": "last", "permission.mode": "on" })
+      expect((yield* service.get()).keybinds).toEqual({ "session.delete": "last", "opencode.settings": "on" })
       return yield* service.update((draft) => {
-        draft.keybinds = { ...draft.keybinds, "session.delete": "changed", "permission.mode": "changed" }
+        draft.keybinds = { ...draft.keybinds, "session.delete": "changed", "opencode.settings": "changed" }
       })
     }),
   )
 
-  expect(config.keybinds).toEqual({ "session.delete": "changed", "permission.mode": "changed" })
+  expect(config.keybinds).toEqual({ "session.delete": "changed", "opencode.settings": "changed" })
   expect(parse(await Bun.file(file).text()).keybinds).toEqual({
     "session.delete": "changed",
-    "permission.mode": "changed",
+    "opencode.settings": "changed",
   })
 })
 

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1171,10 +1171,12 @@ function App(props: { pair?: DialogPairCredentials }) {
       {
         name: "permission.mode",
         title:
-          local.permission.mode === "auto" ? "Disable auto-approve permissions" : "Enable auto-approve permissions",
-        category: "System",
+          local.permission.mode === "autoaccept"
+            ? "Disable auto-approve permissions"
+            : "Enable auto-approve permissions",
+        category: "Session",
         run: () => {
-          local.permission.toggle()
+          void local.permission.toggle().catch(toast.error)
           dialog.clear()
         },
       },

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -173,7 +173,6 @@ const appBindingCommands = [
   "app.toggle.file_context",
   "app.toggle.diffwrap",
   "app.toggle.paste_summary",
-  "permission.mode",
 ] as const
 
 export type TuiInput = {
@@ -1165,18 +1164,6 @@ function App(props: { pair?: DialogPairCredentials }) {
               draft.prompt = { ...draft.prompt, paste: pasteSummaryEnabled() ? "full" : "compact" }
             })
             .catch(toast.error)
-          dialog.clear()
-        },
-      },
-      {
-        name: "permission.mode",
-        title:
-          local.permission.mode === "autoaccept"
-            ? "Disable auto-approve permissions"
-            : "Enable auto-approve permissions",
-        category: "Session",
-        run: () => {
-          void local.permission.toggle().catch(toast.error)
           dialog.clear()
         },
       },

--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -121,6 +121,15 @@ export const settings: Setting[] = [
     keywords: ["directory", "cwd", "inherit"],
   },
   {
+    title: "Permissions",
+    category: "Session",
+    path: ["session", "permissions"],
+    default: "prompt",
+    values: ["prompt", "autoaccept"],
+    labels: ["prompt", "auto accept"],
+    keywords: ["approve", "accept", "permission requests"],
+  },
+  {
     title: "Enabled",
     category: "Tabs",
     path: ["tabs", "enabled"],

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1849,7 +1849,7 @@ export function Prompt(props: PromptProps) {
               <PromptMetadataRow
                 mode={store.mode}
                 agent={agentLabel()}
-                auto={local.permission.mode === "auto"}
+                auto={local.permission.mode === "autoaccept"}
                 model={promptDisplay().modelLabel}
                 provider={promptDisplay().providerLabel}
                 variant={promptDisplay().variant}

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -168,6 +168,9 @@ export const Info = Schema.Struct({
       new_location: Schema.optional(Schema.Literals(["launch", "inherit"])).annotate({
         description: "Start new sessions in the TUI launch directory or inherit the active session location",
       }),
+      permissions: Schema.optional(Schema.Literals(["prompt", "autoaccept"])).annotate({
+        description: "Prompt for permission requests or accept them automatically",
+      }),
     }),
   ).annotate({ description: "Session transcript presentation settings" }),
   tabs: Schema.optional(
@@ -254,8 +257,9 @@ export type Resolved = Omit<Info, "attention" | "cursor" | "keybinds" | "leader"
     style: "block" | "underline" | "line" | "default"
     blinking: boolean
   }
-  session: Omit<NonNullable<Info["session"]>, "new_location" | "tps"> & {
+  session: Omit<NonNullable<Info["session"]>, "new_location" | "permissions" | "tps"> & {
     new_location: "launch" | "inherit"
+    permissions: "prompt" | "autoaccept"
     tps: boolean
   }
   tabs: {
@@ -302,6 +306,7 @@ export function resolve(input: Info, options: { terminalSuspend: boolean }): Res
     session: {
       ...input.session,
       new_location: input.session?.new_location ?? "launch",
+      permissions: input.session?.permissions ?? "prompt",
       // Persistent terminal panes need the opencode-pty daemon, which does not ship Windows binaries.
       terminal: input.session?.terminal ?? process.platform !== "win32",
       tps: input.session?.tps ?? true,

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -60,7 +60,6 @@ export const Definitions = {
   "opencode.settings": keybind("none", "Open settings"),
   "server.pair": keybind("none", "Pair device"),
   "service.restart": keybind("none", "Restart service"),
-  "permission.mode": keybind("none", "Toggle auto-approve permissions"),
   "diff.open": keybind("none", "Open diff viewer"),
   "diff.close": keybind("escape,q", "Close diff viewer"),
   "diff.down": keybind("j,down", "Move diff viewer down"),

--- a/packages/tui/src/context/permission.tsx
+++ b/packages/tui/src/context/permission.tsx
@@ -1,5 +1,3 @@
-import { createStore } from "solid-js/store"
-import { createEffect } from "solid-js"
 import { useConfig } from "../config"
 import { useArgs } from "./args"
 import { createSimpleContext } from "./helper"
@@ -11,27 +9,9 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
   init: () => {
     const args = useArgs()
     const config = useConfig()
-    const [store, setStore] = createStore<{ mode: PermissionMode; configured: PermissionMode }>({
-      mode: args.auto ? "autoaccept" : config.data.session.permissions,
-      configured: config.data.session.permissions,
-    })
-    createEffect(() => {
-      const mode = config.data.session.permissions
-      if (mode === store.configured) return
-      setStore({ mode, configured: mode })
-    })
     return {
-      get mode() {
-        return store.mode
-      },
-      set(mode: PermissionMode) {
-        setStore("mode", mode)
-        return config.update((draft) => {
-          draft.session = { ...draft.session, permissions: mode }
-        })
-      },
-      toggle() {
-        return this.set(store.mode === "autoaccept" ? "prompt" : "autoaccept")
+      get mode(): PermissionMode {
+        return args.auto ? "autoaccept" : config.data.session.permissions
       },
     }
   },

--- a/packages/tui/src/context/permission.tsx
+++ b/packages/tui/src/context/permission.tsx
@@ -1,15 +1,24 @@
 import { createStore } from "solid-js/store"
+import { createEffect } from "solid-js"
+import { useConfig } from "../config"
 import { useArgs } from "./args"
 import { createSimpleContext } from "./helper"
 
-export type PermissionMode = "auto" | "normal"
+export type PermissionMode = "prompt" | "autoaccept"
 
 export const { use: usePermission, provider: PermissionProvider } = createSimpleContext({
   name: "Permission",
   init: () => {
     const args = useArgs()
-    const [store, setStore] = createStore<{ mode: PermissionMode }>({
-      mode: args.auto ? "auto" : "normal",
+    const config = useConfig()
+    const [store, setStore] = createStore<{ mode: PermissionMode; configured: PermissionMode }>({
+      mode: args.auto ? "autoaccept" : config.data.session.permissions,
+      configured: config.data.session.permissions,
+    })
+    createEffect(() => {
+      const mode = config.data.session.permissions
+      if (mode === store.configured) return
+      setStore({ mode, configured: mode })
     })
     return {
       get mode() {
@@ -17,9 +26,12 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       },
       set(mode: PermissionMode) {
         setStore("mode", mode)
+        return config.update((draft) => {
+          draft.session = { ...draft.session, permissions: mode }
+        })
       },
       toggle() {
-        setStore("mode", (mode) => (mode === "auto" ? "normal" : "auto"))
+        return this.set(store.mode === "autoaccept" ? "prompt" : "autoaccept")
       },
     }
   },

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -185,7 +185,7 @@ export function Session(props: {
       (sessionID) => data.session.permission.list(sessionID) ?? [],
     )
   })
-  const promptedPermissions = createMemo(() => (local.permission.mode === "auto" ? [] : permissions()))
+  const promptedPermissions = createMemo(() => (local.permission.mode === "autoaccept" ? [] : permissions()))
   const forms = createMemo(() => {
     const global = data.session.form.list("global", location()) ?? []
     if (session()?.parentID) return global
@@ -235,7 +235,7 @@ export function Session(props: {
   const client = useClient()
   const autoApproved = new Set<string>()
   createEffect(() => {
-    if (local.permission.mode !== "auto") return
+    if (local.permission.mode !== "autoaccept") return
     permissions().forEach((request) => {
       if (autoApproved.has(request.id)) return
       autoApproved.add(request.id)
@@ -2660,7 +2660,7 @@ function useToolPermission(part: () => SessionMessageAssistantTool | undefined) 
   const data = useData()
   const local = useLocal()
   return createMemo(() => {
-    if (local.permission.mode === "auto") return false
+    if (local.permission.mode === "autoaccept") return false
     const request = data.session.permission.list(ctx.sessionID)?.[0]
     return request?.source?.type === "tool" && request.source.id === part()?.id
   })

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -1219,9 +1219,9 @@ test("keeps the prompt display stable while a new location catalog loads", async
   }
 })
 
-test("configured app bindings execute settings and permission commands", async () => {
+test("configured app binding opens settings", async () => {
   await using setup = await createAppFixture({
-    config: { animations: false, keybinds: { "opencode.settings": "f6", "permission.mode": "f7" } },
+    config: { animations: false, keybinds: { "opencode.settings": "f6" } },
   })
   await setup.ready
   await setup.waitForFrame((frame) => frame.includes("commands"))
@@ -1230,23 +1230,6 @@ test("configured app bindings execute settings and permission commands", async (
   const settings = await setup.waitForFrame((frame) => frame.includes("Settings"))
   expect(settings).toContain("Color mode")
   expect(settings).toContain("Animations")
-
-  setup.mockInput.pressEscape()
-  await setup.waitForFrame((frame) => !frame.includes("Settings"))
-  setup.mockInput.pressKey("F7")
-  await setup.renderOnce()
-  setup.mockInput.pressKey("p", { ctrl: true })
-  await setup.waitForFrame((frame) => frame.includes("Commands"))
-  setup.mockInput.pressKey("END")
-  const commands = await setup.waitForFrame(
-    (frame) => {
-      if (frame.includes("Disable auto-approve permissions")) return true
-      setup.mockInput.pressArrow("up")
-      return false
-    },
-    { maxPasses: 100 },
-  )
-  expect(commands).not.toContain("Enable auto-approve permissions")
 })
 
 test("ctrl+c dismisses autocomplete and shell mode before exiting", async () => {

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -176,7 +176,6 @@ test("accepts every v2-only named command ID", () => {
     "diff.mark_reviewed",
     "opencode.settings",
     "service.restart",
-    "permission.mode",
     "session.cd",
     "app.scrap",
   ]

--- a/services/www/src/docs/content/cli/config.mdx
+++ b/services/www/src/docs/content/cli/config.mdx
@@ -134,6 +134,22 @@ Configure notifications and sounds:
 | `sound_pack`    | string                 | Selects the active sound pack.                                                                       |
 | `sounds`        | object                 | Overrides files for `default`, `question`, `permission`, `error`, `done`, or `subagent_done` events. |
 
+## Session
+
+Choose whether the TUI prompts before granting permission requests:
+
+```json title="cli.json"
+{
+  "session": {
+    "permissions": "prompt"
+  }
+}
+```
+
+| Field         | Values                   | Description                                                             |
+| ------------- | ------------------------ | ----------------------------------------------------------------------- |
+| `permissions` | `prompt` or `autoaccept` | Prompts for permission requests or accepts every request automatically. |
+
 ## Diffs
 
 Configure diff presentation:


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `session.permissions` to `cli.json` with `prompt` and `autoaccept` modes. The setting replaces the dedicated permission command and keybind. Starting the TUI with `--auto` still enables auto-accept for that process without changing the config file.

### How did you verify your code works?

- TUI and CLI typechecks
- Full repository pre-push typecheck
- Relevant TUI suite, with the adjusted settings test rerun successfully
- CLI config tests (16 passing)
- Website typecheck, generated-file check, and production build

### Screenshots / recordings

Not included; this adds an entry to the existing settings dialog.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
