### PR TITLE
fix(release): use V2 Docker artifact paths

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -5,10 +5,10 @@ ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 RUN apk add --no-cache libgcc libstdc++ ripgrep
 
 FROM base AS build-amd64
-COPY dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
+COPY dist/cli-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
 
 FROM base AS build-arm64
-COPY dist/opencode-linux-arm64-musl/bin/opencode /usr/local/bin/opencode
+COPY dist/cli-linux-arm64-musl/bin/opencode /usr/local/bin/opencode
 
 ARG TARGETARCH
 FROM build-${TARGETARCH}


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the V2 Docker image to copy the actual `cli-linux-*` build artifact directories. The first 2.0.0 attempt published some npm packages before failing because the Dockerfile still referenced the legacy `opencode-linux-*` paths.

### How did you verify your code works?

- Artifact directory names verified from release output
- Full pre-push monorepo typecheck passed

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR