### PR TITLE
fix(tui): handle session.error events in global sync

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -318,6 +318,34 @@ export const {
           break
         }
 
+        case "session.error": {
+          const sessionID = event.properties.sessionID
+          if (!sessionID) break
+          setStore("session_status", sessionID, { type: "idle" })
+          const messages = store.message[sessionID]
+          if (messages && messages.length > 0) {
+            const lastIndex = messages.length - 1
+            const lastMsg = messages[lastIndex]
+            if (lastMsg && lastMsg.role === "assistant") {
+              setStore(
+                "message",
+                sessionID,
+                lastIndex,
+                produce((draft) => {
+                  if (draft.role === "assistant") {
+                    draft.error = event.properties.error ?? {
+                      name: "UnknownError",
+                      data: { message: "" },
+                    }
+                    draft.finish = "error"
+                  }
+                }),
+              )
+            }
+          }
+          break
+        }
+
         case "message.updated": {
           touchMessage(event.properties.info.sessionID, event.properties.info.id)
           const messages = store.message[event.properties.info.sessionID]

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -62,4 +62,83 @@ describe("tui sync", () => {
       app.renderer.destroy()
     }
   })
+
+  test("session.error resets session status to idle and marks assistant message error", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      const sessionID = "ses_error_test"
+
+      emit({
+        directory: "/tmp/other",
+        project: "proj_test",
+        payload: {
+          id: "evt_status",
+          type: "session.status",
+          properties: {
+            sessionID,
+            status: { type: "busy" },
+          },
+        },
+      })
+      await wait(() => sync.data.session_status[sessionID]?.type === "busy")
+
+      emit({
+        directory: "/tmp/other",
+        project: "proj_test",
+        payload: {
+          id: "evt_msg",
+          type: "message.updated",
+          properties: {
+            sessionID,
+            info: {
+              id: "msg_assist",
+              sessionID,
+              role: "assistant",
+              time: { created: 100 },
+              modelID: "test-model",
+              providerID: "opencode",
+              mode: "build",
+              agent: "build",
+              parentID: "msg_user",
+              path: { cwd: "/tmp", root: "/tmp" },
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            },
+          },
+        },
+      })
+      await wait(() => (sync.data.message[sessionID]?.length ?? 0) === 1)
+
+      emit({
+        directory: "/tmp/other",
+        project: "proj_test",
+        payload: {
+          id: "evt_err",
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: {
+              name: "UnknownError",
+              data: { message: "Internal server error" },
+            },
+          },
+        },
+      })
+
+      await wait(() => sync.data.session_status[sessionID]?.type === "idle")
+      expect(sync.data.session_status[sessionID]?.type).toBe("idle")
+
+      const lastMsg = sync.data.message[sessionID]?.[0]
+      expect(lastMsg?.role).toBe("assistant")
+      if (lastMsg?.role === "assistant") {
+        expect(lastMsg.finish).toBe("error")
+        expect(lastMsg.error?.name).toBe("UnknownError")
+      }
+    } finally {
+      app.renderer.destroy()
+    }
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48530

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the terminal TUI, when a session encounters an error and the server emits a `session.error` event, the global sync reducer in `packages/tui` ignored it. As a result:
1. `session_status[sessionID]` remained permanently stuck in `busy` mode with an unending progress spinner.
2. The last assistant message was never updated with an error marker or `finish: "error"`.

This PR adds a `session.error` handler in `packages/tui/src/context/sync.tsx` (the terminal counterpart to #48534 for `packages/app`). When `session.error` is received:
- `session_status[sessionID]` is reset to `{ type: "idle" }`.
- The last assistant message in the session is marked with the error payload and `finish: "error"`.

### How did you verify your code works?

- Added unit test in `packages/tui/test/cli/cmd/tui/sync.test.tsx` asserting that `session.error` resets the session status to `idle` and marks the assistant message error and finish state.
- Ran `bun test test/cli/cmd/tui/sync.test.tsx` (3/3 pass).
- Ran `bun run --cwd packages/tui typecheck` (`tsgo --noEmit` passes with 0 errors).

### Screenshots / recordings

N/A (TUI state reconciliation)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR