### PR TITLE
fix(llm): retry transient HTTP 408 and 409 responses

### DIFF
--- a/packages/llm/src/route/executor.ts
+++ b/packages/llm/src/route/executor.ts
@@ -88,7 +88,8 @@ const requestId = (headers: Record<string, string>) => {
   )
 }
 
-const retryableStatus = (status: number) => status === 429 || status === 503 || status === 504 || status === 529
+const retryableStatus = (status: number) =>
+  status === 408 || status === 409 || status === 429 || status === 503 || status === 504 || status === 529
 
 const retryAfterMs = (headers: Record<string, string>) => {
   const millis = Number(headers["retry-after-ms"])
@@ -250,13 +251,7 @@ const statusReason = (input: {
       http: input.http,
     })
   }
-  if (
-    input.status === 400 ||
-    input.status === 404 ||
-    input.status === 409 ||
-    input.status === 413 ||
-    input.status === 422
-  ) {
+  if (input.status === 400 || input.status === 404 || input.status === 413 || input.status === 422) {
     return new InvalidRequestReason({
       message: input.message,
       classification: isContextOverflow(body) ? "context-overflow" : undefined,

--- a/packages/llm/test/executor.test.ts
+++ b/packages/llm/test/executor.test.ts
@@ -264,8 +264,30 @@ describe("RequestExecutor", () => {
       ),
     ),
   )
+  ;[408, 409].forEach((status) => {
+    it.effect(`retries HTTP ${status} before returning a successful response`, () =>
+      Effect.gen(function* () {
+        const attempts = yield* Ref.make(0)
+        yield* Effect.gen(function* () {
+          const executor = yield* RequestExecutor.Service
+          const response = yield* executor.execute(request)
 
-  it.effect("marks 504 and 529 status responses retryable", () =>
+          expect(response.status).toBe(200)
+          expect(yield* response.text).toBe("ok")
+          expect(yield* Ref.get(attempts)).toBe(2)
+        }).pipe(
+          Effect.provide(
+            countedResponsesLayer(attempts, [
+              new Response("transient failure", { status, headers: { "retry-after-ms": "0" } }),
+              new Response("ok", { status: 200 }),
+            ]),
+          ),
+        )
+      }),
+    )
+  })
+
+  it.effect("marks 408, 409, 504 and 529 status responses retryable", () =>
     Effect.gen(function* () {
       const failWith = (status: number) =>
         Effect.gen(function* () {
@@ -290,6 +312,8 @@ describe("RequestExecutor", () => {
           ),
         )
 
+      yield* failWith(408)
+      yield* failWith(409)
       yield* failWith(504)
       yield* failWith(529)
     }),


### PR DESCRIPTION
### Issue for this PR

Fixes #47525

This PR covers the V2 runtime. The legacy runtime is covered separately by #47524.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restore HTTP 408 and 409 as retryable provider failures in the LLM request executor, preserving the behavior introduced in #39391. They now use the existing retry budget, backoff, and Retry-After handling instead of failing immediately.

### How did you verify your code works?

The new recovery tests and expanded error-classification test failed before the fix. All 17 executor tests now pass, including retry exhaustion, backoff, and non-retryable errors. Package `bun typecheck`, Prettier, and `git diff --check` pass.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
