### PR TITLE
docs: remove shell prompt prefixes from install commands

### DIFF
--- a/services/www/src/docs/content/index.mdx
+++ b/services/www/src/docs/content/index.mdx
@@ -10,11 +10,11 @@ OpenCode installs and runs as `opencode`.
 
 <div data-install-code>
   <CodeBlock
-    code={`$ npm install -g @opencode/cli
-$ bun install -g --trust @opencode/cli
-$ pnpm add -g --allow-build=@opencode/cli @opencode/cli
-$ yarn global add @opencode/cli
-$ curl -fsSL https://opencode.ai/v2/install | bash`}
+    code={`npm install -g @opencode/cli
+bun install -g --trust @opencode/cli
+pnpm add -g --allow-build=@opencode/cli @opencode/cli
+yarn global add @opencode/cli
+curl -fsSL https://opencode.ai/v2/install | bash`}
   />
 </div>
 


### PR DESCRIPTION
### Issue for this PR

Closes #46554

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Remove `$ ` from the five installation commands. The Copy button copies this text directly, so copied commands no longer include shell prompt prefixes.

### How did you verify your code works?

- `git diff --check` and shell syntax checks passed.
- Website typecheck and build could not run because Bun and dependencies are not installed.

### Screenshots / recordings

Not captured.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR