### PR TITLE
fix(app): expose streaming assistant content

### DIFF
--- a/packages/app/e2e/regression/session-timeline-accessibility.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-accessibility.spec.ts
@@ -1,5 +1,22 @@
 import { expect, test } from "@playwright/test"
-import { assistantMessage, setupTimeline, shell, userMessage } from "../performance/timeline-stability/fixture"
+import {
+  assistantMessage,
+  setupTimeline,
+  shell,
+  textPart,
+  userMessage,
+} from "../performance/timeline-stability/fixture"
+
+test("streaming assistant content remains in the accessibility tree", async ({ page }) => {
+  const text = "Streaming assistant output"
+  await setupTimeline(page, {
+    messages: [userMessage(), assistantMessage([textPart("prt_streaming_accessibility", text)], { completed: false })],
+  })
+
+  await expect(page.locator('[data-slot="session-turn-assistant-content"]')).toMatchAriaSnapshot(`
+    - paragraph: ${text}
+  `)
+})
 
 test("space activates a focused timeline button instead of scrolling", async ({ page }) => {
   const shellID = "prt_space_button_shell"

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1168,10 +1168,7 @@ export function MessageTimeline(props: {
         return (
           <TimelineRowFrame row={assistantPartRow}>
             <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
-              <div
-                data-slot="session-turn-assistant-content"
-                aria-hidden={workingTurn(assistantPartRow().userMessageID)}
-              >
+              <div data-slot="session-turn-assistant-content">
                 {renderAssistantPartGroup(assistantPartRow, onSizeChange)}
               </div>
             </div>


### PR DESCRIPTION
### Issue for this PR

Fixes #33137
Fixes #46396
Addresses the streaming-content half of #41408; its animated-number issue remains separate.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Active assistant output was wrapped in `aria-hidden`, so visible streamed text, reasoning, and tool activity disappeared from the accessibility tree until the turn ended.

This removes that attribute from the current app timeline and adds a Playwright ARIA-snapshot regression test for an incomplete assistant response. It deliberately leaves `aria-live="off"` unchanged so browsing the stream does not also announce every token.

Prior work: @ashu-choudhury identified the root cause and proposed removing the attribute in #33139. @abdullahsaad27 traced the active Desktop renderer and explored the `aria-busy`/live-region alternative in #38393. This PR applies the narrower fix to current `dev` and adds regression coverage.

### How did you verify your code works?

- Confirmed the new test failed before the fix with an empty ARIA snapshot, then passed after it.
- `bun turbo typecheck` (30 packages via the pre-push hook)
- App unit tests: 724 passed
- App browser tests: 41 passed
- Timeline accessibility E2E: 2 passed in Chromium
- Production timeline benchmark passed before and after with all 40 deltas delivered and no row or Markdown remounts

### Screenshots / recordings

N/A — this changes only the accessibility tree. The regression snapshot changes from empty to `paragraph: Streaming assistant output`; visual rendering is unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR