### PR TITLE
fix: align skill slash defaults with docs

### DIFF
--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -440,7 +440,7 @@ async function loadCatalog(client: OpenCodeClient, cwd: string): Promise<Catalog
         modes: agents.map((agent) => ({ id: agent.id, name: agent.name, description: agent.description })),
         defaultModeID: defaultAgent.id,
         commands: commandResult.data,
-        skills: skillResult.data.filter((skill) => skill.slash !== false),
+        skills: skillResult.data.filter((skill) => skill.slash === true),
       }
     }
     missing = defaultModel ? "No primary agents are available" : "No models are available"

--- a/packages/cli/test/acp/service.test.ts
+++ b/packages/cli/test/acp/service.test.ts
@@ -24,7 +24,7 @@ describe("acp service", () => {
         if (url.pathname === "/api/agent") return Response.json({ location, data: [agent] })
         if (url.pathname === "/api/command")
           return Response.json({ location, data: [{ name: "review", template: "" }] })
-        if (url.pathname === "/api/skill") return Response.json({ location, data: [skill] })
+        if (url.pathname === "/api/skill") return Response.json({ location, data: [skill, unmarkedSkill] })
         if (url.pathname === "/api/session" && request.method === "POST") return Response.json({ data: session })
         if (url.pathname === "/api/mcp/docs" && request.method === "PUT") return new Response(null, { status: 204 })
         return new Response(null, { status: 404 })
@@ -103,6 +103,14 @@ const skill = {
   slash: true,
   location: "/skills/verify.md",
   content: "verify",
+}
+
+const unmarkedSkill = {
+  id: "unmarked",
+  name: "unmarked",
+  description: "Not a slash command",
+  location: "/skills/unmarked.md",
+  content: "unmarked",
 }
 
 const session = {

--- a/packages/cli/test/acp/subprocess.ts
+++ b/packages/cli/test/acp/subprocess.ts
@@ -59,6 +59,8 @@ export type AcpProcess = {
 export const verifierSkill = `---
 name: verifier-skill
 description: Verifier compatibility skill.
+metadata:
+  opencode/slash: "true"
 ---
 
 # Verifier Skill

--- a/packages/tui/src/mini/catalog.shared.ts
+++ b/packages/tui/src/mini/catalog.shared.ts
@@ -100,7 +100,7 @@ export async function loadRunCommands(
     sdk.command.list(location(ref), ...requestOptions(signal)),
     sdk.skill.list(location(ref), ...requestOptions(signal)),
   ])
-  return [...commands.data.map(runCommand), ...skills.data.filter((skill) => skill.slash !== false).map(runSkill)]
+  return [...commands.data.map(runCommand), ...skills.data.filter((skill) => skill.slash === true).map(runSkill)]
 }
 
 export async function loadRunReferences(

--- a/packages/tui/test/mini/catalog.shared.test.ts
+++ b/packages/tui/test/mini/catalog.shared.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { OpenCode } from "@opencode/client/promise"
-import { loadRunReferences, runProviders } from "../../src/mini/catalog.shared"
+import { loadRunCommands, loadRunReferences, runProviders } from "../../src/mini/catalog.shared"
 import { catalogModel, catalogProvider } from "./fixture/catalog"
 
 afterEach(() => {
@@ -35,6 +35,47 @@ describe("run catalog shared", () => {
 
     expect(list).toHaveBeenCalledWith({ location: { directory: "/tmp" } })
     expect(references).toMatchObject([{ name: "effect", path: "/repos/effect", description: "Effect v4 sources" }])
+  })
+
+  test("keeps only slash-marked skills when loading run commands", async () => {
+    const client = OpenCode.make({ baseUrl: "https://opencode.test" })
+    spyOn(client.command, "list").mockImplementation(
+      () =>
+        Promise.resolve({
+          location: { directory: "/tmp", project: { id: "proj_1", directory: "/tmp" } },
+          data: [{ name: "review", template: "" }],
+        }) as never,
+    )
+    spyOn(client.skill, "list").mockImplementation(
+      () =>
+        Promise.resolve({
+          location: { directory: "/tmp", project: { id: "proj_1", directory: "/tmp" } },
+          data: [
+            {
+              id: "verify",
+              name: "verify",
+              description: "Verify work",
+              slash: true,
+              location: "/skills/verify.md",
+              content: "verify",
+            },
+            {
+              id: "notes",
+              name: "notes",
+              description: "Not a command",
+              location: "/skills/notes.md",
+              content: "notes",
+            },
+          ],
+        }) as never,
+    )
+
+    const commands = await loadRunCommands(client, { directory: "/tmp" })
+
+    expect(commands).toEqual([
+      { name: "review", description: undefined },
+      { name: "verify", description: "Verify work", source: "skill" },
+    ])
   })
 
   test("merges current providers and models into the footer catalog shape", () => {


### PR DESCRIPTION
Follow-up to #48022 / #48023, which are based on a false premise: the main TUI and desktop already share the same skill slash default (`slash === true`). The surfaces that actually diverge from the documented default are the mini TUI and ACP.

## Behavior matrix (before this PR)

| Surface | Filter | Unmarked skill (`slash` undefined) |
|---|---|---|
| Desktop autocomplete `packages/app/src/composer/model.ts` | `slash === true` | hidden |
| Desktop submit `packages/app/src/composer/submit.ts` | `slash === true` | hidden |
| Main TUI autocomplete `packages/tui/src/component/prompt/autocomplete.tsx` | `slash === true` | hidden |
| Main TUI submit `packages/tui/src/component/prompt/index.tsx` | `slash === true` | hidden |
| Mini TUI `packages/tui/src/mini/catalog.shared.ts` | `slash !== false` | shown |
| ACP `packages/cli/src/acp/service.ts` | `slash !== false` | shown |

## Canonical default is opt-in

- Docs (`packages/web/src/content/docs/skills.mdx`): *"`opencode/slash`: set to `\"true\"` to expose the skill as a `/name` command in the TUI"*
- Built-in skills: only `report` sets `slash: true`; the `opencode` skill deliberately does not — under an opt-out default, `/opencode` would appear in every slash menu
- #47247 deliberately mirrored the TUI's opt-in default into desktop

## Changes

- Mini TUI and ACP now require `slash === true`, matching docs, TUI, and desktop
- ACP subprocess fixture opts its skill in via the documented `opencode/slash` metadata
- New tests assert unmarked skills are excluded (ACP `available_commands_update`, mini run catalog)

## Note: ACP behavior change

ACP clients (e.g. Zed) will stop listing skills that don't set `slash: true` / `opencode/slash: "true"`. This matches the documented promise that "OpenCode works the same via ACP as it does in the terminal", but it is a visible change for ACP users — flagging it explicitly.