### PR TITLE
fix(opencode): ignore directories that decoded to replacement characters

### DIFF
--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -30,6 +30,13 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/In
 
 export const use = serviceUse(Service)
 
+// A directory that decoded to U+FFFD is mojibake from an invalid base64 segment or a stale client, so never load an
+// instance for it. Falling back to the server's own directory keeps requests working instead of failing on realPath.
+function resolveDirectory(input: string): string {
+  if (input.includes("\uFFFD")) return FSUtil.resolve(process.cwd())
+  return FSUtil.resolve(input)
+}
+
 interface Entry {
   readonly deferred: Deferred.Deferred<InstanceContext>
 }
@@ -106,7 +113,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
     })
 
     const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
+      const directory = resolveDirectory(input.directory)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const existing = cache.get(directory)
@@ -124,7 +131,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
     }
 
     const reload = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
+      const directory = resolveDirectory(input.directory)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const previous = cache.get(directory)

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -7,6 +7,7 @@ import * as Socket from "effect/unstable/socket/Socket"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { registerAdapter } from "../../src/control-plane/adapters"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import type { WorkspaceAdapter } from "../../src/control-plane/types"
 import { Workspace } from "../../src/control-plane/workspace"
@@ -185,6 +186,19 @@ describe("HttpApi instance context middleware", () => {
       expect(response.status).toBe(200)
       expect(yield* response.json).toMatchObject({
         directory: path.join(process.cwd(), "%E0%A4%A"),
+      })
+    }),
+  )
+
+  it.live("falls back to the server directory when the routed directory decoded to replacement characters", () =>
+    Effect.gen(function* () {
+      yield* serveProbe()
+
+      const response = yield* HttpClient.get(`/probe?directory=${encodeURIComponent("j\uFFFD")}`)
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toMatchObject({
+        directory: FSUtil.resolve(process.cwd()),
       })
     }),
   )

--- a/packages/opencode/test/server/httpapi-reference.test.ts
+++ b/packages/opencode/test/server/httpapi-reference.test.ts
@@ -60,4 +60,16 @@ describe("reference HttpApi", () => {
       },
     ])
   })
+
+  test("falls back to the server directory when the requested directory decoded to replacement characters", async () => {
+    // Same shape the web UI sends after a malformed directory segment: both the plain and location-scoped query.
+    const directory = encodeURIComponent("j\uFFFD")
+    const response = await Server.Default().app.request(
+      `/api/reference?directory=${directory}&location[directory]=${directory}`,
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.location.directory).not.toContain("\uFFFD")
+  })
 })

--- a/packages/server/src/location.ts
+++ b/packages/server/src/location.ts
@@ -29,9 +29,12 @@ export function response<A, E, R>(data: Effect.Effect<A, E, R>) {
 function ref(request: HttpServerRequest.HttpServerRequest): Location.Ref {
   const query = new URL(request.url, "http://localhost").searchParams
   const workspaceID = query.get("location[workspace]") || request.headers["x-opencode-workspace"]
-  const directory =
+  const requested =
     query.get("location[directory]") ||
     (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : process.cwd())
+  // A directory that decoded to U+FFFD is mojibake from an invalid base64 segment, so use the server's own directory
+  // instead of failing every path lookup against a directory that cannot exist.
+  const directory = requested.includes("\uFFFD") ? process.cwd() : requested
   return Location.Ref.make({
     directory: AbsolutePath.make(directory),
     workspaceID: workspaceID ? WorkspaceV2.ID.make(workspaceID) : undefined,


### PR DESCRIPTION
### Issue for this PR

Closes #37764
Closes #41225

### Type of change

- [x] Bug fix

### What does this PR do?

A request can carry a workspace directory that decoded to U+FFFD, either because a stale client stored one or because a malformed base64 route segment was decoded into one. Today the server accepts it: `InstanceStore.load` creates an instance for that path, and location-scoped handlers resolve it, so the request fails with `FileSystem.realPath ENOENT`. The web UI shows this as an empty interface, `failed to initialize file picker: Invalid path ...\uFFFD` and a 500 on `/api/reference`.

Two guards, both falling back to the server's own directory because the requested one cannot exist:

- `InstanceStore.load` / `reload` resolve a directory containing U+FFFD to `process.cwd()`, which keeps instance bootstrap (file picker, watchers, LSP) off the broken path.
- `packages/server/src/location.ts` does the same when a request resolves its location, which is the lane `/api/reference` uses.

This is the server half of #38314, which the cleanup bot closed. The client half, where the web UI stops decoding a malformed segment into U+FFFD and drops already polluted draft tabs, is #48670.

### How did you verify your code works?

- `bun test test/server/httpapi-instance-context.test.ts`: 10 passed, including a new probe test where `?directory=j%EF%BF%BD` now reports the server directory. Reverting the `InstanceStore` guard fails that test with `<cwd>\j\uFFFD`.
- `bun test test/server/httpapi-reference.test.ts`: 2 passed. The new test replays the exact request the web UI sends (`?directory=j%EF%BF%BD&location[directory]=j%EF%BF%BD`) and asserts 200; without the location guard it returns 500.
- Real server, on this branch (`bun run ./src/index.ts serve --port 4096`): `GET /api/reference?directory=j%EF%BF%BD&location[directory]=j%EF%BF%BD` returned 500 with `FileSystem.realPath (j\uFFFD) ENOENT` before, and 200 with `location.directory` set to the server directory after. The server log has no further `realPath` errors.
- Same server with the web UI on :4444: opening `/app/` no longer produces the `500 /api/reference` console error.
- `bun typecheck` in `packages/server` and `packages/opencode`.

### Screenshots / recordings

No visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
