### PR TITLE
fix(tools): clarify unavailable tool errors

### DIFF
--- a/packages/ai/src/tool-runtime.ts
+++ b/packages/ai/src/tool-runtime.ts
@@ -23,7 +23,13 @@ export interface DispatchResult extends ToolSettlement {
 export const dispatch = (tools: Tools, call: ToolCallPart): Effect.Effect<DispatchResult> => {
   const name = call.namespace === undefined ? call.name : `${call.namespace}.${call.name}`
   const tool = tools[name]
-  if (!tool) return Effect.succeed(result(call, { type: "error", value: `Unknown tool: ${name}` }))
+  if (!tool)
+    return Effect.succeed(
+      result(call, {
+        type: "error",
+        value: `No tool named "${name}" is currently available. Please use a tool from the available tool list.`,
+      }),
+    )
   if (!tool.execute)
     return Effect.succeed(result(call, { type: "error", value: `Tool has no execute handler: ${name}` }))
 

--- a/packages/ai/test/tool-runtime.test.ts
+++ b/packages/ai/test/tool-runtime.test.ts
@@ -237,13 +237,16 @@ describe("LLMClient tools", () => {
         LLMEvent.toolError({
           id: "call_2",
           name: "missing",
-          message: "Unknown tool: missing",
+          message: 'No tool named "missing" is currently available. Please use a tool from the available tool list.',
           providerMetadata,
         }),
         LLMEvent.toolResult({
           id: "call_2",
           name: "missing",
-          result: { type: "error", value: "Unknown tool: missing" },
+          result: {
+            type: "error",
+            value: 'No tool named "missing" is currently available. Please use a tool from the available tool list.',
+          },
           providerMetadata,
         }),
       ])
@@ -712,12 +715,17 @@ describe("LLMClient tools", () => {
 
       const toolError = events.find(LLMEvent.is.toolError)
       expect(toolError).toMatchObject({ type: "tool-error", id: "call_1", name: "missing_tool" })
-      expect(toolError?.message).toContain("Unknown tool")
+      expect(toolError?.message).toBe(
+        'No tool named "missing_tool" is currently available. Please use a tool from the available tool list.',
+      )
       expect(events.find(LLMEvent.is.toolResult)).toMatchObject({
         type: "tool-result",
         id: "call_1",
         name: "missing_tool",
-        result: { type: "error", value: "Unknown tool: missing_tool" },
+        result: {
+          type: "error",
+          value: 'No tool named "missing_tool" is currently available. Please use a tool from the available tool list.',
+        },
       })
     }),
   )

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -264,7 +264,9 @@ const layer = Layer.effect(
                 return yield* executeTool(codeModeTool, name, event.input, context)
               const tool = direct.get(name)
               if (tool) return yield* executeTool(tool, name, event.input, context)
-              return yield* new Tool.Error({ message: `Unknown tool: ${name}` })
+              return yield* new Tool.Error({
+                message: `No tool named "${name}" is currently available. Please use a tool from the available tool list.`,
+              })
             }),
           }
         }),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -4401,7 +4401,13 @@ describe("SessionRunnerLLM", () => {
       Expected.assistant({}, [
         Expected.failedTool(
           { id: "call-missing" },
-          { error: { type: "tool.execution", message: "Unknown tool: missing" } },
+          {
+            error: {
+              type: "tool.execution",
+              message:
+                'No tool named "missing" is currently available. Please use a tool from the available tool list.',
+            },
+          },
         ),
       ]),
       Expected.assistant({ finish: "stop" }, [Expected.text("Recovered")]),

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -594,7 +594,9 @@ describe("Tool", () => {
       const snapshot = yield* service.snapshot()
       expect(snapshot.definitions.map((tool) => tool.name)).toEqual(["healthy", "execute"])
       expect(codeModeListings(snapshot.codeModeCatalog!).map((tool) => tool.path)).toEqual(["codemode"])
-      expect((yield* snapshot.execute(call("phone_type")).pipe(Effect.flip)).message).toBe("Unknown tool: phone_type")
+      expect((yield* snapshot.execute(call("phone_type")).pipe(Effect.flip)).message).toBe(
+        'No tool named "phone_type" is currently available. Please use a tool from the available tool list.',
+      )
     }).pipe(Effect.provide(Logger.layer([logger])))
   })
 
@@ -779,7 +781,13 @@ describe("Tool", () => {
           ...identity,
           call: { type: "tool-call", id: "missing", name: "missing", input: {} },
         }),
-      ).toEqual({ status: "error", error: { type: "tool.execution", message: "Unknown tool: missing" } })
+      ).toEqual({
+        status: "error",
+        error: {
+          type: "tool.execution",
+          message: 'No tool named "missing" is currently available. Please use a tool from the available tool list.',
+        },
+      })
 
       yield* transform(
         service,


### PR DESCRIPTION
## Summary

Give the model actionable feedback when it requests a tool that is not currently available:

```text
No tool named "<name>" is currently available. Please use a tool from the available tool list.
```

Apply the wording consistently in the Core tool registry and the AI package's tool dispatcher. Update the existing assertions for error events, tool results, and persisted session failures.

## Validation

- `packages/ai`: `bun test test/tool-runtime.test.ts` — 27 passed
- `packages/core`: `bun test test/tool-registry.test.ts` — 39 passed
- `packages/core`: `bun test test/session-runner.test.ts --test-name-pattern 'durably settles local tool failures before continuing'` — 1 passed
- `bun typecheck` in `packages/ai` and `packages/core` — passed
- `git diff --check` — passed
