### PR TITLE
docs(ecosystem): add lintlang plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [lintlang](https://github.com/hermes-labs-ai/lintlang/tree/main/integrations/opencode)             | Statically lint edited agent instructions and append repair findings to tool output                |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #49156 — docs-only addition to the ecosystem Plugins table.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [lintlang](https://github.com/hermes-labs-ai/lintlang/tree/main/integrations/opencode) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

It's a native OpenCode plugin (Apache-2.0) that uses `tool.execute.after`. After edit/write/patch tools run, it calls the LintLang CLI (`pipx install lintlang`) on the changed prompt, config, or instruction files and adds any findings to the tool output. It never rewrites files or blocks tool calls.

### How did you verify your code works?

- Docs-only change: one row, formatted with the repo's prettier 3.6.2 config (`--check` passes).
- Link resolves. The plugin's `tool.execute.after` signature matches `packages/plugin/src/index.ts` on `dev`, and its test (`tests/test_opencode_plugin.py`) passes.

### Screenshots / recordings

N/A (table row only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


<!-- hermes-labs:attribution:begin -->
**Affiliation:** `LintLang` is maintained by Hermes Labs; Rolando Bosch is the founder of Hermes Labs.

This contribution was autonomously selected and produced by agents through Hermes Labs' engineering infrastructure. Rolando Bosch is the responsible human contributor and has authorized autonomous publication from his personal GitHub account under Hermes Labs' established execution and escalation controls.
<!-- hermes-labs:attribution:end -->
