### PR TITLE
fix(session-ui): stop animating width in tool status titles

### DIFF
--- a/packages/session-ui/src/components/tool-status-title.css
+++ b/packages/session-ui/src/components/tool-status-title.css
@@ -20,7 +20,6 @@
     display: inline-grid;
     overflow: hidden;
     justify-items: start;
-    transition: width var(--tool-motion-spring-ms, 480ms) var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1));
   }
 
   [data-slot="tool-status-active"],
@@ -37,11 +36,6 @@
   }
 
   &[data-ready="false"] {
-    [data-slot="tool-status-swap"],
-    [data-slot="tool-status-tail"] {
-      transition-duration: 0ms;
-    }
-
     [data-slot="tool-status-active"],
     [data-slot="tool-status-done"] {
       transition-duration: 0ms;


### PR DESCRIPTION
### Issue for this PR

Closes #48697

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops animating `width` on `ToolStatusTitle`'s swap slots. The component writes the target width when the label swaps, and the CSS transitioned it over 480ms, recalculating style and layout each frame. The existing crossfade (`opacity`/`filter`/`transform`) is unchanged; the width now snaps.

Measured in a real desktop instance (1.18.29, via CDP) forcing 125 swaps in 2s:

- before: `RecalcStyleDuration +0.081s`, `LayoutDuration +0.005s`
- after: `0.000s` / `0.000s`

Real frequency is low (roughly once per turn, when the context group label flips), so this is a small cleanup rather than a big win.

### How did you verify your code works?

Ran the installed desktop app (1.18.29) with remote debugging and applied the same CSS change live: forced repeated label swaps and read `Performance.getMetrics` before/after (numbers above). Also confirmed the computed `transition-property` on the swap slot: `width` before, none after, with the crossfade properties untouched.

### Screenshots / recordings

No rest-state visual change — only the intermediate width animation is removed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
