### PR TITLE
docs(ecosystem): add jsluice-skill to Projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [jsluice-skill](https://github.com/essopsp/jsluice-skill)                                  | opencode skill for extracting URLs & secrets from JS via jsluice |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A - no issue. Adds a listing to the Ecosystem docs page.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Adds [jsluice-skill](https://github.com/essopsp/jsluice-skill) to the Projects table of the Ecosystem page (packages/web/src/content/docs/ecosystem.mdx). It is a public opencode skill that wraps Bishop Fox's JSLuice CLI for extracting URLs, endpoints, and secrets from JavaScript files during recon and web app assessments. It installs via `npx skills add essopsp/jsluice-skill --skill jsluice` or by copying the folder into `~/.config/opencode/skills/`.

### How did you verify your code works?

- Installed the skill from the repo with the Vercel `skills` CLI to confirm discovery and a clean YAML frontmatter parse.
- Checked the markdown table renders aligned with the existing rows.

### Screenshots / recordings

N/A - docs change.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR