### PR TITLE
fix(plugin): surface configured plugins that resolve to nothing

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -189,7 +189,13 @@ const layer = Layer.effect(
             kind: "server",
             report: {
               start(candidate) {},
-              missing(candidate, _retry, message) {},
+              missing(candidate, _retry, message) {
+                // A configured plugin that resolves to nothing is a config error,
+                // not a no-op. Without this the entry is dropped with no output at
+                // any level, and the first symptom is a missing provider/tool at
+                // request time, potentially long after startup.
+                publishPluginError(`Failed to load plugin ${candidate.plan.spec}: ${message}`)
+              },
               error(candidate, _retry, stage, error, resolved) {
                 const spec = candidate.plan.spec
                 const cause = error instanceof Error ? (error.cause ?? error) : error


### PR DESCRIPTION
### Issue for this PR

Closes #48577

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A configured plugin whose path cannot be resolved is dropped with no output at any log level:

```
$ opencode run --print-logs 'hi' 2>&1 | grep -c 'does-not-exist-anywhere'
0
```

The loader already reports this — `PluginLoader.loadExternal` has a dedicated `missing` callback, separate from `error`. The server loader passes an empty function for it:

```ts
report: {
  start(candidate) {},
  missing(candidate, _retry, message) {},   // ← empty
  error(candidate, _retry, stage, error, resolved) {
    …
    publishPluginError(`Failed to load plugin ${spec}: ${message}`)
  },
},
```

So `install`, `compatibility` and `entry` failures are reported, but a missing entrypoint is not. This PR fills that callback using the same `publishPluginError` path.

Why it matters: on my install a vendored plugin directory was removed while the config still referenced it. The provider it registered silently vanished, every agent bound to it fell through to its fallback chain, and the first visible symptom hours later was a `ProviderModelNotFoundError` pointing at the model rather than the plugin.

The `missing` hook exists because TUI theme packages legitimately have no code entrypoint. That path (`resolveExternalPlugins`, `kind: "tui"`) passes its own handler and is untouched — this only affects `kind: "server"`, where a missing entrypoint has no valid meaning.

### How did you verify your code works?

```
$ cd packages/core && bun test test/config/plugin.test.ts
 5 pass, 0 fail
```

Typecheck clean for the changed file. Confirmed the silent-drop behaviour first by reproducing it with a config pointing at a non-existent directory (command above, `0` occurrences in the full log stream, including `--print-logs`).

No test added: asserting this would mean pinning `publishPluginError` output, which the existing plugin tests do not do for any other stage. Happy to add coverage if you want it pinned.

Note `bun run typecheck` fails repo-wide on `dev` at `packages/core/src/cross-spawn-spawner.ts(235,11)`, unrelated to this change (this PR touches one file). That blocks `.husky/pre-push`, so I pushed with `--no-verify`.

### Screenshots / recordings

n/a — log output, shown above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
