### PR TITLE
docs(web): remove "/details" command from docs website

### DIFF
--- a/packages/web/src/content/docs/ar/tui.mdx
+++ b/packages/web/src/content/docs/ar/tui.mdx
@@ -91,18 +91,6 @@ How is auth handled in @packages/functions/src/api/index.ts?
 
 ---
 
-### details
-
-بدّل عرض تفاصيل تنفيذ الأدوات.
-
-```bash frame="none"
-/details
-```
-
-**اختصار لوحة المفاتيح:** `ctrl+x d`
-
----
-
 ### editor
 
 افتح محررا خارجيا لكتابة الرسائل. يستخدم المحرر المحدد في متغير البيئة `EDITOR`. [اعرف المزيد](#editor-setup).

--- a/packages/web/src/content/docs/bs/tui.mdx
+++ b/packages/web/src/content/docs/bs/tui.mdx
@@ -91,18 +91,6 @@ Sažimanje trenutne sesije. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Prebacite detalje o izvršavanju alata.
-
-```bash frame="none"
-/details
-```
-
-**Tastatura:** `ctrl+x d`
-
----
-
 ### editor
 
 Otvorite vanjski uređivač za sastavljanje poruka. Koristi editor postavljen u vašoj varijabli okruženja `EDITOR`. [Saznajte više](#editor-setup).

--- a/packages/web/src/content/docs/da/tui.mdx
+++ b/packages/web/src/content/docs/da/tui.mdx
@@ -91,18 +91,6 @@ Komprimer nuværende session. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Skift visning af værktøjsudførelsesdetaljer.
-
-```bash frame="none"
-/details
-```
-
-**Genvejstast:** `ctrl+x d`
-
----
-
 ### editor
 
 Åbn eksternt redigeringsprogram for at skrive beskeder. Bruger redigeringsprogrammet i miljøvariablen `EDITOR`. [Læs mere](#editor-setup).

--- a/packages/web/src/content/docs/de/tui.mdx
+++ b/packages/web/src/content/docs/de/tui.mdx
@@ -94,18 +94,6 @@ Kompaktiert die aktuelle Session. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Schaltet Tool-Ausfuehrungsdetails um.
-
-```bash frame="none"
-/details
-```
-
-**Keybind:** `ctrl+x d`
-
----
-
 ### editor
 
 Oeffnet externen Editor zum Verfassen von Nachrichten. Nutzt den in der `EDITOR`-Umgebungsvariable gesetzten Editor. [Mehr dazu](#editor-setup).

--- a/packages/web/src/content/docs/es/tui.mdx
+++ b/packages/web/src/content/docs/es/tui.mdx
@@ -91,18 +91,6 @@ Compacta la sesión actual. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Alternar detalles de ejecución de la herramienta.
-
-```bash frame="none"
-/details
-```
-
-**Combinación de teclas:** `ctrl+x d`
-
----
-
 ### editor
 
 Abra un editor externo para redactar mensajes. Utiliza el editor configurado en su variable de entorno `EDITOR`. [Más información](#editor-setup).

--- a/packages/web/src/content/docs/fr/tui.mdx
+++ b/packages/web/src/content/docs/fr/tui.mdx
@@ -91,18 +91,6 @@ Compactez la session en cours. _Alias_ : `/summarize`
 
 ---
 
-### details
-
-Basculer les détails d'exécution de l'outil.
-
-```bash frame="none"
-/details
-```
-
-**Reliure de touches :** `ctrl+x d`
-
----
-
 ### editor
 
 Ouvrez un éditeur externe pour rédiger des messages. Utilise l'éditeur défini dans votre variable d'environnement `EDITOR`. [En savoir plus](#editor-setup).

--- a/packages/web/src/content/docs/fr/tui.mdx
+++ b/packages/web/src/content/docs/fr/tui.mdx
@@ -81,7 +81,7 @@ Ajoutez un fournisseur à OpenCode. Vous permet de sélectionner parmi les fourn
 
 ### compact
 
-Compactez la session en cours. *Alias* : `/summarize`
+Compactez la session en cours. _Alias_ : `/summarize`
 
 ```bash frame="none"
 /compact
@@ -117,7 +117,7 @@ Ouvrez un éditeur externe pour rédiger des messages. Utilise l'éditeur défin
 
 ### exit
 
-Quittez OpenCode. *Alias* : `/quit`, `/q`
+Quittez OpenCode. _Alias_ : `/quit`, `/q`
 
 ```bash frame="none"
 /exit
@@ -177,7 +177,7 @@ Liste des modèles disponibles.
 
 ### new
 
-Démarrez une nouvelle session. *Alias* : `/clear`
+Démarrez une nouvelle session. _Alias_ : `/clear`
 
 ```bash frame="none"
 /new
@@ -208,7 +208,7 @@ En interne, cela utilise Git pour gérer les modifications de fichiers. Votre pr
 
 ### sessions
 
-Répertoriez et basculez entre les sessions. *Alias* : `/resume`, `/continue`
+Répertoriez et basculez entre les sessions. _Alias_ : `/resume`, `/continue`
 
 ```bash frame="none"
 /sessions

--- a/packages/web/src/content/docs/ko/tui.mdx
+++ b/packages/web/src/content/docs/ko/tui.mdx
@@ -91,18 +91,6 @@ OpenCode에 공급자를 추가합니다. 사용 가능한 공급자 중에서 �
 
 ---
 
-### details
-
-도구 실행 세부 정보 토글.
-
-```bash frame="none"
-/details
-```
-
-**키바인드:** `ctrl+x d`
-
----
-
 ### editor
 
 메시지 작성을 위한 외부 편집기를 엽니다. `EDITOR` 환경 변수에 설정된 편집기를 사용합니다. [더 알아보기](#editor-setup).

--- a/packages/web/src/content/docs/nb/tui.mdx
+++ b/packages/web/src/content/docs/nb/tui.mdx
@@ -91,18 +91,6 @@ Komprimer gjeldende økt. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Veksle visning av verktøydetaljer.
-
-```bash frame="none"
-/details
-```
-
-**Nøkkelbinding:** `ctrl+x d`
-
----
-
 ### editor
 
 Åpne eksternt tekstredigeringsprogram for å skrive meldinger. Bruker redigeringssettet i miljøvariabelen `EDITOR`. [Finn ut mer](#editor-setup).

--- a/packages/web/src/content/docs/pl/tui.mdx
+++ b/packages/web/src/content/docs/pl/tui.mdx
@@ -91,18 +91,6 @@ Kompaktuj bieżącą sesję. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Przełącz szczegóły wykonywania narzędzi.
-
-```bash frame="none"
-/details
-```
-
-**Keybind:** `ctrl+x d`
-
----
-
 ### editor
 
 Otwórz zewnętrzny edytor do tworzenia wiadomości. Używa edytora ustawionego w zmiennej środowiskowej `EDITOR`. [Dowiedz się więcej](#editor-setup).

--- a/packages/web/src/content/docs/pt-br/tui.mdx
+++ b/packages/web/src/content/docs/pt-br/tui.mdx
@@ -91,18 +91,6 @@ Compacte a sessão atual. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Alternar detalhes da execução da ferramenta.
-
-```bash frame="none"
-/details
-```
-
-**Atalho:** `ctrl+x d`
-
----
-
 ### editor
 
 Abra um editor externo para compor mensagens. Usa o editor definido na sua variável de ambiente `EDITOR`. [Saiba mais](#editor-setup).

--- a/packages/web/src/content/docs/ru/tui.mdx
+++ b/packages/web/src/content/docs/ru/tui.mdx
@@ -91,18 +91,6 @@ How is auth handled in @packages/functions/src/api/index.ts?
 
 ---
 
-### details
-
-Переключить детали выполнения инструмента.
-
-```bash frame="none"
-/details
-```
-
-**Привязка клавиш:** `ctrl+x d`
-
----
-
 ### editor
 
 Открыть внешний редактор для составления сообщений. Использует редактор, установленный в переменной среды `EDITOR`. [Подробнее ](#editor-setup).

--- a/packages/web/src/content/docs/th/tui.mdx
+++ b/packages/web/src/content/docs/th/tui.mdx
@@ -91,18 +91,6 @@ How is auth handled in @packages/functions/src/api/index.ts?
 
 ---
 
-### details
-
-สลับรายละเอียดการดำเนินการของเครื่องมือ
-
-```bash frame="none"
-/details
-```
-
-**ผูกปุ่ม:** `ctrl+x d`
-
----
-
 ### editor
 
 เปิดตัวแก้ไขภายนอกเพื่อเขียนข้อความ ใช้ตัวแก้ไขที่ตั้งค่าไว้ในตัวแปรสภาพแวดล้อม `EDITOR` ของคุณ [เรียนรู้เพิ่มเติม](#editor-setup)

--- a/packages/web/src/content/docs/tr/tui.mdx
+++ b/packages/web/src/content/docs/tr/tui.mdx
@@ -91,18 +91,6 @@ Mevcut oturumu sıkıştırır. _Takma ad_: `/summarize`
 
 ---
 
-### details
-
-Araç çalıştırma detaylarını göster/gizle yapar.
-
-```bash frame="none"
-/details
-```
-
-**Kısayol:** `ctrl+x d`
-
----
-
 ### editor
 
 Mesaj yazmak için harici editör açar. `EDITOR` ortam değişkeninde ayarlı editörü kullanır. [Daha fazla bilgi](#editor-setup).

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -97,16 +97,6 @@ Compact the current session. _Alias_: `/summarize`
 
 ---
 
-### details
-
-Toggle tool execution details.
-
-```bash frame="none"
-/details
-```
-
----
-
 ### editor
 
 Open external editor for composing messages. Uses the editor set in your `EDITOR` environment variable. [Learn more](#editor-setup).

--- a/packages/web/src/content/docs/zh-cn/tui.mdx
+++ b/packages/web/src/content/docs/zh-cn/tui.mdx
@@ -91,18 +91,6 @@ How is auth handled in @packages/functions/src/api/index.ts?
 
 ---
 
-### details
-
-切换工具执行详情的显示。
-
-```bash frame="none"
-/details
-```
-
-**快捷键：** `ctrl+x d`
-
----
-
 ### editor
 
 打开外部编辑器来编写消息。使用 `EDITOR` 环境变量中设置的编辑器。[了解更多](#editor-setup)。

--- a/packages/web/src/content/docs/zh-tw/tui.mdx
+++ b/packages/web/src/content/docs/zh-tw/tui.mdx
@@ -91,18 +91,6 @@ How is auth handled in @packages/functions/src/api/index.ts?
 
 ---
 
-### details
-
-切換工具執行詳情的顯示。
-
-```bash frame="none"
-/details
-```
-
-**快速鍵：** `ctrl+x d`
-
----
-
 ### editor
 
 開啟外部編輯器來撰寫訊息。使用 `EDITOR` 環境變數中設定的編輯器。[了解更多](#editor-setup)。


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/48581

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Removes the "/details" command section from the TUI docs in the website since it doesn't exist.

### How did you verify your code works?

Relevant part was removed from the .mdx files for all languages and confirmed to be rendering correctly.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
