### PR TITLE
fix(app): polyfill startup APIs for older Safari

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
         "@solidjs/router": "catalog:",
         "@tanstack/solid-query": "5.91.4",
         "@tanstack/solid-virtual": "catalog:",
+        "core-js": "3.50.0",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
         "ghostty-web": "github:anomalyco/ghostty-web#83c0a07b8628b748aed073b232cb4b52a6ca11c1",
@@ -3701,6 +3702,8 @@
     "cookie-es": ["cookie-es@2.0.1", "", {}, "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "core-js": ["core-js@3.50.0", "", {}, "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw=="],
 
     "core-js-compat": ["core-js-compat@3.50.0", "", { "dependencies": { "browserslist": "^4.28.7" } }, "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q=="],
 

--- a/packages/app/e2e/regression/browser-polyfills.spec.ts
+++ b/packages/app/e2e/regression/browser-polyfills.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test"
+import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+test("loads home and the directory picker without newer browser APIs", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    sessions: fixture.sessions,
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages,
+    fileList: () => [],
+  })
+  await page.addInitScript((directory) => {
+    // Safari 16.6 has neither API. Remove them before the web entry runs.
+    Reflect.deleteProperty(Map, "groupBy")
+    Reflect.deleteProperty(Promise, "withResolvers")
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({
+        projects: { local: [{ worktree: directory, expanded: true }] },
+        lastProject: { local: directory },
+      }),
+    )
+  }, fixture.directory)
+
+  await page.goto("/")
+  const row = page.locator('[data-component="home-session-row"]').filter({ hasText: fixture.expected.targetTitle })
+  await expect(row).toBeVisible()
+
+  await page.getByRole("button", { name: "Add project", exact: true }).click()
+  const dialog = page.getByRole("dialog")
+  await expect(dialog.getByRole("button", { name: "Select folder", exact: true })).toBeEnabled()
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click()
+  await expect(dialog).toBeHidden()
+  await expect(row).toBeVisible()
+})

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -84,6 +84,7 @@
     "@solidjs/router": "catalog:",
     "@tanstack/solid-query": "5.91.4",
     "@tanstack/solid-virtual": "catalog:",
+    "core-js": "3.50.0",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
     "ghostty-web": "github:anomalyco/ghostty-web#83c0a07b8628b748aed073b232cb4b52a6ca11c1",

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -1,5 +1,6 @@
 // @refresh reload
 
+import "@/runtime/polyfills"
 import { init } from "@sentry/solid"
 import { render } from "solid-js/web"
 import { AppBaseProviders, AppInterface } from "@/app"

--- a/packages/app/src/runtime/polyfills.ts
+++ b/packages/app/src/runtime/polyfills.ts
@@ -1,0 +1,3 @@
+// Safari before 17.4 does not provide these runtime APIs.
+import "core-js/es/map/group-by"
+import "core-js/es/promise/with-resolvers"


### PR DESCRIPTION
Closes #48610

- Load `Map.groupBy` and `Promise.withResolvers` polyfills before web startup. Both APIs were [added in Safari 17.4](https://webkit.org/blog/15063/webkit-features-in-safari-17-4/#javascript).
- Restore Home and the directory picker on browsers missing these APIs. The failed session-index memo otherwise surfaces as a misleading `groups.length` error.

Production build in Chromium with both native APIs removed before startup:

| Before | After |
| --- | --- |
| ![Home fails with the groups.length error](https://github.com/user-attachments/assets/8bb54407-6332-4c21-a947-427c87585087) | ![Home loads its session list](https://github.com/user-attachments/assets/63280311-18ba-4172-b51a-d2824a88cac1) |
