### PR TITLE
fix(nix): install opencode and keep opencode2 alias

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     export OPENCODE_CLI_DIST="$TMPDIR/desktop-cli"
     cli_package=$(bun -e 'import { getCurrentCli } from "./scripts/utils.ts"; console.log(getCurrentCli().package.replace("@opencode/", ""))')
     mkdir -p "$OPENCODE_CLI_DIST/$cli_package/bin"
-    cp ${lib.getExe opencode} "$OPENCODE_CLI_DIST/$cli_package/bin/opencode2"
+    cp ${lib.getExe opencode} "$OPENCODE_CLI_DIST/$cli_package/bin/opencode"
 
     bun run build
     npx electron-builder --dir \

--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -62,9 +62,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 dist/cli-*/bin/opencode2 $out/bin/opencode2
+    install -Dm755 dist/cli-*/bin/opencode $out/bin/opencode
 
-    wrapProgram $out/bin/opencode2 \
+    wrapProgram $out/bin/opencode \
       --prefix PATH : ${
         lib.makeBinPath (
           [
@@ -75,11 +75,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         )
       }
 
+    ln -s opencode $out/bin/opencode2
+
     runHook postInstall
   '';
 
   postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
     # trick yargs into also generating zsh completions
+    installShellCompletion --cmd opencode \
+      --bash <($out/bin/opencode completion) \
+      --zsh <(SHELL=/bin/zsh $out/bin/opencode completion)
+
     installShellCompletion --cmd opencode2 \
       --bash <($out/bin/opencode2 completion) \
       --zsh <(SHELL=/bin/zsh $out/bin/opencode2 completion)
@@ -101,7 +107,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "The open source coding agent";
     homepage = "https://opencode.ai";
     license = lib.licenses.mit;
-    mainProgram = "opencode2";
+    mainProgram = "opencode";
     inherit (node_modules.meta) platforms;
   };
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48663

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Nix package was still installing `opencode2` as the primary CLI even though V2 uses `opencode`.

This switches the packaged binary to `opencode`, keeps `opencode2` as a symlink for compatibility, generates completions for both names, and updates `mainProgram` to `opencode`.

It also aligns `nix/desktop.nix` with that contract so the desktop packaging path stages `opencode`, matching the bundled CLI path that the desktop build consumes.

### How did you verify your code works?

- `nix build .#opencode --no-link`
- ran both `$out/bin/opencode --version` and `$out/bin/opencode2 --version`
- confirmed `$out/bin/opencode2` is a symlink to `opencode`
- `nix build .#opencode-desktop --dry-run`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
