### PR TITLE
fix(session-ui): stop expand/collapse all label from overflowing in longer locales

### DIFF
--- a/packages/session-ui/src/components/session-review.tsx
+++ b/packages/session-ui/src/components/session-review.tsx
@@ -360,7 +360,7 @@ export const SessionReview = (props: SessionReviewProps) => {
             <Button
               size="small"
               icon="chevron-grabber-vertical"
-              class="w-[106px] justify-start"
+              class="min-w-[106px] justify-start"
               onClick={handleExpandOrCollapseAll}
             >
               <Switch>


### PR DESCRIPTION
### Issue for this PR

Closes #48685

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The expand/collapse all button in the session review header uses a fixed width (`w-[106px]`). "Expand all" fits at 106px, but longer translations (e.g. "Expandir tudo" in pt-BR) overflow the button border, because the button label is `white-space: nowrap` and not truncated.

Changing the fixed width to a minimum width lets the button grow to fit the label, while keeping the current size when the label is shorter.

### How did you verify your code works?

Rendered the button with the compiled CSS from the installed desktop app (1.18.29) in Chromium, before and after the class change: before, the pt-BR label renders past the 106px button border; after, the button grows to ~126px and the label fits. The English label stays at 106px.

### Screenshots / recordings

![before/after](https://raw.githubusercontent.com/yanhenrique-dev/opencode/857af6d0a7ce2ce954ee5f940cecbbe59ec0e23e/issue-assets/expand-overflow-before-after.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
