### PR TITLE
fix(desktop): preserve keyboard focus during browser navigation

### DIFF
--- a/packages/desktop/src/main/browser-chromium.ts
+++ b/packages/desktop/src/main/browser-chromium.ts
@@ -53,6 +53,8 @@ export function createBrowserPage(
       webviewTag: false,
       devTools: false,
       backgroundThrottling: false,
+      // Agent navigation, including in hidden tabs, must not take the user's keyboard focus.
+      focusOnNavigation: false,
     },
   })
   const contents = view.webContents
@@ -157,6 +159,8 @@ export function createBrowserPage(
               webSecurity: true,
               webviewTag: false,
               devTools: false,
+              // Electron applies these preferences before the popup is adopted by our view.
+              focusOnNavigation: false,
               partition: options.partition,
             },
           },


### PR DESCRIPTION
- Keep keyboard focus in the composer while the agent opens, navigates, or reloads in-app browser tabs.
- Set `focusOnNavigation: false` for regular pages and popup preferences, including hidden and restored tabs. Explicit user focus still works.

Before/after in an isolated Electron fixture using the production browser page:

| Before | After |
| --- | --- |
| ![Browser navigation takes keyboard focus](https://github.com/user-attachments/assets/ba966dc8-d9f5-4768-8f6d-d1abaf86ae0a) | ![Composer keeps keyboard focus](https://github.com/user-attachments/assets/14dbd3e6-c1ef-42af-8cf4-b716f2e0e53c) |