### PR TITLE
feat(release): isolate v2 stable publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
         required: false
         type: string
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version || inputs.bump }}
+concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref_name == 'v2' && (inputs.version || inputs.bump) && 'release') || inputs.version || inputs.bump }}
 
 permissions:
   id-token: write
@@ -33,7 +33,7 @@ permissions:
   packages: write
 
 env:
-  OPENCODE_CHANNEL: ${{ (github.ref_name == 'v2' && 'dev') || '' }}
+  OPENCODE_CHANNEL: ${{ (github.ref_name == 'v2' && !inputs.bump && !inputs.version && 'dev') || '' }}
 
 jobs:
   version:
@@ -378,7 +378,7 @@ jobs:
     needs:
       - version
       - sign-cli-macos
-    if: github.repository == 'anomalyco/opencode' && github.ref_name != 'v2'
+    if: github.repository == 'anomalyco/opencode' && (github.ref_name != 'v2' || needs.version.outputs.release != '')
     continue-on-error: false
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/ai": {
       "name": "@opencode/ai",
-      "version": "1.17.20",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.1057.0",
         "@opencode/schema": "workspace:*",
@@ -53,7 +53,7 @@
     },
     "packages/app": {
       "name": "@opencode/app",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -111,7 +111,7 @@
     },
     "packages/cli": {
       "name": "@opencode/cli",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "bin": {
         "opencode2": "./bin/opencode2.cjs",
       },
@@ -175,7 +175,7 @@
     },
     "packages/client": {
       "name": "@opencode/client",
-      "version": "1.17.13",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/protocol": "workspace:*",
         "@opencode/schema": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/codemode": {
       "name": "@opencode/codemode",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -215,7 +215,7 @@
     },
     "packages/console/app": {
       "name": "@opencode/console-app",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -251,7 +251,7 @@
     },
     "packages/console/core": {
       "name": "@opencode/console-core",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -278,7 +278,7 @@
     },
     "packages/console/function": {
       "name": "@opencode/console-function",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@openauthjs/openauth": "0.0.0-20250322224806",
         "@opencode/console-core": "workspace:*",
@@ -295,7 +295,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode/console-mail",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -319,7 +319,7 @@
     },
     "packages/console/support": {
       "name": "@opencode/console-support",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode/console-core": "workspace:*",
@@ -339,7 +339,7 @@
     },
     "packages/core": {
       "name": "@opencode/core",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "dependencies": {
         "@ai-sdk/alibaba": "1.0.17",
         "@ai-sdk/anthropic": "3.0.82",
@@ -411,7 +411,7 @@
     },
     "packages/desktop": {
       "name": "@opencode/desktop",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "electron-context-menu": "4.1.2",
@@ -463,7 +463,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode/enterprise",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/sdk": "1.18.21",
@@ -500,7 +500,7 @@
     },
     "packages/function": {
       "name": "@opencode/function",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -516,7 +516,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode/http-recorder",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@effect/platform-node-shared": "4.0.0-rc.112",
       },
@@ -535,7 +535,7 @@
     },
     "packages/httpapi-codegen": {
       "name": "@opencode/httpapi-codegen",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "effect": "catalog:",
         "prettier": "3.6.2",
@@ -548,7 +548,7 @@
     },
     "packages/latex": {
       "name": "@opencode/latex",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/plugin": "workspace:*",
         "@opentui/core": "catalog:",
@@ -562,7 +562,7 @@
     },
     "packages/merman": {
       "name": "@opencode/merman",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/plugin": "workspace:*",
         "@opentui/core": "catalog:",
@@ -577,7 +577,7 @@
     },
     "packages/plugin": {
       "name": "@opencode/plugin",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode/ai": "workspace:*",
@@ -616,7 +616,7 @@
     },
     "packages/plugin-browser": {
       "name": "@opencode/plugin-browser",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/plugin": "workspace:*",
         "@opencode/schema": "workspace:*",
@@ -646,7 +646,7 @@
     },
     "packages/protocol": {
       "name": "@opencode/protocol",
-      "version": "1.17.11",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/schema": "workspace:*",
         "effect": "catalog:",
@@ -661,7 +661,7 @@
     },
     "packages/schema": {
       "name": "@opencode/schema",
-      "version": "1.17.11",
+      "version": "2.0.0",
       "dependencies": {
         "@standard-schema/spec": "catalog:",
         "effect": "catalog:",
@@ -685,7 +685,7 @@
     },
     "packages/sdk": {
       "name": "@opencode/sdk",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/client": "workspace:*",
         "@opencode/core": "workspace:*",
@@ -706,7 +706,7 @@
     },
     "packages/server": {
       "name": "@opencode/server",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@effect/platform-node-shared": "catalog:",
@@ -728,7 +728,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode/session-ui",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode/client": "workspace:*",
@@ -763,7 +763,7 @@
     },
     "packages/simulation": {
       "name": "@opencode/simulation",
-      "version": "1.17.13",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/ai": "workspace:*",
         "@opencode/core": "workspace:*",
@@ -783,7 +783,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode/stats-app",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -817,7 +817,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode/stats-core",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -836,7 +836,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode/stats-server",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -882,7 +882,7 @@
     },
     "packages/theme": {
       "name": "@opencode/theme",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@opentui/core": "catalog:",
         "effect": "catalog:",
@@ -896,7 +896,7 @@
     },
     "packages/tui": {
       "name": "@opencode/tui",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "dependencies": {
         "@opencode/client": "workspace:*",
         "@opencode/core": "workspace:*",
@@ -931,7 +931,7 @@
     },
     "packages/ui": {
       "name": "@opencode/ui",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -966,7 +966,7 @@
     },
     "packages/util": {
       "name": "@opencode/util",
-      "version": "1.18.3",
+      "version": "2.0.0",
       "dependencies": {
         "@effect/opentelemetry": "catalog:",
         "@effect/platform-node": "catalog:",
@@ -999,7 +999,7 @@
     },
     "packages/web": {
       "name": "@opencode/web",
-      "version": "1.18.15",
+      "version": "2.0.0",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",
@@ -1040,7 +1040,7 @@
     },
     "services/update": {
       "name": "@opencode/update",
-      "version": "1.18.4",
+      "version": "2.0.0",
       "dependencies": {
         "jose": "6.0.11",
         "semver": "catalog:",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencode",
   "description": "AI-powered development tool",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.4.2",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.20",
+  "version": "2.0.0",
   "name": "@opencode/ai",
   "type": "module",
   "license": "MIT",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/app",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine AS base
+
+ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
+RUN apk add --no-cache libgcc libstdc++ ripgrep
+
+FROM base AS build-amd64
+COPY dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
+
+FROM base AS build-arm64
+COPY dist/opencode-linux-arm64-musl/bin/opencode /usr/local/bin/opencode
+
+ARG TARGETARCH
+FROM build-${TARGETARCH}
+RUN opencode --version
+ENTRYPOINT ["opencode"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/cli",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/cli/script/publish.ts
+++ b/packages/cli/script/publish.ts
@@ -147,6 +147,10 @@ if (existsSync(path.join(root, "node"))) {
   })
 }
 
+if (Script.channel === "latest" && Script.release && !dryRun) {
+  await $`docker buildx build --platform linux/amd64,linux/arm64 --tag ghcr.io/anomalyco/opencode:${Script.version} --push .`
+}
+
 if (Script.channel === "beta" && Script.release) {
   await $`bun ./script/publish-aur.ts ${dryRun ? ["--dry-run"] : []}`.env({ ...process.env, OPENCODE_CLI_DIST: root })
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/client",
-  "version": "1.17.13",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/codemode",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "description": "Effect-native confined code execution over schema-described tools",
   "type": "module",
   "license": "MIT",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/console-app",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/console-core",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/console-function",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/console-mail",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/console-support",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "name": "@opencode/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode/desktop",
   "private": true,
-  "version": "1.18.15",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/desktop/scripts/publish.ts
+++ b/packages/desktop/scripts/publish.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env bun
 
 import { Script } from "@opencode/script"
-import { $ } from "bun"
-import path from "node:path"
 import { UpdateArtifact } from "../../../script/update-artifact"
 
 const dryRun = process.argv.includes("--dry-run")
@@ -10,11 +8,8 @@ if (!Script.release) {
   console.log("skipped desktop publication without a release")
   process.exit(0)
 }
-const repo = process.env.GH_REPO
-if (!repo) throw new Error("GH_REPO is required")
 const directory = process.env.OPENCODE_DESKTOP_DIST
 if (!directory) throw new Error("OPENCODE_DESKTOP_DIST is required")
-const tag = `v${Script.version}`
 const files = (
   await Array.fromAsync(
     new Bun.Glob("*.{exe,blockmap,dmg,zip,AppImage,deb,rpm,app.tar.gz}").scan({ cwd: directory, absolute: true }),
@@ -22,24 +17,16 @@ const files = (
 ).sort()
 if (!files.length) throw new Error("No desktop release files found")
 
-if (!dryRun) {
-  await $`gh release upload ${tag} ${files} --clobber --repo ${repo}`
-  await $`bun ${path.join(import.meta.dir, "finalize-latest-json.ts")}`
-  await $`bun ${path.join(import.meta.dir, "finalize-latest-yml.ts")}`
-}
-
 const uploaded = await UpdateArtifact.upload({ version: Script.version, files, dryRun })
-const artifacts = [
-  { distribution: "github", metadata: await metadata(Script.version, repo) },
-  { distribution: "opencode", metadata: { files: uploaded, ...(await metadata(Script.version, repo, uploaded)) } },
-]
-
-if (!dryRun) await $`gh release edit ${tag} --draft=false --repo ${repo}`
-for (const artifact of artifacts) {
-  const input = { ...artifact, channel: Script.channel, name: "desktop", version: Script.version }
-  if (dryRun) console.log(`dry-run artifact: ${JSON.stringify(input)}`)
-  if (!dryRun) await UpdateArtifact.publish(input)
+const artifact = {
+  channel: Script.channel,
+  name: "desktop",
+  distribution: "opencode",
+  version: Script.version,
+  metadata: { files: uploaded, ...(await metadata(Script.version, uploaded)) },
 }
+if (dryRun) console.log(`dry-run artifact: ${JSON.stringify(artifact)}`)
+if (!dryRun) await UpdateArtifact.publish(artifact)
 
 type DesktopFile = {
   url: string
@@ -48,26 +35,53 @@ type DesktopFile = {
   blockMapSize?: number
 }
 
-async function metadata(version: string, repo: string, files?: Record<string, { url: string }>) {
-  const directory = process.env.RUNNER_TEMP ?? "/tmp"
+async function metadata(version: string, files: Record<string, { url: string }>) {
+  const directory = process.env.LATEST_YML_DIR
+  if (!directory) throw new Error("LATEST_YML_DIR is required")
   const entries = await Promise.all(
     [
-      ["desktop.yml", "latest.yml"],
-      ["desktop-mac.yml", "latest-mac.yml"],
-      ["desktop-linux.yml", "latest-linux.yml"],
-      ["desktop-linux-arm64.yml", "latest-linux-arm64.yml"],
-    ].map(async ([name, source]) => {
-      const file = Bun.file(`${directory}/${source}`)
-      if (!(await file.exists())) return undefined
-      return [name, parse(await file.text(), version, repo, files)] as const
+      {
+        name: "desktop.yml",
+        sources: [
+          ["latest-yml-aarch64-pc-windows-msvc", "latest.yml"],
+          ["latest-yml-x86_64-pc-windows-msvc", "latest.yml"],
+        ],
+      },
+      {
+        name: "desktop-mac.yml",
+        sources: [
+          ["latest-yml-aarch64-apple-darwin", "latest-mac.yml"],
+          ["latest-yml-x86_64-apple-darwin", "latest-mac.yml"],
+        ],
+      },
+      { name: "desktop-linux.yml", sources: [["latest-yml-x86_64-unknown-linux-gnu", "latest-linux.yml"]] },
+      {
+        name: "desktop-linux-arm64.yml",
+        sources: [["latest-yml-aarch64-unknown-linux-gnu", "latest-linux-arm64.yml"]],
+      },
+    ].map(async (item) => {
+      const manifests = (
+        await Promise.all(
+          item.sources.map(async ([subdirectory, source]) => {
+            const file = Bun.file(`${directory}/${subdirectory}/${source}`)
+            if (!(await file.exists())) return undefined
+            return parse(await file.text(), version, files)
+          }),
+        )
+      ).filter((manifest) => manifest !== undefined)
+      if (manifests.length !== item.sources.length) return undefined
+      return [
+        item.name,
+        { files: manifests.flatMap((manifest) => manifest.files), releaseDate: manifests[0]!.releaseDate },
+      ] as const
     }),
   )
+  if (entries.some((entry) => entry === undefined)) throw new Error("Desktop update metadata is incomplete")
   const manifests = Object.fromEntries(entries.filter((entry) => entry !== undefined))
-  if (!Object.keys(manifests).length) throw new Error("No desktop update metadata found")
   return { manifests }
 }
 
-function parse(content: string, version: string, repo: string, uploaded?: Record<string, { url: string }>) {
+function parse(content: string, version: string, uploaded: Record<string, { url: string }>) {
   const lines = content.split("\n")
   const found = lines
     .find((line) => line.startsWith("version:"))
@@ -86,11 +100,7 @@ function parse(content: string, version: string, repo: string, uploaded?: Record
     if (value.startsWith("- url:")) {
       const name = value.slice("- url:".length).trim()
       const filename = name.startsWith("http") ? decodeURIComponent(new URL(name).pathname.split("/").pop()!) : name
-      const url = uploaded
-        ? uploaded[filename]?.url
-        : name.startsWith("http")
-          ? name
-          : `https://github.com/${repo}/releases/download/v${version}/${encodeURIComponent(name)}`
+      const url = uploaded[filename]?.url
       if (!url) throw new Error(`Desktop update file was not uploaded: ${filename}`)
       files.push({ url, sha512: "", size: 0 })
       return

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/enterprise",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/function",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "name": "@opencode/http-recorder",
   "description": "Record and replay Effect HTTP and WebSocket traffic with deterministic cassettes",
   "type": "module",

--- a/packages/httpapi-codegen/package.json
+++ b/packages/httpapi-codegen/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/httpapi-codegen",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/latex/package.json
+++ b/packages/latex/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/latex",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/merman/package.json
+++ b/packages/merman/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/merman",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-browser/package.json
+++ b/packages/plugin-browser/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/plugin-browser",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "description": "OpenCode's desktop browser plugin",
   "type": "module",
   "license": "MIT",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/plugin",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/protocol",
-  "version": "1.17.11",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/schema",
-  "version": "1.17.11",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -40,6 +40,7 @@ const VERSION = await (async () => {
       return res.json()
     })
     .then((data: any) => data.version)
+  if (semver.lt(version, "2.0.0")) return "2.0.0"
   const [major, minor, patch] = version.split(".").map((x: string) => Number(x) || 0)
   const t = env.OPENCODE_BUMP?.toLowerCase()
   if (t === "major") return `${major + 1}.0.0`

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "name": "@opencode/sdk",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/server",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/session-ui",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/simulation/package.json
+++ b/packages/simulation/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/simulation",
-  "version": "1.17.13",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/stats-app",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/stats-core",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/stats-server",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/theme",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/tui",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode/ui",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/util",
-  "version": "1.18.3",
+  "version": "2.0.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -34,6 +34,8 @@ if (Script.release && !Script.preview) {
 
 await prepareReleaseFiles()
 
+if (Script.release) await $`bun ./packages/desktop/scripts/publish.ts --dry-run`
+
 console.log("\n=== schema ===\n")
 await $`bun ./packages/schema/script/publish.ts`
 
@@ -80,16 +82,18 @@ console.log("\n=== ui ===\n")
 await $`bun ./packages/ui/script/publish.ts`
 
 if (Script.release && !Script.preview) {
-  await $`git commit -am "release: ${tag}"`
+  if ((await $`git diff --quiet`.nothrow()).exitCode !== 0) await $`git commit -am "release: ${tag}"`
   await $`git tag -d ${tag}`.nothrow()
   await $`git tag ${tag}`
   await $`git push origin refs/tags/${tag} --force-with-lease --no-verify`
   await new Promise((resolve) => setTimeout(resolve, 5_000))
   await $`git fetch origin`
-  await $`git checkout -B dev origin/dev`
+  await $`git checkout -B v2 origin/v2`
   await prepareReleaseFiles()
-  await $`git commit -am "sync release versions for ${tag}"`
-  await $`git push origin HEAD:dev --no-verify`
+  if ((await $`git diff --quiet`.nothrow()).exitCode !== 0) {
+    await $`git commit -am "sync release versions for ${tag}"`
+    await $`git push origin HEAD:v2 --no-verify`
+  }
 }
 
 if (Script.release) {

--- a/script/release
+++ b/script/release
@@ -1,3 +1,17 @@
 #!/usr/bin/env bash
 
-gh workflow run publish.yml --ref v2
+VERSION=${1:-patch}
+
+case "$VERSION" in
+  major|minor|patch)
+    gh workflow run publish.yml --ref v2 -f bump="$VERSION"
+    ;;
+  *)
+    if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+      gh workflow run publish.yml --ref v2 -f version="$VERSION"
+      exit 0
+    fi
+    echo "usage: $0 [major|minor|patch|version]" >&2
+    exit 1
+    ;;
+esac

--- a/script/version.ts
+++ b/script/version.ts
@@ -1,30 +1,12 @@
 #!/usr/bin/env bun
 
 import { Script } from "@opencode/script"
-import { $ } from "bun"
 
 const output = [`version=${Script.version}`]
-const sha = process.env.GITHUB_SHA ?? (await $`git rev-parse HEAD`.text()).trim()
 
-if (!Script.preview) {
-  await $`bun script/changelog.ts --to ${sha}`.cwd(process.cwd())
-  const file = `${process.cwd()}/UPCOMING_CHANGELOG.md`
-  const body = await Bun.file(file)
-    .text()
-    .catch(() => "No notable changes")
-  const dir = process.env.RUNNER_TEMP ?? "/tmp"
-  const notesFile = `${dir}/opencode-release-notes.txt`
-  await Bun.write(notesFile, body)
-  await $`gh release create v${Script.version} -d --target ${sha} --title "v${Script.version}" --notes-file ${notesFile}`
-  const release = await $`gh release view v${Script.version} --json tagName,databaseId`.json()
-  output.push(`release=${release.databaseId}`)
-  output.push(`tag=${release.tagName}`)
-} else if (Script.channel === "beta") {
-  await $`gh release create v${Script.version} -d --title "v${Script.version}" --repo ${process.env.GH_REPO}`
-  const release =
-    await $`gh release view v${Script.version} --json tagName,databaseId --repo ${process.env.GH_REPO}`.json()
-  output.push(`release=${release.databaseId}`)
-  output.push(`tag=${release.tagName}`)
+if (!Script.preview || Script.channel === "beta") {
+  output.push("release=true")
+  output.push(`tag=v${Script.version}`)
 }
 
 output.push(`repo=${process.env.GH_REPO}`)

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.15",
+  "version": "2.0.0",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",

--- a/services/update/package.json
+++ b/services/update/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode/update",
-  "version": "1.18.4",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/update/src/index.ts
+++ b/services/update/src/index.ts
@@ -520,7 +520,7 @@ export function validGitHubClaims(claims: JWTPayload): claims is GitHubClaims {
 
 export function channelsForRef(ref: string) {
   if (ref === "refs/heads/dev") return ["dev", "latest"]
-  if (ref === "refs/heads/v2") return ["dev"]
+  if (ref === "refs/heads/v2") return ["dev", "latest"]
   if (ref === "refs/heads/beta") return ["beta"]
   if (ref === "refs/heads/ci") return ["ci"]
   if (ref === "refs/heads/fix/npm-native-binary-install") return ["fix/npm-native-binary-install"]


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an isolated V2 stable release path starting at 2.0.0. V2 publishes the `@opencode/*` npm packages to `latest`, syncs release versions only to `v2`, and keeps V1's `dev` branch and package namespaces untouched.

Desktop artifacts move off GitHub Releases onto the V2 R2/update-service feed. Stable AUR publishing remains disabled, while Docker publishes only immutable `2.x` tags without updating `:latest`.

### How did you verify your code works?

- Full pre-push monorepo typecheck: 35 tasks passed
- GitHub workflow validated with actionlint
- Desktop artifact aggregation and update metadata exercised with a local dry run
- Release bump and exact-version dispatch paths exercised with stubbed GitHub CLI calls
- Independent release-path audit completed with PASS

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
