### PR TITLE
fix(app): reject invalid utf-8 directory segments

### DIFF
--- a/packages/app/src/context/tab-migration.ts
+++ b/packages/app/src/context/tab-migration.ts
@@ -10,10 +10,12 @@ export function migrateTabs(value: unknown, fallback: ServerConnection.Key): Tab
     if (tab.type === "session" && typeof tab.sessionId === "string") {
       return [{ type: tab.type, server, sessionId: tab.sessionId }]
     }
+    // A directory decoded to U+FFFD can never resolve, so do not restore a draft that points at it.
     if (
       tab.type === "draft" &&
       typeof tab.draftID === "string" &&
       typeof tab.directory === "string" &&
+      !tab.directory.includes("\uFFFD") &&
       (tab.worktree === undefined || typeof tab.worktree === "string")
     ) {
       return [{ type: tab.type, server, draftID: tab.draftID, directory: tab.directory, worktree: tab.worktree }]

--- a/packages/app/src/context/tabs.test.ts
+++ b/packages/app/src/context/tabs.test.ts
@@ -27,6 +27,12 @@ describe("tab migration", () => {
     expect(migrateTabs(null, server)).toEqual([])
     expect(migrateTabs({}, server)).toEqual([])
   })
+
+  test("drops drafts whose directory decoded to replacement characters", () => {
+    const damaged: Tab = { type: "draft", server, draftID: "a", directory: "j\uFFFD" }
+    const valid: Tab = { type: "draft", server, draftID: "b", directory: "/home/dev/repo" }
+    expect(migrateTabs([damaged, valid], server)).toEqual([valid])
+  })
 })
 
 describe("tab memory", () => {

--- a/packages/app/src/pages/directory-layout.test.ts
+++ b/packages/app/src/pages/directory-layout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { decodeDirectory } from "./directory-layout"
+
+describe("decodeDirectory", () => {
+  test("decodes canonical directory segments", () => {
+    const decoded: string | undefined = decodeDirectory(base64Encode("项目/repo"))
+    expect(decoded).toBe("项目/repo")
+  })
+
+  test("rejects segments that do not round trip", () => {
+    // "app" decodes to "j\uFFFD", which is not a directory we would have encoded.
+    expect(decodeDirectory("app")).toBeUndefined()
+  })
+})

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -80,6 +80,8 @@ export type ProjectDirString = Schema.Schema.Type<typeof ProjectDirString>
 export function decodeDirectory(dir: string): ProjectDirString | undefined {
   const decoded = decode64(dir)
   if (!decoded) return
+  // A non-canonical segment like "app" decodes to "j\uFFFD", which is never a directory we encoded.
+  if (base64Encode(decoded) !== dir) return
   return ProjectDirString.make(decoded)
 }
 

--- a/packages/core/src/util/encode.ts
+++ b/packages/core/src/util/encode.ts
@@ -7,7 +7,7 @@ export function base64Encode(value: string) {
 export function base64Decode(value: string) {
   const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/"))
   const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
-  return new TextDecoder().decode(bytes)
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
 }
 
 export async function hash(content: string, algorithm = "SHA-256"): Promise<string> {

--- a/packages/core/test/util/encode.test.ts
+++ b/packages/core/test/util/encode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { base64Decode, base64Encode } from "@opencode-ai/core/util/encode"
+
+describe("base64", () => {
+  test("round trips utf-8 values", () => {
+    const value = "项目/café"
+    expect(base64Decode(base64Encode(value))).toBe(value)
+  })
+
+  test("throws when the decoded bytes are not valid utf-8", () => {
+    // "app" is valid base64 whose bytes (6a 9a) are not valid utf-8.
+    expect(() => base64Decode("app")).toThrow()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #38235

### Type of change

- [x] Bug fix

### What does this PR do?

Opening `/app/` in the web UI matches the `/:dir` route with `dir="app"`. `atob("app")` does not throw, it yields the bytes `6A 9A`, and the non-fatal `TextDecoder` turned `9A` into U+FFFD. So `"j\uFFFD"` became the working directory, was written to the localStorage draft tab, and every request for it failed with `FileSystem.realPath ENOENT` (500 on `/api/reference`).

The fix is three small changes:

- `base64Decode` decodes with `{ fatal: true }`, so invalid UTF-8 rejects instead of producing mojibake. The `decode64` wrapper already handles the error.
- `decodeDirectory` only accepts segments that round-trip through `base64Encode`, the same guard `requireServerKey` already uses.
- `migrateTabs` drops persisted draft tabs whose directory contains U+FFFD, so drafts polluted by older versions do not survive the upgrade.

This is the client half of #38314, which the PR cleanup bot closed. The server half, where a request carrying a U+FFFD `x-opencode-directory` still loads an instance for that path, is not covered here. That is a separate follow-up PR for #37764 and #41225, whose servers start up on a mojibake workspace directory.

### How did you verify your code works?

Reproduced on Windows against `opencode serve` 1.18.30 before the change: opening `/app/` redirected to `/new-session?draftId=…`, localStorage held `"directory":"j\uFFFD"`, and `GET /api/reference?directory=j%EF%BF%BD` returned 500 with `FileSystem.realPath (j\uFFFD) ENOENT` in the server log.

With this branch, running the dev backend plus `packages/app` on :4444: opening `/app/` redirects to `/` with the invalid URL toast, nothing is written to localStorage, and no request is made for the bad path. Seeding `opencode.window.browser.dat:tabs` with a polluted draft tab and reloading leaves `[]`.

- `bun test test/util/encode.test.ts` in `packages/core`: 2 passed
- `bun test --conditions=solid --preload ./happydom.ts ./src/pages/directory-layout.test.ts ./src/context/tabs.test.ts` in `packages/app`: 15 passed
- `bun typecheck` in `packages/app` and `packages/core`

### Screenshots / recordings

No visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
