### PR TITLE
fix(opencode): list file commands without blocking on MCP connections

### DIFF
--- a/packages/opencode/src/acp/directory.ts
+++ b/packages/opencode/src/acp/directory.ts
@@ -117,6 +117,9 @@ export const loaderLayer = Layer.effect(
         const ctx = yield* store.load({ directory })
         return yield* Effect.gen(function* () {
           const providers = yield* provider.list()
+          // ACP snapshots are cached per directory for the process lifetime, so
+          // wait for MCP prompts to settle before capturing the command list.
+          yield* command.ready()
           const [agents, defaultAgent, commands, defaultModel] = yield* Effect.all(
             [agent.list(), agent.defaultInfo(), command.list(), provider.defaultModel().pipe(Effect.option)],
             { concurrency: "unbounded" },

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -3,7 +3,9 @@ import path from "path"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
-import { Effect, Layer, Context, Schema } from "effect"
+import { CommandEvent } from "@opencode-ai/schema/command-event"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Effect, Layer, Context, Schema, Deferred } from "effect"
 import { Config } from "@/config/config"
 import { MCP } from "../mcp"
 import { Skill } from "../skill"
@@ -13,6 +15,8 @@ import { LegacyEvent } from "@opencode-ai/schema/legacy-event"
 
 type State = {
   commands: Record<string, Info>
+  // Resolves once the background MCP prompt merge settles, successfully or not.
+  mcpSettled: Deferred.Deferred<void, never>
 }
 
 export const Event = {
@@ -51,6 +55,8 @@ export const Default = {
 export interface Interface {
   readonly get: (name: string) => Effect.Effect<Info | undefined>
   readonly list: () => Effect.Effect<Info[]>
+  /** Resolves once MCP prompts have settled; file-based commands never wait on it. */
+  readonly ready: () => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Command") {}
@@ -61,6 +67,7 @@ const layer = Layer.effect(
     const config = yield* Config.Service
     const mcp = yield* MCP.Service
     const skill = yield* Skill.Service
+    const events = yield* EventV2Bridge.Service
 
     const init = Effect.fn("Command.state")(function* (ctx: InstanceContext) {
       const cfg = yield* config.get()
@@ -102,35 +109,6 @@ const layer = Layer.effect(
         }
       }
 
-      for (const [name, prompt] of Object.entries(yield* mcp.prompts())) {
-        commands[name] = {
-          name,
-          source: "mcp",
-          description: prompt.description,
-          get template() {
-            return bridge.promise(
-              mcp
-                .getPrompt(
-                  prompt.client,
-                  prompt.name,
-                  prompt.arguments
-                    ? Object.fromEntries(prompt.arguments.map((argument, i) => [argument.name, `$${i + 1}`]))
-                    : {},
-                )
-                .pipe(
-                  Effect.map(
-                    (template) =>
-                      template?.messages
-                        .map((message) => (message.content.type === "text" ? message.content.text : ""))
-                        .join("\n") || "",
-                  ),
-                ),
-            )
-          },
-          hints: prompt.arguments?.map((_, i) => `$${i + 1}`) ?? [],
-        }
-      }
-
       for (const item of yield* skill.all()) {
         if (commands[item.name]) continue
         const dir = item.location === "<built-in>" ? undefined : path.dirname(item.location)
@@ -151,8 +129,60 @@ const layer = Layer.effect(
         }
       }
 
+      // MCP prompts block on every server connecting (seconds each). Load
+      // file-based commands now and merge MCP prompts in the background,
+      // publishing CommandEvent.Updated so clients re-fetch; MCP keeps its
+      // old name-precedence override.
+      const mcpSettled = yield* Deferred.make<void, never>()
+      const mergeMcpPrompts = Effect.fn("Command.mergeMcpPrompts")(function* () {
+        yield* Effect.ensuring(
+          Effect.gen(function* () {
+            const prompts = yield* mcp.prompts()
+            for (const [name, prompt] of Object.entries(prompts)) {
+              commands[name] = {
+                name,
+                source: "mcp",
+                description: prompt.description,
+                get template() {
+                  return bridge.promise(
+                    mcp
+                      .getPrompt(
+                        prompt.client,
+                        prompt.name,
+                        prompt.arguments
+                          ? Object.fromEntries(prompt.arguments.map((argument, i) => [argument.name, `$${i + 1}`]))
+                          : {},
+                      )
+                      .pipe(
+                        Effect.map(
+                          (template) =>
+                            template?.messages
+                              .map((message) => (message.content.type === "text" ? message.content.text : ""))
+                              .join("\n") || "",
+                        ),
+                      ),
+                  )
+                },
+                hints: prompt.arguments?.map((_, i) => `$${i + 1}`) ?? [],
+              }
+            }
+            if (Object.keys(prompts).length > 0) yield* events.publish(CommandEvent.Updated, {})
+          }),
+          // Settle even on failure so `ready()` awaiters never hang.
+          Deferred.succeed(mcpSettled, undefined),
+        )
+      })
+      yield* mergeMcpPrompts().pipe(
+        Effect.catchCause((cause) => Effect.logWarning("Command MCP prompt merge failed", { cause })),
+        Effect.forkScoped,
+      )
+      // Also settle from the entry scope in case the fiber is interrupted
+      // before its `ensuring` finalizer registers; double-succeed is a no-op.
+      yield* Effect.addFinalizer(() => Deferred.succeed(mcpSettled, undefined))
+
       return {
         commands,
+        mcpSettled,
       }
     })
 
@@ -168,10 +198,19 @@ const layer = Layer.effect(
       return Object.values(s.commands)
     })
 
-    return Service.of({ get, list })
+    const ready = Effect.fn("Command.ready")(function* () {
+      const s = yield* InstanceState.get(state)
+      return yield* Deferred.await(s.mcpSettled)
+    })
+
+    return Service.of({ get, list, ready })
   }),
 )
 
-export const node = LayerNode.make({ service: Service, layer: layer, deps: [Config.node, MCP.node, Skill.node] })
+export const node = LayerNode.make({
+  service: Service,
+  layer: layer,
+  deps: [Config.node, MCP.node, Skill.node, EventV2Bridge.node],
+})
 
 export * as Command from "."

--- a/packages/opencode/test/command/index.test.ts
+++ b/packages/opencode/test/command/index.test.ts
@@ -1,0 +1,99 @@
+import path from "node:path"
+import { expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CommandEvent } from "@opencode-ai/schema/command-event"
+import { Deferred, Effect, Layer } from "effect"
+import { Command } from "../../src/command/index"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
+import { InstanceStore } from "../../src/project/instance-store"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
+
+const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+const env = AppNodeBuilder.build(
+  LayerNode.group([Command.node, EventV2Bridge.node, CrossSpawnSpawner.node, InstanceStore.node]),
+  [[InstanceStore.bootstrapNode, noopBootstrap]],
+)
+const it = testEffect(env)
+const slowFixture = path.join(import.meta.dir, "../fixture/mcp-slow-prompts-stdio.ts")
+
+// Must exceed the awaitWithTimeout budget below so the old synchronous
+// behavior (command.list blocking on every MCP connection) fails the test.
+const CONNECT_DELAY_MS = 1500
+
+it.instance(
+  "command.list returns file commands immediately and merges MCP prompts in the background",
+  Effect.gen(function* () {
+    const command = yield* Command.Service
+
+    const events = yield* EventV2Bridge.Service
+    const eventSeen = yield* Deferred.make<string>()
+    const unsub = yield* events.listen((event) => {
+      if (event.type === CommandEvent.Updated.type) Deferred.doneUnsafe(eventSeen, Effect.succeed(event.type))
+      return Effect.void
+    })
+    yield* Effect.addFinalizer(() => unsub)
+
+    // File-based commands (config + defaults) must be available without
+    // waiting for the slow MCP server to connect.
+    const initial = yield* awaitWithTimeout(
+      command.list(),
+      "command.list blocked on MCP connections",
+      `${CONNECT_DELAY_MS - 500} millis`,
+    )
+    const initialNames = new Set(initial.map((item) => item.name))
+    expect(initialNames.has("hello")).toBe(true)
+    expect(initialNames.has(Command.Default.INIT)).toBe(true)
+    expect(initialNames.has(Command.Default.REVIEW)).toBe(true)
+    expect(initialNames.has("slow-server:slow_prompt")).toBe(false)
+
+    // Once MCP settles, prompts are merged into the same state and the
+    // command.updated event notifies clients to re-fetch.
+    yield* command.ready()
+    expect(yield* Deferred.await(eventSeen)).toBe("command.updated")
+
+    const settled = yield* command.list()
+    const settledNames = new Set(settled.map((item) => item.name))
+    expect(settledNames.has("hello")).toBe(true)
+    const prompt = settled.find((item) => item.name === "slow-server:slow_prompt")
+    expect(prompt?.source).toBe("mcp")
+    expect(prompt?.description).toBe("A prompt from a slow MCP server")
+  }),
+  {
+    config: {
+      command: {
+        hello: { template: "hello from a file-based command" },
+      },
+      mcp: {
+        "slow-server": {
+          type: "local",
+          command: [process.execPath, slowFixture, "--delay-ms", String(CONNECT_DELAY_MS)],
+        },
+      },
+    },
+  },
+  30_000,
+)
+
+it.instance(
+  "ready resolves even when no MCP servers are configured",
+  Effect.gen(function* () {
+    const command = yield* Command.Service
+
+    const initial = yield* command.list()
+    expect(initial.map((item) => item.name)).toContain(Command.Default.INIT)
+
+    yield* awaitWithTimeout(command.ready(), "command.ready hung without MCP servers", "5 seconds")
+    const settled = yield* command.list()
+    expect(settled.map((item) => item.name)).toContain("hello")
+  }),
+  {
+    config: {
+      command: {
+        hello: { template: "hello from a file-based command" },
+      },
+    },
+  },
+)

--- a/packages/opencode/test/event-manifest.test.ts
+++ b/packages/opencode/test/event-manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { SessionEvent } from "@opencode-ai/core/session/event"
+import { CommandEvent } from "@opencode-ai/schema/command-event"
 import { EventManifest as SchemaEventManifest } from "@opencode-ai/schema/event-manifest"
 import { Todo } from "@/session/todo"
 import { EventManifest } from "@/event-manifest"
@@ -9,9 +10,10 @@ describe("public event manifest", () => {
     expect(EventManifest.Definitions).toBe(SchemaEventManifest.Definitions)
     expect(EventManifest.Latest).toBe(SchemaEventManifest.Latest)
     expect(EventManifest.Durable).toBe(SchemaEventManifest.Durable)
-    expect(EventManifest.Latest.size).toBe(88)
+    expect(EventManifest.Latest.size).toBe(89)
     expect(EventManifest.Latest.get("session.next.step.ended")).toBe(SessionEvent.Step.Ended)
     expect(EventManifest.Latest.get("todo.updated")).toBe(Todo.Event.Updated)
+    expect(EventManifest.Latest.get("command.updated")).toBe(CommandEvent.Updated)
     expect(EventManifest.Latest.has("ide.installed")).toBe(false)
     expect(EventManifest.Latest.has("server.connected")).toBe(true)
     expect(EventManifest.Latest.has("global.disposed")).toBe(true)

--- a/packages/opencode/test/fixture/mcp-slow-prompts-stdio.ts
+++ b/packages/opencode/test/fixture/mcp-slow-prompts-stdio.ts
@@ -1,0 +1,19 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { ListPromptsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+
+// Simulates a slow-to-connect MCP server: sleeps before the stdio handshake
+// becomes responsive, then serves a single prompt. Used by command tests to
+// assert that file-based commands are listed without waiting on MCP.
+const delay = Number(process.argv[process.argv.indexOf("--delay-ms") + 1])
+await Bun.sleep(delay)
+
+const server = new Server({ name: "mcp-slow-prompts-stdio", version: "1.0.0" }, { capabilities: { prompts: {} } })
+
+server.setRequestHandler(ListPromptsRequestSchema, () =>
+  Promise.resolve({
+    prompts: [{ name: "slow_prompt", description: "A prompt from a slow MCP server" }],
+  }),
+)
+
+await server.connect(new StdioServerTransport())

--- a/packages/schema/src/command-event.ts
+++ b/packages/schema/src/command-event.ts
@@ -1,0 +1,9 @@
+export * as CommandEvent from "./command-event"
+
+import { Event } from "./event"
+
+// Emitted when commands change after the initial load (e.g. MCP prompts
+// finish connecting); clients should re-fetch /command.
+export const Updated = Event.define({ type: "command.updated", schema: {} })
+
+export const Definitions = Event.inventory(Updated)

--- a/packages/schema/src/event-manifest.ts
+++ b/packages/schema/src/event-manifest.ts
@@ -1,6 +1,7 @@
 export * as EventManifest from "./event-manifest"
 
 import { Catalog } from "./catalog"
+import { CommandEvent } from "./command-event"
 import { Durable } from "./durable-event-manifest"
 import { Event } from "./event"
 import { FileSystem } from "./filesystem"
@@ -67,6 +68,7 @@ export const Definitions = Event.inventory(
   ...featureDefinitions,
   ...SessionTodo.Event.Definitions,
   ...LspEvent.Definitions,
+  ...CommandEvent.Definitions,
   ...PermissionV1.Event.Definitions,
   ...TuiEvent.Definitions,
   ...McpEvent.Definitions,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -69,6 +69,7 @@ export type Event =
   | EventQuestionV2Rejected
   | EventTodoUpdated
   | EventLspUpdated
+  | EventCommandUpdated
   | EventPermissionAsked
   | EventPermissionReplied
   | EventTuiPromptAppend2
@@ -1369,6 +1370,13 @@ export type GlobalEvent = {
     | {
         id: string
         type: "lsp.updated"
+        properties: {
+          [key: string]: unknown
+        }
+      }
+    | {
+        id: string
+        type: "command.updated"
         properties: {
           [key: string]: unknown
         }
@@ -2917,6 +2925,7 @@ export type V2Event =
   | QuestionV2Rejected
   | TodoUpdated
   | LspUpdated
+  | CommandUpdated
   | PermissionAsked
   | PermissionReplied
   | TuiPromptAppend
@@ -5693,6 +5702,23 @@ export type LspUpdated = {
   }
 }
 
+export type CommandUpdated = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  type: "command.updated"
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  data: {
+    [key: string]: unknown
+  }
+}
+
 export type PermissionAsked = {
   id: string
   metadata?: {
@@ -6851,6 +6877,14 @@ export type EventTodoUpdated = {
 export type EventLspUpdated = {
   id: string
   type: "lsp.updated"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventCommandUpdated = {
+  id: string
+  type: "command.updated"
   properties: {
     [key: string]: unknown
   }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15452,6 +15452,9 @@
             "$ref": "#/components/schemas/EventLspUpdated"
           },
           {
+            "$ref": "#/components/schemas/EventCommandUpdated"
+          },
+          {
             "$ref": "#/components/schemas/EventPermissionAsked"
           },
           {
@@ -19653,6 +19656,25 @@
                   "type": {
                     "type": "string",
                     "enum": ["lsp.updated"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {}
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["command.updated"]
                   },
                   "properties": {
                     "type": "object",
@@ -24193,6 +24215,9 @@
           },
           {
             "$ref": "#/components/schemas/LspUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/CommandUpdated"
           },
           {
             "$ref": "#/components/schemas/PermissionAsked"
@@ -32580,6 +32605,47 @@
         "required": ["id", "type", "data"],
         "additionalProperties": false
       },
+      "CommandUpdated": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["command.updated"]
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "data": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
       "PermissionAsked": {
         "type": "object",
         "properties": {
@@ -36056,6 +36122,25 @@
           "type": {
             "type": "string",
             "enum": ["lsp.updated"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventCommandUpdated": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["command.updated"]
           },
           "properties": {
             "type": "object",

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -436,6 +436,12 @@ export const {
           break
         }
 
+        case "command.updated": {
+          const workspace = project.workspace.current()
+          void sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? [])))
+          break
+        }
+
         case "vcs.branch.updated": {
           if (workspace === project.workspace.current()) {
             setStore("vcs", { branch: event.properties.branch })


### PR DESCRIPTION
### Issue for this PR

Closes #36288
Closes #48629

### Type of change

- [x] Bug fix

### What does this PR do?

`/command` currently waits for all MCP servers to connect before returning file-based commands (measured 5.6s with 9 servers, 0.65s with MCP disabled — see issue). This PR makes the initial listing immediate and merges MCP prompts asynchronously:

- `Command.init` now loads defaults + config commands + skills synchronously; `mcp.prompts()` is forked into a background fiber (scoped to the cache entry) that merges prompts in-place once servers settle, preserving the existing `mcp > config > skill` precedence
- new `command.updated` event (same shape/pattern as `lsp.updated`) is published when the merge lands; the TUI sync store re-fetches `command.list` on receipt, so prompts appear in the `/` menu as soon as they exist
- `command.ready()` lets callers opt back into the old wait-for-prompts semantics; the ACP directory loader uses it (its snapshot is cached per-directory forever, so it must capture the merged state — behavior there is unchanged)
- prompt execution path is unaffected: it reads state fresh at execution time

Known trade-off (stated in the issue): a one-shot API consumer that neither subscribes to events nor re-fetches will see prompts missing from its first response during the connection window. The web app's bootstrap fetch is currently one-shot too; I'm happy to wire `command.updated` into it as a follow-up for consistency.

### How did you verify your code works?

- new regression tests (`packages/opencode/test/command/index.test.ts`): a stdio MCP server fixture with a 1.5s handshake delay — `command.list()` returns file commands within a 1s budget without the prompt, the prompt appears after `ready()`, and `command.updated` is received via `EventV2Bridge`; a second test covers the no-MCP-servers case (`ready()` resolves without hanging). Verified that both fail on the old implementation (the first behaviorally, the second at the missing `ready()` API).
- full `packages/opencode` suite: 3276 pass / 2 fail, both failures reproduce on the base commit (umask-dependent file mode assert + audio decode, unrelated)
- typecheck + prettier + generated SDK check pass
- manual smoke against a real server with a deliberately slow (5s) MCP server: `/command` returns in 0.52s at t≈2s with file commands only; after settle, prompt is listed (8ms)

### Screenshots / recordings

N/A (no visual change; behavior is timing-only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR