### PR TITLE
fix(cli): spawn managed serve in its own systemd scope

### DIFF
--- a/packages/cli/src/services/daemon.ts
+++ b/packages/cli/src/services/daemon.ts
@@ -119,6 +119,7 @@ export const layer = Layer.effect(
         return yield* Effect.fail(new Error("Failed to resolve CLI entrypoint"))
 
       const args = [...(entrypoint ? [entrypoint] : []), "serve", "--register"]
+      const direct = [process.execPath, ...args]
 
       // `detached` frees the serve from the client's lifetime but not its
       // cgroup: a client under memory/pids limits still starves the shared
@@ -129,38 +130,41 @@ export const layer = Layer.effect(
       const runtime = process.env.XDG_RUNTIME_DIR
       const scoped =
         process.platform === "linux" &&
-        runtime !== undefined &&
+        !!runtime &&
         Bun.which("systemd-run") !== null &&
         (yield* fs.exists(path.join(runtime, "bus")))
-      const command = scoped
-        ? [
-            "systemd-run",
-            "--user",
-            "--scope",
-            "--quiet",
-            "--collect",
-            "--description=opencode serve",
-            "--",
-            process.execPath,
-            ...args,
-          ]
-        : [process.execPath, ...args]
 
-      yield* Effect.try({
-        try: () => {
-          spawn(command[0], command.slice(1), {
-            detached: true,
-            stdio: "ignore",
-          }).unref()
-        },
-        catch: (cause) => new Error("Failed to start server", { cause }),
-      })
+      // Spawn detached, then wait for a healthy registration. A scoped spawn
+      // can still fail at exec — a stale or forwarded bus socket passes the
+      // gate while the user manager rejects the scope — and `detached` hides
+      // the exit, so fall back to the direct spawn after the retry budget.
+      const startWith = (command: string[]) =>
+        Effect.try({
+          try: () => {
+            spawn(command[0], command.slice(1), { detached: true, stdio: "ignore" }).unref()
+          },
+          catch: (cause) => new Error("Failed to start server", { cause }),
+        }).pipe(
+          Effect.andThen(
+            compatible().pipe(
+              Effect.retry(Schedule.spaced("50 millis").pipe(Schedule.both(Schedule.recurs(100)))),
+              Effect.map((info) => info.url),
+            ),
+          ),
+          Effect.mapError(() => new Error("Failed to start server")),
+        )
 
-      return yield* compatible().pipe(
-        Effect.retry(Schedule.spaced("50 millis").pipe(Schedule.both(Schedule.recurs(100)))),
-        Effect.map((info) => info.url),
-        Effect.mapError(() => new Error("Failed to start server")),
-      )
+      const scopedCommand = [
+        "systemd-run",
+        "--user",
+        "--scope",
+        "--quiet",
+        "--collect",
+        "--description=opencode serve",
+        "--",
+        ...direct,
+      ]
+      return yield* scoped ? startWith(scopedCommand).pipe(Effect.catch(() => startWith(direct))) : startWith(direct)
     })
 
     const transport = Effect.fn("cli.daemon.transport")(function* () {

--- a/packages/cli/src/services/daemon.ts
+++ b/packages/cli/src/services/daemon.ts
@@ -117,9 +117,38 @@ export const layer = Layer.effect(
       const entrypoint = compiled ? undefined : process.argv[1]
       if (!compiled && entrypoint === undefined)
         return yield* Effect.fail(new Error("Failed to resolve CLI entrypoint"))
+
+      const args = [...(entrypoint ? [entrypoint] : []), "serve", "--register"]
+
+      // `detached` frees the serve from the client's lifetime but not its
+      // cgroup: a client under memory/pids limits still starves the shared
+      // server until the health probe fails and it is recycled
+      // (anomalyco/opencode#48588). On Linux, hand the spawn to the user
+      // manager so the serve lands in its own scope — a sibling of the
+      // client's cgroup — instead of inheriting its limits.
+      const runtime = process.env.XDG_RUNTIME_DIR
+      const scoped =
+        process.platform === "linux" &&
+        runtime !== undefined &&
+        Bun.which("systemd-run") !== null &&
+        (yield* fs.exists(path.join(runtime, "bus")))
+      const command = scoped
+        ? [
+            "systemd-run",
+            "--user",
+            "--scope",
+            "--quiet",
+            "--collect",
+            "--description=opencode serve",
+            "--",
+            process.execPath,
+            ...args,
+          ]
+        : [process.execPath, ...args]
+
       yield* Effect.try({
         try: () => {
-          spawn(process.execPath, [...(entrypoint ? [entrypoint] : []), "serve", "--register"], {
+          spawn(command[0], command.slice(1), {
             detached: true,
             stdio: "ignore",
           }).unref()


### PR DESCRIPTION
## Summary

Fixes #48588.

- `Daemon.start()` spawns the managed `serve` with `detached: true`. That detaches the session but leaves the process inside the spawning client's cgroup. A client running under memory/pids limits (a `systemd-run` scope, container, etc.) then starves the shared server until the 2s health probe fails and it is recycled into another client's constrained cgroup — the kill/respawn loop described in the issue.
- On Linux, when a user session bus and `systemd-run` are available, the serve is now spawned through `systemd-run --user --scope --quiet --collect`, so it lands in its own transient scope — a sibling of the client's cgroup — and `--collect` removes the scope when the serve exits.
- A scoped spawn can still fail silently at exec (stale or forwarded bus socket passes the gate while the user manager rejects the scope, and `detached` hides the exit). In that case the registration never appears, so after the existing ~5s retry budget we fall back to the direct spawn.
- Everywhere else (macOS, Windows, Linux without a user bus), the spawn path is unchanged.

#### Test plan

- [x] `bun typecheck` in `packages/cli` — clean
- [x] `oxlint` — no new findings
- [x] `prettier --check` — clean
- [x] Scoped path, end-to-end on NixOS: `service start` from a scope-confined client put the serve in `app.slice/run-p<pid>.scope` (a sibling of the client's scope), `service status` healthy, `service stop` SIGTERMed it and the scope was collected
- [x] Fallback path: pointed `XDG_RUNTIME_DIR` at a dir with a stale `bus` file — `systemd-run` failed, the registration retry elapsed, the direct spawn ran, and the server registered and stopped cleanly
- [ ] Fallback path on a non-systemd host (unchanged code path, gated on `process.platform`, `XDG_RUNTIME_DIR`, bus socket, and `systemd-run` presence)

Not included here (possible follow-ups from the issue): tolerating reclaim stalls in the health probe, and ownership semantics for which client may recycle the registered server.