### PR TITLE
docs: list gutchapa-opencode-telegram under Projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -63,6 +63,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                                                       | Description                                                      |
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK       |
+| [gutchapa-opencode-telegram](https://github.com/gutchapa/opencode-telegram)   | Telegram bot for OpenCode with shell/file tools, voice notes, and a bundled daily AI briefing — runs free on OpenCode Zen models |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
 | [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                           |


### PR DESCRIPTION
### Issue for this PR

Fixes #48746 (docs addition per the Ecosystem page's own "Submit a PR" note).

### Type of change

- [x] Documentation

### What does this PR do?

Lists gutchapa-opencode-telegram under Projects, next to kimaki (the closest precedent: a chat bot driving OpenCode sessions). One table row, no other changes. This supersedes #44498, which added the same repo under Plugins with an outdated description — I am closing that one.

### How did you verify your code works?

Docs-only change. Verified the table renders (column alignment matches surrounding rows) and both links resolve: repo (https://github.com/gutchapa/opencode-telegram) and npm (https://www.npmjs.com/package/gutchapa-opencode-telegram).

### Screenshots / recordings

N/A (docs table).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR