### PR TITLE
fix(cli): remove inherited wizard and log-level flags

### DIFF
--- a/packages/cli/src/framework/runtime.ts
+++ b/packages/cli/src/framework/runtime.ts
@@ -1,5 +1,5 @@
 import { Effect, FileSystem, Scope } from "effect"
-import { Command } from "effect/unstable/cli"
+import { CliConfig, Command, GlobalFlag } from "effect/unstable/cli"
 import { PrintLogs } from "../commands/commands"
 import { Spec } from "./spec"
 import { Global } from "@opencode/util/global"
@@ -82,11 +82,13 @@ export function handlers<const Root extends Spec.Any>(root: Root, handlers: Hand
 }
 
 export function run(commands: Spec.Any, handlers: ReadonlyArray<LazyHandler>, options: { readonly version: string }) {
-  return Command.run(provide(commands, handlers).pipe(Command.withGlobalFlags([PrintLogs])), options) as Effect.Effect<
-    void,
-    unknown,
-    Command.Environment
-  >
+  return Command.run(provide(commands, handlers).pipe(Command.withGlobalFlags([PrintLogs])), options).pipe(
+    Effect.provide(
+      CliConfig.layer({
+        builtIns: [GlobalFlag.Help, GlobalFlag.Version, GlobalFlag.Completions],
+      }),
+    ),
+  ) as Effect.Effect<void, unknown, Command.Environment>
 }
 
 function provide(node: Spec.Any, handlers: ReadonlyArray<LazyHandler>): ProvidedCommand {


### PR DESCRIPTION
## Why

Every OpenCode command inherits Effect CLI's `--wizard` and `--log-level` flags. These expose framework-level behavior as part of OpenCode's public CLI and clutter the global help section.

## What Changes

Explicitly allowlist Effect's help, version, and shell-completion built-ins at the shared command runner.

| Input | Before | After |
| --- | --- | --- |
| `--wizard` | Starts Effect's interactive command wizard | Unrecognized flag, exit 1 |
| `--log-level debug` | Configures Effect's minimum log level | Unrecognized flag, exit 1 |
| `--help` on root or nested commands | Lists both inherited flags | Lists help, version, completions, and OpenCode's `--print-logs` |

The explicit list also prevents newly introduced Effect built-ins from silently expanding OpenCode's CLI.

## Demo

Matched real PTY captures of `bun run src/index.ts debug paths --help`, recorded with termctrl at 160 × 24. Before: `7c5a4d01aa`; after: `6b04d490a6`. The nine-second video holds each captured result for readability and cuts out setup time. Captured with Bun 1.4.0; validation and the pre-push hook also passed with Bun 1.4.2.

https://github.com/user-attachments/assets/4920d9a6-1751-4247-bd17-5c254204aa5d

## Scope

Owns the built-in global flag policy for the CLI command tree through `Runtime.run`.

## Verification

```sh
# packages/cli, Bun 1.4.2
bun typecheck
bun run test test/debug-paths.test.ts test/import-boundaries.test.ts

# Smoke-checked from packages/cli
bun run src/index.ts --help
bun run src/index.ts debug paths --help
bun run src/index.ts --wizard
bun run src/index.ts --log-level debug
bun run src/index.ts debug paths --wizard
bun run src/index.ts debug paths --log-level debug
bun run src/index.ts --version
bun run src/index.ts --completions bash
bun run src/index.ts --completions zsh
bun run src/index.ts --completions fish
```

Six focused tests pass. Both removed flags exit 1 at root and nested command paths; help omits them and retains the supported flags. Version and all three completion generators succeed. The normal pre-push hook passed all 35 typecheck tasks with Bun 1.4.2.
