### PR TITLE
fix(tui): read text from clipboard directly on Windows (#13800)

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -53,11 +53,15 @@ export async function read() {
 
   if (platform() === "win32" || release().includes("WSL")) {
     const script =
-      "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $ms = New-Object System.IO.MemoryStream; $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray()) }"
-    const image = await command("powershell.exe", ["-NonInteractive", "-NoProfile", "-command", script]).catch(() =>
+      "$t=Get-Clipboard -Raw -EA SilentlyContinue;if($t){[Console]::OutputEncoding=[Text.Encoding]::UTF8;[Console]::Out.Write('T:'+$t)}else{$i=Get-Clipboard -Format Image -EA SilentlyContinue;if($i){$m=New-Object IO.MemoryStream;$i.Save($m,[Drawing.Imaging.ImageFormat]::Png);[Console]::Out.Write('I:'+[Convert]::ToBase64String($m.ToArray()))}}"
+    const output = await command("powershell.exe", ["-NonInteractive", "-NoProfile", "-command", script]).catch(() =>
       Buffer.alloc(0),
     )
-    if (image.length) return { data: image.toString().trim(), mime: "image/png" }
+    if (output.length) {
+      const text = output.toString("utf8")
+      if (text.startsWith("T:")) return { data: text.slice(2), mime: "text/plain" }
+      if (text.startsWith("I:")) return { data: text.slice(2).trim(), mime: "image/png" }
+    }
   }
 
   if (platform() === "linux") {


### PR DESCRIPTION
### Issue for this PR

Closes #13800

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows 11, pressing `Ctrl+V` or clicking clipboard history (`Win+V`) in the TUI prompt fails to paste text.

In `packages/tui/src/clipboard.ts`, the Windows implementation only checks for images with PowerShell and then falls through to `clipboardy.read()` for text. In compiled standalone binaries, `clipboardy` fails or is blocked by execution policy, causing clipboard reading to silently return `undefined`.

This PR updates the Windows/WSL `read()` implementation in `packages/tui/src/clipboard.ts` to use PowerShell's built-in `Get-Clipboard` cmdlet:
- Reads text first via `Get-Clipboard -Raw` and outputs directly as UTF-8.
- Falls back to `Get-Clipboard -Format Image` if no text is present to handle images as base64 PNG.
- Employs `[Console]::Out.Write` to stream output without appending extraneous trailing newlines.

### How did you verify your code works?

Tested locally on Windows 11 in Windows Terminal, PowerShell, and cmd.exe:
- Pasting single-line plain text via `Ctrl+V`
- Pasting multi-line text via `Ctrl+V`
- Pasting text with UTF-8 / emoji characters
- Pasting image from clipboard (screenshots)

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A (TUI clipboard behavior fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
