### PR TITLE
fix(tui): restore terminal capability detection over SSH

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
@@ -192,6 +192,9 @@ export async function createRuntimeLifecycle(input: LifecycleInput): Promise<Lif
       externalOutputMode: "capture-stdout",
       consoleMode: "disabled",
       clearOnShutdown: false,
+      // Same as the TUI: avoid opentui's SSH auto-detection, which skips
+      // TERM/COLORTERM parsing and emits truecolor-only SGR.
+      remote: false,
     })
     const theme = await resolveRunTheme(renderer)
     renderer.setBackgroundColor(theme.background)

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -199,6 +199,10 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
               useKittyKeyboard: {},
               autoFocus: false,
               openConsoleOnError: false,
+              // Always run terminal detection as if local, even over SSH: opentui's auto
+              // remote detection skips TERM/COLORTERM parsing and emits truecolor-only
+              // SGR that 256-color-only terminals (e.g. macOS Terminal) cannot render.
+              remote: false,
               useMouse: !Flag.OPENCODE_DISABLE_MOUSE && input.config.mouse,
               consoleOptions: {
                 keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],


### PR DESCRIPTION
### Issue for this PR

Closes #39923

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It fixes colors when run via SSH to a Linux box on a MacOS

opentui's auto remote detection treats SSH sessions as opaque and returns early from environment parsing, so TERM/COLORTERM are never applied and the renderer emits unconditional truecolor SGR. On 256-color-only endpoints (macOS Terminal, GNU screen chains) every colored cell is dropped, producing the unreadable monochrome/garbled TUI

The opencode TUI always runs on a host-side pty, so pass `remote: false` to keep full capability detection (color depth, wcwidth, multiplexer) active regardless of SSH

### How did you verify your code works?

By looking at the screen when running via SSH
The new look is not perfect, but way better than before

### Screenshots / recordings

BEFORE (with bug):

<img width="1200" height="598" alt="Screenshot 2026-09-12 at 05 29 21" src="https://github.com/user-attachments/assets/a3b9401c-8974-419c-9d62-23cc69c779a8" />

AFTER (with fix):

<img width="1191" height="591" alt="Screenshot 2026-09-12 at 05 31 17" src="https://github.com/user-attachments/assets/2ab72ce9-6137-46f6-a8ad-4a50d970fd39" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
