### PR TITLE
fix(release): omit node CLI from latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,7 @@ jobs:
     needs: version
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
-    if: github.repository == 'anomalyco/opencode'
+    if: github.repository == 'anomalyco/opencode' && !(github.ref_name == 'v2' && (inputs.bump || inputs.version))
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
@@ -221,7 +221,7 @@ jobs:
     needs:
       - version
       - build-node-app-archive
-    if: github.repository == 'anomalyco/opencode'
+    if: github.repository == 'anomalyco/opencode' && !(github.ref_name == 'v2' && (inputs.bump || inputs.version))
     strategy:
       fail-fast: false
       matrix:

--- a/packages/cli/script/publish.ts
+++ b/packages/cli/script/publish.ts
@@ -136,7 +136,7 @@ await publishDistribution({
   packagePrefix: "@opencode/cli-",
   artifact: "cli",
 })
-if (existsSync(path.join(root, "node"))) {
+if (Script.channel !== "latest" && existsSync(path.join(root, "node"))) {
   await publishDistribution({
     root: path.join(root, "node"),
     name: "@opencode/cli-node",


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Excludes the experimental Node CLI distribution from official `latest` releases. Dev and beta builds remain unchanged. The publisher also guards against publishing Node artifacts on `latest`.

### How did you verify your code works?

- Full pre-push monorepo typecheck passed
- Workflow validated with actionlint
- CLI package typecheck passed

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR