### PR TITLE
refactor(app): replace transition-all with explicit transition properties

### DIFF
--- a/packages/app/src/components/dialog-release-notes.tsx
+++ b/packages/app/src/components/dialog-release-notes.tsx
@@ -103,7 +103,7 @@ export function DialogReleaseNotes(props: { highlights: Highlight[] }) {
                 {props.highlights.map((_, i) => (
                   <button
                     type="button"
-                    class="h-6 flex items-center cursor-pointer bg-transparent border-none p-0 transition-all duration-200"
+                    class="h-6 flex items-center cursor-pointer bg-transparent border-none p-0 transition-[width] duration-200"
                     classList={{
                       "w-8": i === index(),
                       "w-3": i !== index(),

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -51,7 +51,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
               >
                 <div
                   classList={{
-                    "group shrink-0 flex flex-col rounded-[6px] pl-2 pr-1 py-1 max-w-[200px] h-12 cursor-default transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
+                    "group shrink-0 flex flex-col rounded-[6px] pl-2 pr-1 py-1 max-w-[200px] h-12 cursor-default transition-[box-shadow,background-color] shadow-xs-border hover:shadow-xs-border-hover": true,
                     "hover:bg-surface-interactive-weak": !!item.commentID && !selected,
                     "bg-surface-interactive-hover hover:bg-surface-interactive-hover shadow-xs-border-hover": selected,
                     "bg-background-stronger": !selected,
@@ -76,7 +76,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                       type="button"
                       icon="close-small"
                       variant="ghost"
-                      class="ml-auto size-3.5 text-text-weak hover:text-text-strong transition-all"
+                      class="ml-auto size-3.5 text-text-weak hover:text-text-strong transition-colors"
                       onClick={(e) => {
                         e.stopPropagation()
                         props.remove(item)

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -627,7 +627,7 @@ function TitlebarUpdateIconButton(props: { state: TitlebarUpdatePillState }) {
         aria-busy={props.state.installing}
         aria-label={props.state.ariaLabel}
       >
-        <span class="shrink-0 ml-[8px] mr-px text-[11px] text-v2-text-text-accent [font-weight:530] opacity-0 translate-x-2 motion-safe:transition-all duration-150 ease-out group-hover:opacity-100 group-hover:translate-x-0 group-focus-within:opacity-100 group-focus-within:translate-x-0 motion-reduce:translate-x-0">
+        <span class="shrink-0 ml-[8px] mr-px text-[11px] text-v2-text-text-accent [font-weight:530] opacity-0 translate-x-2 motion-safe:transition-[opacity,translate] duration-150 ease-out group-hover:opacity-100 group-hover:translate-x-0 group-focus-within:opacity-100 group-focus-within:translate-x-0 motion-reduce:translate-x-0">
           {props.state.label}
         </span>
         <span class="flex size-5 shrink-0 items-center justify-center">

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -131,7 +131,7 @@ const WorkspaceHeader = (props: {
         openOnDblClick={false}
       />
     </Show>
-    <div class="flex items-center justify-center shrink-0 overflow-hidden w-0 opacity-0 transition-all duration-200 group-hover/workspace:w-3.5 group-hover/workspace:opacity-100 group-focus-within/workspace:w-3.5 group-focus-within/workspace:opacity-100">
+    <div class="flex items-center justify-center shrink-0 overflow-hidden w-0 opacity-0 transition-[width,opacity] duration-200 group-hover/workspace:w-3.5 group-hover/workspace:opacity-100 group-focus-within/workspace:w-3.5 group-focus-within/workspace:opacity-100">
       <Icon name={props.open() ? "chevron-down" : "chevron-right"} size="small" class="text-icon-base" />
     </div>
   </div>

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1299,7 +1299,7 @@ export function MessageTimeline(props: {
   return (
     <div class="relative w-full h-full min-w-0">
       <div
-        class="absolute left-1/2 -translate-x-1/2 z-[60] pointer-events-none transition-all duration-200 ease-out"
+        class="absolute left-1/2 -translate-x-1/2 z-[60] pointer-events-none transition-[opacity,translate,scale] duration-200 ease-out"
         classList={{
           "bottom-8": settings.general.newLayoutDesigns(),
           "bottom-6": !settings.general.newLayoutDesigns(),


### PR DESCRIPTION
### Issue for this PR

Closes #48703

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces the six `transition-all` usages with the explicit properties that actually change. `transition-all` makes the browser consider every animatable property on interaction, including unintended ones (box-shadow is paint, width is layout), and any class added later silently starts animating.

| file | before | after |
| --- | --- | --- |
| `titlebar.tsx` | `transition-all` | `transition-[opacity,translate]` |
| `context-items.tsx` (chip) | `transition-all transition-transform` | `transition-[box-shadow,background-color]` |
| `context-items.tsx` (remove button) | `transition-all` | `transition-colors` |
| `dialog-release-notes.tsx` | `transition-all` | `transition-[width]` |
| `message-timeline.tsx` (scroll button) | `transition-all` | `transition-[opacity,translate,scale]` |
| `sidebar-workspace.tsx` (workspace icon) | `transition-all` | `transition-[width,opacity]` |

No visual or behavioral change. `translate-*`/`scale-*` set the `translate`/`scale` properties in this Tailwind version (verified in the compiled CSS), so the lists use those names rather than `transform`.

### How did you verify your code works?

Checked the compiled CSS for the property names this project's Tailwind generates (`translate-x-2` sets `translate`, `scale-95` sets `scale`, `transition-colors` covers text/background/border colors, `transition-transform` covers `transform, translate, scale, rotate`), then mapped each replaced class to the properties that actually change on hover/selection in each component.

Also rendered the replacement transition lists in Chromium with the app's compiled CSS and toggled each element's end state: computed `transition-property` reads `opacity, translate`, `box-shadow, background-color`, `width, opacity` and `opacity, translate, scale` respectively, and the toggled values reach their targets (`opacity 1`, `translate 0px`, `scale 1`).

### Screenshots / recordings

No visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
