### PR TITLE
fix(app): restore top edge dragging with vertical tabs

### DIFF
--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -53,6 +53,20 @@ export default function Layout(props: ParentProps) {
             : "max(0px, calc(8px - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))))",
         }}
       >
+        <Show
+          when={
+            platform.platform === "desktop" &&
+            platform.os === "macos" &&
+            verticalTabs() &&
+            !platform.windowFullscreen?.()
+          }
+        >
+          <div
+            data-slot="shell-drag-region"
+            data-tauri-drag-region
+            class="absolute inset-x-0 top-0 z-10 h-[var(--shell-top-inset,8px)]"
+          />
+        </Show>
         <Titlebar
           update={update}
           verticalTabs={verticalTabs() ? { mount: state.tabsMount } : undefined}


### PR DESCRIPTION
### Issue for this PR

Closes #48422

This PR targets `v2` as required by [CONTRIBUTING.md](https://github.com/anomalyco/opencode/blob/v2/CONTRIBUTING.md#link-issues-when-required). The default-branch checker does not recognize closing keywords on `v2`; please manually link #48422 in Development to clear `needs:issue`. The linking API requires maintainer permissions.

### Type of change

- [x] Bug fix

### What does this PR do?

Vertical tabs hide the macOS titlebar, leaving the empty top edge above the main content without a drag region. Cover the existing 8px shell inset with a native drag region for desktop macOS windows using vertical tabs outside fullscreen. The layout stays unchanged, and the shared CSS disables dragging when a modal hides the root.

### How did you verify your code works?

- `bun run test` in `packages/app`: 858 unit tests and 157 browser-condition tests passed; one skipped.
- The repository's `.husky/pre-push` check passed all 35 typecheck tasks. Prettier and `git diff --check` passed.
- Real App components in an isolated Electron 42.10.1 window: the top region changes from `none` to `drag`, measures 1000×8px, and leaves the content below unchanged. Checked horizontal tabs, other platforms, fullscreen, and the modal visibility guard.
- Physical window movement remains unverified: native mouse automation repeatedly returned `noWindowsAvailable`. Please manually drag the empty top edge on macOS with vertical tabs to confirm.

### Screenshots / recordings

Before and after show the unchanged layout; the change is the top edge's native hit region.

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/tianhaotian/opencode/4cf614e8f951592f501c56f9db527f345b675295/48422-before.png) | ![After](https://raw.githubusercontent.com/tianhaotian/opencode/4cf614e8f951592f501c56f9db527f345b675295/48422-after.png) |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
