### PR TITLE
refactor(ui): replace text shimmer sweep with an opacity pulse

### DIFF
--- a/packages/ui/src/components/text-shimmer.css
+++ b/packages/ui/src/components/text-shimmer.css
@@ -3,18 +3,7 @@
   --text-shimmer-duration: 1200ms;
   --text-shimmer-swap: 220ms;
   --text-shimmer-index: 0;
-  --text-shimmer-angle: 90deg;
-  --text-shimmer-spread: 5.2ch;
-  --text-shimmer-size: 360%;
   --text-shimmer-base-color: var(--text-weak);
-  --text-shimmer-peak-color: var(--text-strong);
-  --text-shimmer-sweep: linear-gradient(
-    var(--text-shimmer-angle),
-    transparent calc(50% - var(--text-shimmer-spread)),
-    var(--text-shimmer-peak-color) 50%,
-    transparent calc(50% + var(--text-shimmer-spread))
-  );
-  --text-shimmer-base: linear-gradient(var(--text-shimmer-base-color), var(--text-shimmer-base-color));
 
   display: inline-flex;
   align-items: baseline;
@@ -47,56 +36,28 @@
 }
 
 [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
-  color: var(--text-weaker);
+  color: var(--text-shimmer-base-color);
   opacity: 0;
 }
 
-[data-component="text-shimmer"][data-active="true"] [data-slot="text-shimmer-char-shimmer"] {
-  opacity: 1;
-}
-
 [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"][data-run="true"] {
-  animation-name: text-shimmer-sweep;
+  animation-name: text-shimmer-pulse;
   animation-duration: var(--text-shimmer-duration);
   animation-iteration-count: infinite;
-  animation-timing-function: linear;
+  animation-timing-function: ease-in-out;
   animation-fill-mode: both;
   animation-delay: calc(var(--text-shimmer-step) * var(--text-shimmer-index) * -1);
-  will-change: background-position;
+  will-change: opacity;
 }
 
