### PR TITLE
fix(snapshot): guard diffFull against memory exhaustion on large files

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -22,6 +22,7 @@ export type FileDiff = typeof FileDiff.Type
 
 const prune = "7.days"
 const limit = 2 * 1024 * 1024
+const lineLimit = 10_000
 const core = ["-c", "core.longpaths=true", "-c", "core.symlinks=true"]
 const cfg = ["-c", "core.autocrlf=false", ...core]
 const quote = [...cfg, "-c", "core.quotepath=false"]
@@ -561,7 +562,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
               }
 
               const show = Effect.fnUntraced(function* (row: Row) {
-                if (row.binary) return ["", ""]
+                if (row.binary || (row.additions + row.deletions) > lineLimit) return ["", ""]
                 if (row.status === "added") {
                   return [
                     "",
@@ -588,7 +589,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
               const load = Effect.fnUntraced(
                 function* (rows: Row[]) {
                   const refs = rows.flatMap((row) => {
-                    if (row.binary) return []
+                    if (row.binary || (row.additions + row.deletions) > lineLimit) return []
                     if (row.status === "added")
                       return [{ file: row.file, side: "after", ref: `${to}:${row.file}` } satisfies Ref]
                     if (row.status === "deleted") {
@@ -660,7 +661,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
                       )
                     }
 
-                    const text = dec.decode(out.slice(i, i + size))
+                    const text = size > limit ? "" : dec.decode(out.slice(i, i + size))
                     if (ref.side === "before") hit.before = text
                     if (ref.side === "after") hit.after = text
                     map.set(ref.file, hit)
@@ -743,9 +744,14 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
                 for (const row of run) {
                   const hit = text?.get(row.file) ?? { before: "", after: "" }
                   const [before, after] = row.binary ? ["", ""] : text ? [hit.before, hit.after] : yield* show(row)
+                  const tooLarge =
+                    row.binary ||
+                    (row.additions + row.deletions) > lineLimit ||
+                    before.length > limit ||
+                    after.length > limit
                   result.push({
                     file: row.file,
-                    patch: row.binary ? "" : patch(row.file, before, after),
+                    patch: tooLarge ? "" : patch(row.file, before, after),
                     additions: row.additions,
                     deletions: row.deletions,
                     status: row.status,

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1120,6 +1120,28 @@ it.instance(
 )
 
 it.instance(
+  "diffFull with large text changes omits patch",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrap()
+    const snapshot = yield* Snapshot.Service
+    const lines1 = Array.from({ length: 15_000 }, (_, i) => `line ${i}`).join("\n")
+    yield* write(`${tmp.path}/large.txt`, lines1)
+    const before = yield* snapshot.track()
+    expect(before).toBeTruthy()
+    const lines2 = Array.from({ length: 15_000 }, (_, i) => `line modified ${i}`).join("\n")
+    yield* write(`${tmp.path}/large.txt`, lines2)
+    const after = yield* snapshot.track()
+    expect(after).toBeTruthy()
+    const diffs = yield* snapshot.diffFull(before!, after!)
+    expect(diffs.length).toBe(1)
+    expect(diffs[0].file).toBe("large.txt")
+    expect(diffs[0].patch).toBe("")
+    expect(diffs[0].additions).toBeGreaterThan(10_000)
+  }),
+  { git: true },
+)
+
+it.instance(
   "diffFull with whitespace changes",
   Effect.gen(function* () {
     const tmp = yield* bootstrap()


### PR DESCRIPTION
### Issue for this PR

Closes #48616

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When large text or generated files (such as simulation meshes, logs, or datasets) are modified in a workspace, `snapshot.diffFull` attempts to compute an in-memory Myers diff using `diff.structuredPatch`. If a modified file has tens of thousands of lines or is several megabytes, the diff computation runs synchronously on the main thread, leading to 100%+ CPU spin and massive memory allocation (often over 1-2 GB), freezing OpenCode completely.

This PR guards against Myers diff CPU/memory exhaustion on large files:
1. Adds `lineLimit = 10_000` to skip loading diff blobs in `show()` and `load()` when `additions + deletions > lineLimit`.
2. Prevents decoding git blob strings in `load()` when raw blob size exceeds `limit` (2MB).
3. In `diffFull()`, checks `tooLarge` (binary, `> lineLimit`, or buffer `> limit`) and emits `patch: ""` instead of invoking `diff.structuredPatch`. OpenCode's UI already handles empty patches gracefully by indicating no patch is available.

### How did you verify your code works?

1. Ran `bun --cwd packages/opencode test test/snapshot/snapshot.test.ts`, including a new regression test (`"diffFull with large text changes omits patch"`) that verifies 15,000 modified lines return `patch: ""` without locking up. All 57 tests passed.
2. Ran `turbo typecheck --concurrency=2 --filter=opencode` with zero type errors.
3. Ran `oxlint` on `packages/opencode/src/snapshot` and `packages/opencode/test/snapshot` with zero lint errors.

### Screenshots / recordings

N/A (internal snapshot engine fix, no UI changes).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR