### PR TITLE
fix(desktop): respawn crashed sidecar; classify image-count errors as overflow

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -47,6 +47,7 @@ import { registerWslIpcHandlers } from "./wsl/ipc"
 import { spawnWslSidecar } from "./wsl/sidecar"
 import { migrate } from "./migrate"
 import { cleanupStoreFiles } from "./store-cleanup"
+import { createSidecarSupervisor } from "./sidecar-supervisor"
 import { startBackgroundCli } from "./background-cli"
 import { setNativeTranslations } from "./native-translations"
 
@@ -62,10 +63,12 @@ const APP_IDS: Record<string, string> = {
 }
 const TEST_ONBOARDING = process.env.OPENCODE_TEST_ONBOARDING === "1"
 const SIDECAR_VERSION = process.env.OPENCODE_SIDECAR_V2 === "1" ? "v2" : "v1"
+const SIDECAR_RESPAWN_LIMIT = 3
 const jsCallStackFeature = "DocumentPolicyIncludeJSCallStacksInCrashReports"
 
 let logger: ReturnType<typeof initLogging>
 let server: SidecarListener | null = null
+let quitting = false
 
 const pendingDeepLinks: string[] = []
 
@@ -89,7 +92,12 @@ async function killSidecar() {
   if (!server) return
   const current = server
   server = null
-  await current.stop()
+  quitting = true
+  try {
+    await current.stop()
+  } finally {
+    quitting = false
+  }
 }
 
 function ensureLoopbackNoProxy() {
@@ -169,6 +177,7 @@ const main = Effect.gen(function* () {
     wslServers.stopAll()
   }
   const relaunch = () => {
+    quitting = true
     setAppQuitting()
     void stopSidecars().finally(() => {
       app.relaunch()
@@ -222,11 +231,13 @@ const main = Effect.gen(function* () {
   })
 
   app.on("before-quit", () => {
+    quitting = true
     setAppQuitting()
     void stopSidecars()
   })
 
   app.on("will-quit", () => {
+    quitting = true
     setAppQuitting()
     void stopSidecars()
   })
@@ -245,6 +256,7 @@ const main = Effect.gen(function* () {
 
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.on(signal, () => {
+      quitting = true
       setAppQuitting()
       void stopSidecars().finally(() => app.quit())
     })
@@ -374,15 +386,41 @@ const main = Effect.gen(function* () {
     const url = `http://${hostname}:${port}`
     const password = randomUUID()
 
-    logger.log("spawning sidecar", { url })
-    const { listener, health } = yield* Effect.promise(() =>
-      spawnLocalServer(hostname, port, password, {
+    // If the sidecar crashes (e.g. V8 aborts under memory pressure) the app
+    // window stays open but every request fails with "Failed to fetch".
+    // Respawn on the same port with the same password so the renderer can
+    // reconnect without a full app restart, then reload the windows.
+    const supervisor = createSidecarSupervisor({ respawnLimit: SIDECAR_RESPAWN_LIMIT })
+    const spawnWithSupervisor = async () => {
+      const spawned = await spawnLocalServer(hostname, port, password, {
         userDataPath: app.getPath("userData"),
         onStdout: (message) => writeLog("server", "stdout", { message }),
         onStderr: (message) => writeLog("server", "stderr", { message }, "warn"),
-        onExit: (code) => writeLog("utility", "sidecar exited", { code }, "warn"),
-      }),
-    )
+        onExit: (code) => {
+          writeLog("utility", "sidecar exited", { code }, "warn")
+          if (quitting || !supervisor.shouldRespawn(code)) {
+            if (!quitting) logger.error("sidecar restart limit reached", { code, attempts: supervisor.attempts })
+            return
+          }
+          logger.log("respawning sidecar after exit", { code, attempt: supervisor.attempts })
+          spawnWithSupervisor()
+            .then(async (next) => {
+              server = next.listener
+              supervisor.succeeded()
+              await next.health.wait
+              logger.log("sidecar respawned", { url })
+              for (const win of BrowserWindow.getAllWindows()) {
+                if (!win.isDestroyed()) win.reload()
+              }
+            })
+            .catch((error) => logger.error("sidecar respawn failed", error))
+        },
+      })
+      return spawned
+    }
+
+    logger.log("spawning sidecar", { url })
+    const { listener, health } = yield* Effect.promise(() => spawnWithSupervisor())
     server = listener
     yield* Deferred.succeed(serverReady, {
       url,

--- a/packages/desktop/src/main/sidecar-supervisor.test.ts
+++ b/packages/desktop/src/main/sidecar-supervisor.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { createSidecarSupervisor } from "./sidecar-supervisor"
+
+// Regression: the opencode server sidecar was dying with 0xC0000409 (V8
+// abort under memory pressure, often while Gradle builds ran alongside)
+// and the desktop had no recovery path — the window stayed open with every
+// request failing until the user restarted the whole app. The supervisor
+// exists so the main process can respawn the sidecar instead.
+describe("sidecar supervisor", () => {
+  test("allows respawns up to the limit for crash exit codes", () => {
+    const supervisor = createSidecarSupervisor({ respawnLimit: 3 })
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    expect(supervisor.shouldRespawn(3221226505)).toBe(false)
+    expect(supervisor.attempts).toBe(3)
+  })
+
+  test("resets the attempt counter after a successful respawn", () => {
+    const supervisor = createSidecarSupervisor({ respawnLimit: 3 })
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    supervisor.succeeded()
+    expect(supervisor.attempts).toBe(0)
+    // Hours later, a fresh crash still gets a full budget of attempts.
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    expect(supervisor.shouldRespawn(3221226505)).toBe(true)
+    expect(supervisor.shouldRespawn(3221226505)).toBe(false)
+  })
+
+  test("clean exits are also eligible for respawn", () => {
+    // A clean exit (code 0) while the app is still running is a bug just the
+    // same — the server must be up for the app to work.
+    const supervisor = createSidecarSupervisor({ respawnLimit: 1 })
+    expect(supervisor.shouldRespawn(0)).toBe(true)
+    expect(supervisor.shouldRespawn(0)).toBe(false)
+  })
+})

--- a/packages/desktop/src/main/sidecar-supervisor.ts
+++ b/packages/desktop/src/main/sidecar-supervisor.ts
@@ -1,0 +1,29 @@
+export type SidecarSupervisor = {
+  /** Whether an exit should trigger a respawn. Increments the attempt counter when true. */
+  shouldRespawn: (code: number) => boolean
+  /** Reset the attempt counter after a successful respawn. */
+  succeeded: () => void
+  readonly attempts: number
+}
+
+// Deliberate stops report code 0; crashes report non-zero fast-fail codes
+// (e.g. 0xC0000409). Both can be transient under memory pressure, so any
+// exit while the app is running is eligible for a bounded number of
+// consecutive respawn attempts. The counter resets after a respawn becomes
+// healthy, so sporadic crashes hours apart never exhaust the limit.
+export function createSidecarSupervisor(input: { respawnLimit: number }): SidecarSupervisor {
+  let attempts = 0
+  return {
+    get attempts() {
+      return attempts
+    },
+    shouldRespawn() {
+      if (attempts >= input.respawnLimit) return false
+      attempts++
+      return true
+    },
+    succeeded() {
+      attempts = 0
+    },
+  }
+}

--- a/packages/llm/src/provider-error.ts
+++ b/packages/llm/src/provider-error.ts
@@ -29,6 +29,7 @@ const patterns = [
   /model_context_window_exceeded/i,
   /too many tokens/i,
   /token limit exceeded/i,
+  /too many images in request: \d+ > \d+/i,
 ]
 
 const exclusions = [/^(throttling error|service unavailable):/i, /rate limit/i, /too many requests/i]

--- a/packages/llm/test/provider-error.test.ts
+++ b/packages/llm/test/provider-error.test.ts
@@ -13,6 +13,7 @@ describe("provider error classification", () => {
       "Prompt has 5,958,968 tokens, but the configured context size is 256,000 tokens",
       "Too many tokens",
       "Token limit exceeded",
+      "Error from provider (Console Go): Upstream request failed: [invalid_request_error] Too many images in request: 31 > 30",
     ]
 
     expect(messages.every(isContextOverflow)).toBe(true)

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1450,6 +1450,7 @@ describe("session.message-v2.fromError", () => {
       "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)",
       "tokens in request more than max tokens allowed",
       "Please reduce the length of the messages or completion",
+      "Error from provider (Console Go): Upstream request failed: [invalid_request_error] Too many images in request: 31 > 30",
       "400 status code (no body)",
       "413 status code (no body)",
     ]


### PR DESCRIPTION
### Issue for this PR

Closes #48715

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two fixes for the desktop crash loop reported in #48715, where the opencode server utility process dies with 0xC0000409 (V8 fast-fail abort, typically memory commit exhaustion while Gradle builds run alongside the app) and the window stays open with every request failing until the user restarts the app. The exported debug bundles show 30 such crashes across 37 desktop runs in one week.

**1. Respawn the sidecar after a crash** (`packages/desktop`): when the sidecar exits while the app is running, the main process now respawns it on the same port with the same password, waits for the health check to pass, and reloads the windows so the renderer reconnects. Respawn attempts are bounded (3 consecutive, resetting after a healthy respawn) so a permanently failing sidecar cannot spin the machine. Deliberate stops during app quit do not trigger a respawn. The respawn policy lives in a small pure module (`sidecar-supervisor.ts`) so it can be unit tested without Electron.

**2. Classify provider image-count errors as context overflow** (`packages/llm`): `Too many images in request: 31 > 30` was not classified as context overflow, so auto-compaction never ran and every retry rebuilt the request with the same images, bricking the session until the user manually compacted. The message now matches the overflow patterns, which routes it through the existing compaction flow that strips media from replayed messages.

I know #47493 and #40167 cover related ground for the image-count classification (#47493 also caps images per request). That part of this PR can be dropped if those land first; the sidecar respawn is independent.

### How did you verify your code works?

- New `sidecar-supervisor.test.ts` covers the respawn budget, the reset after a healthy respawn (so sporadic crashes hours apart never exhaust the limit), and that clean exits are also eligible.
- `packages/llm/test/provider-error.test.ts` and `packages/opencode/test/session/message-v2.test.ts` include the exact failing message from my logs and assert it classifies as context overflow.
- `bun test` passes on all touched files (the only failing test in `packages/desktop/src/main`, `draft-store.test.ts`, fails on `dev` too in this environment — `node:sqlite` unavailable — and is unrelated).
- `bun typecheck` passes in `packages/desktop`, `packages/llm`, and `packages/opencode`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