-@keyframes text-shimmer-sweep {
-  0% {
-    background-position:
-      100% 0,
-      0 0;
-  }
-
+@keyframes text-shimmer-pulse {
+  0%,
   100% {
-    background-position:
-      0% 0,
-      0 0;
-  }
-}
-
-@supports ((-webkit-background-clip: text) or (background-clip: text)) {
-  [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
-    color: transparent;
-    -webkit-text-fill-color: transparent;
-    background-image: var(--text-shimmer-sweep), var(--text-shimmer-base);
-    background-size:
-      var(--text-shimmer-size) 100%,
-      100% 100%;
-    background-position:
-      100% 0,
-      0 0;
-    background-repeat: no-repeat;
-    -webkit-background-clip: text;
-    background-clip: text;
-  }
-
-  [data-component="text-shimmer"][data-active="true"] [data-slot="text-shimmer-char-base"] {
     opacity: 0;
+  }
+
+  50% {
+    opacity: 1;
   }
 }
 
@@ -108,9 +69,7 @@
 
   [data-component="text-shimmer"] [data-slot="text-shimmer-char-shimmer"] {
     animation: none !important;
-    color: inherit;
-    -webkit-text-fill-color: currentColor;
-    background-image: none;
+    opacity: 0 !important;
   }
 
   [data-component="text-shimmer"] [data-slot="text-shimmer-char-base"] {

--- a/packages/ui/src/v2/components/text-shimmer-v2.css
+++ b/packages/ui/src/v2/components/text-shimmer-v2.css
@@ -9,18 +9,7 @@
   --_duration: 1200ms;
   --_swap: 220ms;
   --_index: 0;
-  --_angle: 90deg;
-  --_spread: 5.2ch;
-  --_size: 360%;
   --_base-color: var(--v2-text-text-muted);
-  --_peak-color: var(--v2-text-text-base);
-  --_sweep: linear-gradient(
-    var(--_angle),
-    transparent calc(50% - var(--_spread)),
-    var(--_peak-color) 50%,
-    transparent calc(50% + var(--_spread))
-  );
-  --_base: linear-gradient(var(--_base-color), var(--_base-color));
 
   display: inline-flex;
   align-items: baseline;
@@ -58,51 +47,23 @@
   opacity: 0;
 }
 
-[data-component="text-shimmer-v2"][data-active="true"] [data-slot="text-shimmer-v2-shimmer"] {
-  opacity: 1;
-}
-
 [data-component="text-shimmer-v2"] [data-slot="text-shimmer-v2-shimmer"][data-run="true"] {
-  animation-name: text-shimmer-v2-sweep;
+  animation-name: text-shimmer-v2-pulse;
   animation-duration: var(--_duration);
   animation-iteration-count: infinite;
-  animation-timing-function: linear;
+  animation-timing-function: ease-in-out;
   animation-fill-mode: both;
   animation-delay: calc(var(--_step) * var(--_index) * -1);
-  will-change: background-position;
+  will-change: opacity;
 }
 
-@keyframes text-shimmer-v2-sweep {
-  0% {
-    background-position:
-      100% 0,
-      0 0;
-  }
+@keyframes text-shimmer-v2-pulse {
+  0%,
   100% {
-    background-position:
-      0% 0,
-      0 0;
-  }
-}
-
-@supports ((-webkit-background-clip: text) or (background-clip: text)) {
-  [data-component="text-shimmer-v2"] [data-slot="text-shimmer-v2-shimmer"] {
-    color: transparent;
-    -webkit-text-fill-color: transparent;
-    background-image: var(--_sweep), var(--_base);
-    background-size:
-      var(--_size) 100%,
-      100% 100%;
-    background-position:
-      100% 0,
-      0 0;
-    background-repeat: no-repeat;
-    -webkit-background-clip: text;
-    background-clip: text;
-  }
-
-  [data-component="text-shimmer-v2"][data-active="true"] [data-slot="text-shimmer-v2-base"] {
     opacity: 0;
+  }
+  50% {
+    opacity: 1;
   }
 }
 
@@ -114,9 +75,7 @@
 
   [data-component="text-shimmer-v2"] [data-slot="text-shimmer-v2-shimmer"] {
     animation: none !important;
-    color: inherit;
-    -webkit-text-fill-color: currentColor;
-    background-image: none;
+    opacity: 0 !important;
   }
 
   [data-component="text-shimmer-v2"] [data-slot="text-shimmer-v2-base"] {


### PR DESCRIPTION
### Issue for this PR

Closes #48708

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces the text shimmer sweep with an opacity pulse, in both `text-shimmer` and `text-shimmer-v2`.

Before: the overlay copy painted two gradient layers with `background-clip: text` and animated `background-position`, repainting the text every frame. After: the overlay copy is a plain colored text that pulses its opacity between 0 and 1 (the base copy stays visible underneath), which only composites.

This also removes the now-unused `--text-shimmer-angle/-spread/-size/-peak-color/-sweep` variables and the `@supports (background-clip: text)` block (v2: `--_angle/-spread/-size/-peak-color/-sweep`).

**This is a visual change** (sweep → pulse), so it's opened as a proposal for design review.

Measured in a real desktop instance (1.18.29, via CDP), 3s windows, 2 visible shimmers:

| variant | RecalcStyleDuration | TaskDuration |
| --- | --- | --- |
| sweep (before) | ~30ms | ~330–450ms |
| frozen (control) | 0ms | ~51–56ms |

### How did you verify your code works?

Rendered both variants' compiled CSS in Chromium with the component DOM, paused the CSS animations and set deterministic `currentTime` values (0/300/600ms) for the screenshots. Verified the registered animations changed from `text-shimmer-sweep`/`text-shimmer-v2-sweep` to `text-shimmer-pulse`/`text-shimmer-v2-pulse`, and that `prefers-reduced-motion` still disables the animation and leaves plain text.

### Screenshots / recordings

![before/after](https://raw.githubusercontent.com/yanhenrique-dev/opencode/54ec53d8d67b98b3639cbe496b5fe550372050e1/issue-assets/shimmer-before-after.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
