### PR TITLE
fix(core): include hidden files in glob and find results

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -52,7 +52,6 @@ export interface FindInput {
   readonly cwd: string
   readonly pattern: string
   readonly limit: number
-  readonly hidden?: boolean
   readonly follow?: boolean
   readonly signal?: AbortSignal
   readonly onEntry?: (entry: Entry) => Effect.Effect<void>
@@ -62,7 +61,6 @@ export interface GlobInput {
   readonly cwd: string
   readonly pattern: string
   readonly limit: number
-  readonly hidden?: boolean
   readonly follow?: boolean
   readonly signal?: AbortSignal
 }
@@ -160,10 +158,14 @@ const layer = Layer.effect(
           args: [
             "--no-config",
             "--files",
-            ...(input.hidden ? ["--hidden"] : []),
+            // rg prunes hidden directories during traversal unless a glob
+            // matches the directory entry itself, so precise globs can only
+            // reach paths inside hidden directories with --hidden
+            "--hidden",
             ...(input.follow ? ["--follow"] : []),
             `--glob=${input.pattern}`,
             "--glob=!**/.git/**",
+            "--glob=!**/.jj/**",
             ".",
           ],
           parse: (line) =>
@@ -192,10 +194,11 @@ const layer = Layer.effect(
           args: [
             "--no-config",
             "--files",
-            ...(input.hidden ? ["--hidden"] : []),
+            "--hidden",
             ...(input.follow ? ["--follow"] : []),
             ...(input.pattern === "*" ? [] : [`--glob=${input.pattern}`]),
             "--glob=!**/.git/**",
+            "--glob=!**/.jj/**",
             ".",
           ],
           parse: (line) => {
@@ -225,6 +228,7 @@ const layer = Layer.effect(
             "--no-messages",
             ...(input.include ? [`--glob=${input.include}`] : []),
             "--glob=!**/.git/**",
+            "--glob=!**/.jj/**",
             "--",
             input.pattern,
             input.file ?? ".",

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -31,7 +31,7 @@ describe("Ripgrep", () => {
     ),
   )
 
-  it.live("never includes git metadata", () =>
+  it.live("never includes VCS metadata", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),
       (tmp) =>
@@ -40,11 +40,19 @@ describe("Ripgrep", () => {
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".opencode", "config"), "needle\n"))
           yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, ".git")))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".git", "config"), "needle\n"))
+          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, ".jj")))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".jj", "config"), "needle\n"))
           const ripgrep = yield* Ripgrep.Service
 
           const files = yield* ripgrep.find({ cwd: tmp.path, pattern: "**/*", limit: 10 })
           expect(files.map((item) => item.path)).toContain(RelativePath.make(".opencode/config"))
           expect(files.map((item) => item.path)).not.toContain(RelativePath.make(".git/config"))
+          expect(files.map((item) => item.path)).not.toContain(RelativePath.make(".jj/config"))
+
+          const globbed = yield* ripgrep.glob({ cwd: tmp.path, pattern: "**/.opencode/config", limit: 10 })
+          expect(globbed.map((item) => item.path)).toContain(RelativePath.make(".opencode/config"))
+          expect(globbed.map((item) => item.path)).not.toContain(RelativePath.make(".git/config"))
+          expect(globbed.map((item) => item.path)).not.toContain(RelativePath.make(".jj/config"))
 
           const observed: string[] = []
           const limited = yield* ripgrep.find({
@@ -58,6 +66,7 @@ describe("Ripgrep", () => {
           const matches = yield* ripgrep.grep({ cwd: tmp.path, pattern: "needle", include: "config", limit: 10 })
           expect(matches.map((item) => item.entry.path)).toContain(RelativePath.make(".opencode/config"))
           expect(matches.map((item) => item.entry.path)).not.toContain(RelativePath.make(".git/config"))
+          expect(matches.map((item) => item.entry.path)).not.toContain(RelativePath.make(".jj/config"))
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),


### PR DESCRIPTION
### Issue for this PR

Closes #45911

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`find` and `glob` never passed `--hidden` to rg (the `hidden` input field existed but no caller set it), while `grep` always does. rg prunes hidden directories during traversal unless a glob matches the directory entry itself, so catch-all patterns like `**/*` still surface hidden files - which is why the existing test asserting `.opencode/config` in `find("**/*")` results passed and masked the bug - but precise patterns like `**/.github/PULL_REQUEST_TEMPLATE*` can never match.

This PR does the following:

- `find`/`glob` always pass `--hidden` like `grep`
- The unused `hidden` fields are removed
- `!**/.jj/**` has been added alongside the `.git` exclusion in all three tools, since traversal now reaches hidden directories and jj working copies duplicate every file under `.jj/working-copy/`.

### How did you verify your code works?

See section below.

### Screenshots / recordings

- Before (v1.18.29): https://opncd.ai/share/B0FY5MJe - Glob returns "No files found"
- After (dev with fix): https://opncd.ai/share/HkMGH87z - Glob returns 1 match

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
