### PR TITLE
fix(ai): omit empty Bedrock tool descriptions

### DIFF
--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -106,7 +106,7 @@ type BedrockSystemBlock = Schema.Schema.Type<typeof BedrockSystemBlock>
 const BedrockToolSpec = Schema.Struct({
   toolSpec: Schema.Struct({
     name: Schema.String,
-    description: Schema.String,
+    description: Schema.optional(Schema.String),
     inputSchema: Schema.Struct({
       json: JsonObject,
     }),
@@ -222,7 +222,7 @@ type BedrockEvent = Schema.Schema.Type<typeof BedrockEvent>
 const lowerToolSpec = (tool: ToolDefinition, inputSchema: JsonSchema): BedrockToolSpec => ({
   toolSpec: {
     name: tool.name,
-    description: tool.description,
+    ...(tool.description.trim().length > 0 ? { description: tool.description } : {}),
     inputSchema: { json: inputSchema },
   },
 })

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -279,6 +279,52 @@ describe("Bedrock Converse route", () => {
       })
     }),
   )
+  ;["", " \t\r\n"].forEach((description) => {
+    it.effect(`omits blank tool description ${JSON.stringify(description)}`, () =>
+      Effect.gen(function* () {
+        const prepared = yield* compileRequest(
+          LLMRequest.update(baseRequest, {
+            tools: [
+              ToolDefinition.make({
+                name: "lookup",
+                description,
+                inputSchema: { type: "object", properties: { query: { type: "string" } } },
+              }),
+            ],
+          }),
+        )
+
+        expect(prepared.body.toolConfig.tools).toEqual([
+          {
+            toolSpec: {
+              name: "lookup",
+              inputSchema: { json: { type: "object", properties: { query: { type: "string" } } } },
+            },
+          },
+        ])
+        expect(prepared.body.toolConfig.tools[0].toolSpec).not.toHaveProperty("description")
+      }),
+    )
+  })
+
+  it.effect("preserves meaningful tool descriptions including surrounding whitespace", () =>
+    Effect.gen(function* () {
+      const description = " \tLookup data.\n"
+      const prepared = yield* compileRequest(
+        LLMRequest.update(baseRequest, {
+          tools: [
+            ToolDefinition.make({
+              name: "lookup",
+              description,
+              inputSchema: { type: "object" },
+            }),
+          ],
+        }),
+      )
+
+      expect(prepared.body.toolConfig.tools[0].toolSpec.description).toBe(description)
+    }),
+  )
 
   it.effect("keeps tools and omits the unsupported choice when tool choice is none", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Problem

Bedrock Converse rejects an empty `toolSpec.description` with HTTP 400 because a supplied description must contain at least one character. Tools with empty descriptions currently emit that invalid field.

## Fix

- Make the Bedrock tool description optional in its wire schema.
- Omit the field when the canonical description is empty or whitespace-only.
- Preserve meaningful descriptions exactly, including surrounding whitespace.
- Add provider regression tests through the actual request compiler for empty, whitespace-only, and meaningful descriptions.

## Validation

- Confirmed both blank-description regression cases fail before the fix.
- `RECORD=false bun test test/provider/bedrock-converse.test.ts --timeout 30000 --only-failures` from `packages/ai`: **79 passed, 0 failed**.
- `bun typecheck` from `packages/ai`: passed.
- Prettier check for both changed files and `git diff --check`: passed.
- Previously captured live Bedrock Converse validation using `global.anthropic.claude-sonnet-5` in `us-east-1`: an empty description returned HTTP 400 with the minimum-length validation error; omitting the description returned HTTP 200 with text `OK`.