### PR TITLE
fix(session-ui): stop animating layout in streaming count labels

### DIFF
--- a/packages/session-ui/src/components/tool-count-summary.css
+++ b/packages/session-ui/src/components/tool-count-summary.css
@@ -12,13 +12,11 @@
     transform: translateY(0) scale(1);
     overflow: hidden;
     transform-origin: left center;
-    transition-property: grid-template-columns, opacity, filter, transform;
+    transition-property: opacity, filter, transform;
     transition-duration:
-      var(--tool-motion-spring-ms, 480ms), var(--tool-motion-fade-ms, 240ms), var(--tool-motion-fade-ms, 280ms),
+      var(--tool-motion-fade-ms, 240ms), var(--tool-motion-fade-ms, 280ms),
       var(--tool-motion-spring-ms, 480ms);
-    transition-timing-function:
-      var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1)), ease-out, ease-out,
-      var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1));
+    transition-timing-function: ease-out, ease-out, var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1));
   }
 
   [data-slot="tool-count-summary-empty"][data-active="false"] {
@@ -37,13 +35,11 @@
     transform: translateY(0.06em) scale(0.985);
     overflow: hidden;
     transform-origin: left center;
-    transition-property: grid-template-columns, opacity, filter, transform;
+    transition-property: opacity, filter, transform;
     transition-duration:
-      var(--tool-motion-spring-ms, 480ms), var(--tool-motion-fade-ms, 280ms), var(--tool-motion-fade-ms, 320ms),
+      var(--tool-motion-fade-ms, 280ms), var(--tool-motion-fade-ms, 320ms),
       var(--tool-motion-spring-ms, 480ms);
-    transition-timing-function:
-      var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1)), ease-out, ease-out,
-      var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1));
+    transition-timing-function: ease-out, ease-out, var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1));
   }
 
   [data-slot="tool-count-summary-item"][data-active="true"] {

--- a/packages/ui/src/components/animated-number.css
+++ b/packages/ui/src/components/animated-number.css
@@ -13,7 +13,6 @@
     line-height: inherit;
     width: var(--animated-number-width, 1ch);
     overflow: hidden;
-    transition: width var(--tool-motion-spring-ms, 560ms) var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1));
   }
 
   [data-slot="animated-number-digit"] {


### PR DESCRIPTION
### Issue for this PR

Closes #48693

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops animating layout properties on the streaming count labels:

- `packages/session-ui/src/components/tool-count-summary.css` no longer transitions `grid-template-columns` (480ms) on the empty/items slots.
- `packages/ui/src/components/animated-number.css` no longer transitions `width` (560ms) on the value container.

Both properties run on every count/status change while tools execute, forcing a layout per frame for ~0.5s each time. The `opacity`/`filter`/`transform` transitions are kept, so the fade/blur of the labels is unchanged; the sizes now snap.

### How did you verify your code works?

Loaded the component CSS in Chromium 153 before/after and read the computed styles with the same DOM:

- before: `transition-property: grid-template-columns, opacity, filter, transform` (durations `0.48s, 0.28s, 0.32s, 0.48s`); number `transition-property: width`, `transition-duration: 0.56s`
- after: `transition-property: opacity, filter, transform` (durations `0.28s, 0.32s, 0.48s`); number has no transition (`0s`)

Resting geometry is unchanged (`animated-number` value still `2ch` = `15.5625px` in both).

### Screenshots / recordings

No rest-state visual change — this only removes the intermediate layout animation.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
