### PR TITLE
chore: remove duplicate options blocks in oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,11 +41,5 @@
     // Warn when spreading non-plain objects (Headers, class instances, etc.)
     "typescript/no-misused-spread": "warn"
   },
-  "options": {
-    "typeAware": true
-  },
-  "options": {
-    "typeAware": true
-  },
   "ignorePatterns": ["**/node_modules", "**/dist", "**/.build", "**/.sst", "**/*.d.ts", "**/sdk.gen.ts"]
 }


### PR DESCRIPTION
### Issue for this PR

Closes #37365

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

There are three total "options" entries in `.oxlintrc.json`. This is harmless, but causes the JSON to be semantically invalid. The fix is to simply drop the duplicated entries.

### How did you verify your code works?

By running `oxlint`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
