### PR TITLE
fix(provider): exclude rejected models from suggestions

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1360,6 +1360,7 @@ function modeOptions(model: Model, body: Record<string, unknown> | undefined) {
 function modelSuggestions(provider: Info | undefined, modelID: ModelV2.ID, enableExperimentalModels: boolean) {
   const available = provider
     ? Object.keys(provider.models).filter((id) => {
+        if (id === modelID) return false
         const model = provider.models[id]
         if (model.status === "deprecated") return false
         if (model.status === "alpha" && !enableExperimentalModels) return false

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1200,6 +1200,29 @@ it.instance("ModelNotFoundError suggests catalog models for unloaded providers",
   }),
 )
 
+it.instance("ModelNotFoundError does not suggest the rejected catalog model", () =>
+  Effect.gen(function* () {
+    yield* remove("OPENCODE_API_KEY")
+    const error = yield* Provider.use
+      .getModel(ProviderV2.ID.opencode, ModelV2.ID.make("claude-haiku-4-5"))
+      .pipe(Effect.flip)
+    if (!Provider.ModelNotFoundError.isInstance(error)) throw error
+    expect(error.suggestions ?? []).not.toContain("claude-haiku-4-5")
+  }),
+)
+
+it.instance(
+  "ModelNotFoundError does not suggest the rejected model for a disabled provider",
+  Effect.gen(function* () {
+    const error = yield* Provider.use
+      .getModel(ProviderV2.ID.anthropic, ModelV2.ID.make("claude-sonnet-4-6"))
+      .pipe(Effect.flip)
+    if (!Provider.ModelNotFoundError.isInstance(error)) throw error
+    expect(error.suggestions ?? []).not.toContain("claude-sonnet-4-6")
+  }),
+  { config: { disabled_providers: ["anthropic"] } },
+)
+
 it.instance("getProvider returns undefined for nonexistent provider", () =>
   Effect.gen(function* () {
     const provider = yield* Provider.Service.use((svc) => svc.getProvider(ProviderV2.ID.make("nonexistent")))


### PR DESCRIPTION
### Issue for this PR

Closes #48578

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Exclude the rejected model ID before ranking catalog suggestions. An unavailable model or disabled provider can otherwise produce “Did you mean” with the exact model that failed. Other catalog suggestions remain available.

### How did you verify your code works?

Both new regression tests failed before the fix and pass afterward. Provider and CLI error suites: 110 pass, 0 fail. Package `bun typecheck`, Prettier, and `git diff --check` pass.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
