### PR TITLE
fix(app): shorten session panel width transition to 160ms

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2261,7 +2261,7 @@ export default function Page() {
         <div
           classList={{
             "@container relative shrink-0 flex flex-col min-h-0 h-full flex-1 md:flex-none transition-[width]": true,
-            "duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
+            "duration-[160ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
               !size.active() && !ui.reviewSnap && !desktopInlineTerminalOnlyOpen(),
           }}
           style={{

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -301,7 +301,7 @@ export function SessionSidePanel(props: {
           "h-full shrink-0": !props.stacked,
           "h-full min-h-0": props.stacked,
           "pointer-events-none": !open(),
-          "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
+          "transition-[width] duration-[160ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
             !props.size.active() && !props.reviewSnap,
           "rounded-[10px] shadow-[var(--v2-elevation-raised)] overflow-hidden": settings.general.newLayoutDesigns(),
           "flex-1": reviewOpen(),


### PR DESCRIPTION
### Issue for this PR

Closes #48701

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shortens the session panel width transition from 240ms to 160ms, in both the chat panel (`pages/session.tsx`) and the side panel (`pages/session/session-side-panel.tsx`, kept in sync so they don't animate at different speeds).

The animation shape and easing are unchanged; it just spends less time reflowing content. `contain: layout paint` was tried and gave no measurable gain (the cost is inside the panel, not around it), so it is not included.

Measured in a real desktop instance (1.18.29, via CDP), per panel toggle, average of 6 toggles per variant:

| variant | layout | script | task |
| --- | --- | --- | --- |
| 240ms (before) | 64ms | 16ms | 239ms |
| `contain: layout paint` | 62ms | 15ms | 231ms |
| 160ms (this PR) | 45ms | 13ms | 181ms |
| no animation (control) | 7ms | 4ms | 32ms |

### How did you verify your code works?

Ran the installed desktop app with remote debugging and toggled the panel width via CDP, reading `Performance.getMetrics` per variant (numbers above). The no-animation control shows the floor cost of a single reflow. Visual behavior is unchanged apart from the shorter duration.

### Screenshots / recordings

No rest-state visual change — same animation, just faster.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
