### PR TITLE
fix(session-ui): keep divider notices out of used groups

### DIFF
--- a/packages/session-ui/src/timeline/projection.ts
+++ b/packages/session-ui/src/timeline/projection.ts
@@ -271,7 +271,7 @@ export namespace Timeline {
             detail,
             new Set(
               messages
-                .filter((message) => message.type === "compaction" && timelineNoticeRequired(message))
+                .filter((message) => message.type === "compaction" || message.type === "model-switched")
                 .map((message) => message.id),
             ),
           )
@@ -415,13 +415,13 @@ function shellFailed(message: SessionMessageShell) {
   )
 }
 
-function groupMessages(rows: TimelineRow.TimelineRow[], detail: TimelineDetail, required: ReadonlySet<string>) {
+function groupMessages(rows: TimelineRow.TimelineRow[], detail: TimelineDetail, separate: ReadonlySet<string>) {
   return rows.reduce<TimelineRow.TimelineRow[]>((result, row) => {
     const previous = result.at(-1)
     const current =
       ((row._tag === "Notice" && detail.notices.placement === "grouped") ||
         (row._tag === "Shell" && detail.shell.placement === "grouped")) &&
-      !required.has(row.messageID)
+      !separate.has(row.messageID)
         ? new TimelineRow.AssistantPart({
             userMessageID: row.userMessageID,
             previousAssistantPart: previous?._tag === "AssistantPart",


### PR DESCRIPTION
- Keep model-change and compaction notices outside **Used** groups, including completed compactions.
- Preserve each horizontal divider as a boundary between adjacent tool groups.

| Before (Compact detail) | After (Compact detail) |
| --- | --- |
| ![Divider notices hidden inside Used](https://github.com/user-attachments/assets/e048715b-fb56-4a8c-b490-d28caed3cdb7) | ![Divider notices separate the Used groups](https://github.com/user-attachments/assets/23e3e3a3-d219-4d6e-97af-69b3909c4748) |
