### PR TITLE
fix(tui): defer named-theme palette detection

### DIFF
--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -184,7 +184,11 @@ const themeContext = createSimpleContext({
     }
 
     onMount(() => {
-      void Promise.allSettled([resolveSystemTheme(store.mode), syncCustomThemes()]).finally(() => {
+      const systemTheme = resolveSystemTheme(store.mode)
+      void Promise.allSettled([
+        store.active === "system" ? systemTheme : Promise.resolve(),
+        syncCustomThemes(),
+      ]).finally(() => {
         valuesV2()
         setStore("ready", true)
       })


### PR DESCRIPTION
## Summary

Terminal palette detection already starts before `ThemeProvider` mounts. Previously, startup always waited for that request before making the selected theme ready—even when a named theme such as `opencode` does not use terminal palette colors.

This keeps palette discovery exactly where it is and changes only what startup waits for:

- `system` theme: wait for terminal colors, unchanged
- named themes: continue palette discovery in the background and wait only for custom-theme discovery

The production diff is one five-line change in `ThemeProvider`; there are no timers, new public APIs, or cross-component lifecycle coordination.

## Performance

Final formulation, 15 interleaved exact Bun 1.4.2 compiled runs through a non-backpressured PTY against the same warm server:

| milestone | before median | after median |
| --- | ---: | ---: |
| prompt bytes | 401.2ms | **97.3ms** |
| immediate typed echo | 418.4ms | **113.8ms** |

The result varies with machine/load, but consistently removes the terminal palette detector's roughly 300ms timeout from named-theme readiness.

A separate corrected 30-run benchmark confirmed explicit `system` is flat (prompt bytes 445.1ms before vs 446.7ms after).

The PTY harness drains until `EAGAIN`; a one-call 5,502-byte frame arrives in 0.112ms median, avoiding terminal-control recorder backpressure that affected early measurements.

## UX verification

| scenario | result |
| --- | --- |
| default `opencode` | same stable colors/layout; visible sooner |
| other named/custom themes | custom discovery is still awaited; palette discovery remains background-only |
| explicit `system` | same palette wait and generated colors |
| explicit light/dark mode | unchanged code path |
| terminal theme notification | unchanged refresh path |
| switching to `system` | palette discovery starts at the same absolute time as before |
| cleanup/shutdown | unchanged; no new resources or listeners |

Baseline and changed binaries were also captured after settling at narrow width for default and system configurations; stable visual output matched aside from randomized placeholder text.

## Verification

- TUI typecheck
- Existing theme and lifecycle tests: 39 passed
- Exact Bun 1.4.2 compiled build
- Default and system terminal captures
- Immediate input/echo probe

No new tests are added by this PR.