### PR TITLE
docs: use stable V2 packages

### DIFF
--- a/services/www/src/docs/content/build/client/effect.mdx
+++ b/services/www/src/docs/content/build/client/effect.mdx
@@ -6,7 +6,7 @@ title: "Effect"
 and decodes responses into OpenCode schema values.
 
 ```sh
-bun add @opencode/client@beta effect
+bun add @opencode/client effect
 ```
 
 ## Create a client

--- a/services/www/src/docs/content/build/client/index.mdx
+++ b/services/www/src/docs/content/build/client/index.mdx
@@ -10,7 +10,7 @@ network. Its native types and methods are generated from the same contract as th
 ## Install
 
 ```sh
-bun add @opencode/client@beta
+bun add @opencode/client
 ```
 
 ## Create a client

--- a/services/www/src/docs/content/build/plugins/effect.mdx
+++ b/services/www/src/docs/content/build/plugins/effect.mdx
@@ -7,7 +7,7 @@ Effects or Streams, callbacks return Effects, and plugin lifetime is represented
 plugin package.
 
 ```sh
-bun add @opencode/plugin@beta effect
+bun add @opencode/plugin effect
 ```
 
 Export an Effect plugin from `.opencode/plugins/` to load it automatically.

--- a/services/www/src/docs/content/build/sdk/cloudflare.mdx
+++ b/services/www/src/docs/content/build/sdk/cloudflare.mdx
@@ -6,7 +6,7 @@ Use `@opencode/sdk/workerd` inside a Cloudflare Durable Object. This profile use
 persists durable events for eviction recovery, and replaces unavailable local filesystem and process services.
 
 ```sh
-bun add @opencode/sdk@beta
+bun add @opencode/sdk
 ```
 
 Hold one host for the lifetime of the Durable Object instance instead of creating one for every request.

--- a/services/www/src/docs/content/build/sdk/effect.mdx
+++ b/services/www/src/docs/content/build/sdk/effect.mdx
@@ -6,7 +6,7 @@ title: "Effect"
 the owning Scope releases the router, Location services, fibers, and plugin registrations.
 
 ```sh
-bun add @opencode/sdk@beta effect
+bun add @opencode/sdk effect
 ```
 
 ## Create a host

--- a/services/www/src/docs/content/build/sdk/index.mdx
+++ b/services/www/src/docs/content/build/sdk/index.mdx
@@ -12,7 +12,7 @@ For Cloudflare Durable Objects, see the [Cloudflare guide](/build/sdk/cloudflare
 Install the SDK:
 
 ```sh
-bun add @opencode/sdk@beta
+bun add @opencode/sdk
 ```
 
 ## Create a host

--- a/services/www/src/docs/content/cli/commands.mdx
+++ b/services/www/src/docs/content/cli/commands.mdx
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install --global @opencode/cli@beta
+      - run: npm install --global @opencode/cli
       - run: opencode run --standalone --model anthropic/claude-sonnet-4-5 "Review this repository for correctness and summarize any issues."
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/services/www/src/docs/content/index.mdx
+++ b/services/www/src/docs/content/index.mdx
@@ -10,11 +10,10 @@ OpenCode installs and runs as `opencode`.
 
 <div data-install-code>
   <CodeBlock
-    code={`$ npm install -g @opencode/cli@beta
-$ bun install -g --trust @opencode/cli@beta
-$ pnpm add -g --allow-build=@opencode/cli @opencode/cli@beta
-$ yarn global add @opencode/cli@beta
-$ paru -S opencode-beta
+    code={`$ npm install -g @opencode/cli
+$ bun install -g --trust @opencode/cli
+$ pnpm add -g --allow-build=@opencode/cli @opencode/cli
+$ yarn global add @opencode/cli
 $ curl -fsSL https://opencode.ai/v2/install | bash`}
   />
 </div>
@@ -22,10 +21,9 @@ $ curl -fsSL https://opencode.ai/v2/install | bash`}
 The npm package uses a trusted postinstall script to select the native `opencode` binary for your platform. The Bun and pnpm
 commands above explicitly allow that script to run.
 
-On Arch Linux, install [`opencode-beta`](https://aur.archlinux.org/packages/opencode-beta) from the AUR with `paru`.
-It provides the `opencode` command; manage updates through your AUR helper.
+Docker images use versioned tags, for example `ghcr.io/anomalyco/opencode:2.0.0`.
 
-Homebrew, Windows package managers, Docker, and standalone binaries are not supported.
+Homebrew, AUR, Windows package managers, and standalone binaries are not supported.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates V2 installation, client, SDK, plugin, and command examples to use the stable `@opencode/*` packages instead of `@beta`. Removes the beta-only AUR recommendation and documents the versioned Docker image.

### How did you verify your code works?

- `bun typecheck`
- `bun run check:generated`
- `bun run build`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR