### PR TITLE
docs: add npm v11/v12 --allow-scripts note

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ nix run nixpkgs#opencode           # or github:anomalyco/opencode for latest dev
 > [!TIP]
 > Remove versions older than 0.1.x before installing.
 
+> [!NOTE]
+> On npm v11+ / v12+, if lifecycle scripts are blocked, run:  
+> `npm i -g opencode-ai@latest --allow-scripts=opencode-ai`
+
 ### Desktop App (BETA)
 
 OpenCode is also available as a desktop application. Download directly from the [releases page](https://github.com/anomalyco/opencode/releases) or [opencode.ai/download](https://opencode.ai/download).


### PR DESCRIPTION
### Issue for this PR

Relates to #39660 (documents install workaround)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a troubleshooting note in the README installation section for users on npm v11+ / v12+. On these versions, global install blocks lifecycle scripts by default unless `--allow-scripts=opencode-ai` is explicitly passed.

### How did you verify your code works?

Verified on Windows 11 (Node v24.16.0, npm 12.0.0). Running `npm i -g opencode-ai@latest --allow-scripts=opencode-ai` successfully installs the package with scripts allowed.

### Screenshots / recordings

_N/A (README documentation update)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR