### PR TITLE
fix(desktop): rename Linux deb/rpm package to opencode-desktop

### DIFF
--- a/packages/desktop/electron-builder.config.test.ts
+++ b/packages/desktop/electron-builder.config.test.ts
@@ -29,6 +29,20 @@ for (const channel of channels) {
   })
 }
 
+test("names the prod Linux packages so they cannot collide with the opencode CLI", async () => {
+  const previous = process.env.OPENCODE_CHANNEL
+  process.env.OPENCODE_CHANNEL = "prod"
+
+  const module = await import("./electron-builder.config.ts?package-name=prod")
+  const config = module.default as Configuration
+
+  if (previous === undefined) delete process.env.OPENCODE_CHANNEL
+  else process.env.OPENCODE_CHANNEL = previous
+
+  expect(config.deb?.packageName).toBe("opencode-desktop")
+  expect(config.rpm?.packageName).toBe("opencode-desktop")
+})
+
 test("keeps a hidden prod launcher for old Linux pins", async () => {
   const previous = process.env.OPENCODE_CHANNEL
   process.env.OPENCODE_CHANNEL = "prod"

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -150,8 +150,8 @@ function getConfig() {
         productName: "OpenCode",
         protocols: { name: "OpenCode", schemes: ["opencode"] },
         publish: { provider: "github", owner: "anomalyco", repo: "opencode", channel: "latest" },
-        deb: { fpm: [metainfoFpm(appId), legacyDesktopEntryFpm] },
-        rpm: { packageName: "opencode", fpm: [metainfoFpm(appId), legacyDesktopEntryFpm] },
+        deb: { packageName: "opencode-desktop", fpm: [metainfoFpm(appId), legacyDesktopEntryFpm] },
+        rpm: { packageName: "opencode-desktop", fpm: [metainfoFpm(appId), legacyDesktopEntryFpm] },
       }
     }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #43905

Related open: #36982, #37268, #42879, #45766, #45767

Related closed: #15827, #15829, #15834, #9273, #7666, #7617, #27064, #28953, #22572

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The prod Linux deb/rpm packages are named `opencode`, the same name as the CLI package. Desktop and CLI are separate products — the prod Desktop does not bundle the CLI (`electron-builder.config.ts` excludes `resources/opencode-cli*`; only dev bundles it). Sharing one package name makes package managers treat them as versions of the same package: on openSUSE, `zypper dup`/Discover offer to replace the Desktop with the CLI.

#15834 set the Linux name to `opencode` while fixing the old `open-code` (#15829), without accounting for the separate CLI package. The collision already breaks things (#36982, #37268, #42879), and #45766/#45767 add CLI DEB/RPM packages that also use `name: opencode`, so it will get worse.

This sets the prod `deb.packageName` and `rpm.packageName` to `opencode-desktop`. Artifact names are unchanged (`opencode-desktop-linux-x86_64.rpm`), the app id/executable stay `ai.opencode.desktop`, and dev/beta keep `opencode-dev`/`opencode-beta`. The app already keeps the CLI binary distinct (`opencode-cli`/`opencode-cli.exe`), so a distinct Linux package name is consistent with what the project already does elsewhere.

I did not add Obsoletes/Replaces: the old Desktop package and the CLI share the exact name, so such a rule would also remove a distro-installed CLI. Existing Desktop installs on the old name must be removed once by hand (`zypper remove opencode` / `dpkg -r opencode`).

### How did you verify your code works?

Added a regression test asserting prod `deb.packageName` and `rpm.packageName` are `opencode-desktop`. Ran `bun test electron-builder.config.test.ts` from `packages/desktop`: 8 pass, 0 fail.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
