### PR TITLE
fix(session): keep todo list current for non-Claude models

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,6 +54,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { eq } from "drizzle-orm"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
+import { Todo } from "./todo"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
 
@@ -140,6 +141,7 @@ const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
+    const todo = yield* Todo.Service
     const { db } = database
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
@@ -1181,6 +1183,7 @@ const layer = Layer.effect(
             Effect.provideService(RuntimeFlags.Service, flags),
             Effect.provideService(FSUtil.Service, fsys),
             Effect.provideService(Session.Service, sessions),
+            Effect.provideService(Todo.Service, todo),
           )
 
           const msg: SessionV1.Assistant = {
@@ -1621,6 +1624,7 @@ export const node = LayerNode.make({
     SessionRevert.node,
     SessionSummary.node,
     SystemPrompt.node,
+    Todo.node,
     LLM.node,
     EventV2Bridge.node,
     RuntimeFlags.node,

--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -77,3 +77,10 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Do not use URIs like file://, vscode://, or https://.
   * Do not provide range of lines
   * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\repo\project\main.rs:12:5
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -93,3 +93,10 @@ When referencing specific functions or pieces of code include the pattern `file_
 user: Where are errors from the client handled?
 assistant: Clients are marked as failed in the `connectToServer` function in src/services/process.ts:712.
 </example>
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/prompt/gemini.txt
+++ b/packages/opencode/src/session/prompt/gemini.txt
@@ -153,3 +153,10 @@ To help you check their settings, I can read their contents. Which one would you
 
 # Final Reminder
 Your core function is efficient and safe assistance. Balance extreme conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/prompt/gpt-astra.txt
+++ b/packages/opencode/src/session/prompt/gpt-astra.txt
@@ -44,3 +44,10 @@ In your final answer back to the user, focus on the most important information.
 # Delegation
 
 Do not spawn subagents unless the user or applicable AGENTS.md/skill instructions explicitly ask for subagents, delegation, or parallel agent work.
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -105,3 +105,10 @@ Structure your final response if necessary. The complexity of the answer should 
 If the user asks for a code explanation, include code references. For simple tasks, just state the outcome without heavy formatting.
 
 For large or complex changes, lead with the solution, then explain what you did and why. For casual chat, just chat. If something couldn’t be done (tests, builds, etc.), say so. Suggest next steps only when they are natural and useful; if you list options, use numbered items.
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/prompt/kimi.txt
+++ b/packages/opencode/src/session/prompt/kimi.txt
@@ -93,3 +93,10 @@ At any time, you should be HELPFUL, CONCISE, and ACCURATE. Be thorough in your a
 - Do not give up too early.
 - ALWAYS, keep it stupidly simple. Do not overcomplicate things.
 - When the task requires creating or modifying files, always use tools to do so. Never treat displaying code in your response as a substitute for actually writing it to the file system.
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/prompt/trinity.txt
+++ b/packages/opencode/src/session/prompt/trinity.txt
@@ -95,3 +95,10 @@ When referencing specific functions or pieces of code include the pattern `file_
 user: Where are errors from the client handled?
 assistant: Clients are marked as failed in the `connectToServer` function in src/services/process.ts:712.
 </example>
+
+# Task Management
+You have access to the todowrite tool to plan and track multi-step work. Use it whenever a task has three or more distinct steps, and keep it current so the user can see real progress.
+- Before starting a step, mark it in_progress (exactly one at a time).
+- As soon as a step is actually finished and verified, call todowrite again and mark it completed. Do this immediately, not at the end of the turn, and never batch several completions together.
+- Add newly discovered work as new todos; mark work that is no longer needed cancelled.
+- Do not end your turn while items you have finished are still shown as pending or in_progress.

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -8,9 +8,42 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { Session } from "./session"
+import { Todo } from "./todo"
 import PROMPT_PLAN from "./prompt/plan.txt"
 import BUILD_SWITCH from "./prompt/build-switch.txt"
 import PLAN_MODE from "./prompt/plan-mode.txt"
+
+// Number of consecutive tool-using assistant steps without a todowrite call before the model is reminded.
+export const TODO_STALE_STEPS = 3
+
+// Counts assistant steps in the current turn that ran tools without touching todowrite.
+// Returns undefined when there is no user message to anchor the turn.
+export function todoStaleSteps(messages: SessionV1.WithParts[]) {
+  const start = messages.findLastIndex((msg) => msg.info.role === "user")
+  if (start === -1) return
+  let count = 0
+  for (let i = messages.length - 1; i > start; i--) {
+    const msg = messages[i]
+    if (msg.info.role !== "assistant") continue
+    const tools = msg.parts.filter((part) => part.type === "tool")
+    if (tools.length === 0) continue
+    if (tools.some((part) => part.tool === "todowrite")) return count
+    count++
+  }
+  return count
+}
+
+export function todoReminder(todos: ReadonlyArray<Todo.Info>) {
+  const open = todos.filter((todo) => todo.status === "pending" || todo.status === "in_progress")
+  if (open.length === 0) return
+  return [
+    "<system-reminder>",
+    `The todo list still has ${open.length} open item(s):`,
+    ...open.map((todo) => `- [${todo.status}] ${todo.content}`),
+    "If any of these are actually finished, call todowrite now to mark them completed before continuing. Keep exactly one item in_progress while work remains. This is an automated reminder, not a message from the user.",
+    "</system-reminder>",
+  ].join("\n")
+}
 
 export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   messages: SessionV1.WithParts[]
@@ -20,8 +53,24 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const flags = yield* RuntimeFlags.Service
   const fsys = yield* FSUtil.Service
   const sessions = yield* Session.Service
+  const todo = yield* Todo.Service
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
+
+  const stale = todoStaleSteps(input.messages)
+  if (stale !== undefined && stale >= TODO_STALE_STEPS) {
+    const text = todoReminder(yield* todo.get(input.session.id))
+    if (text) {
+      userMessage.parts.push({
+        id: PartID.ascending(),
+        messageID: userMessage.info.id,
+        sessionID: userMessage.info.sessionID,
+        type: "text",
+        text,
+        synthetic: true,
+      })
+    }
+  }
 
   if (!flags.experimentalPlanMode) {
     if (input.agent.name === "plan") {

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -33,9 +33,14 @@ export const TodoWriteTool = Tool.define<typeof Parameters, Metadata, Todo.Servi
             todos: params.todos,
           })
 
+          const open = params.todos.filter((x) => x.status === "pending" || x.status === "in_progress")
+          const note = open.length
+            ? `Todo list updated. ${open.length} item(s) still open. Keep using todowrite as you work: mark each item completed as soon as it is actually done, and do not batch completions.`
+            : "Todo list updated. All items are completed or cancelled."
+
           return {
             title: `${params.todos.filter((x) => x.status !== "completed").length} todos`,
-            output: JSON.stringify(params.todos, null, 2),
+            output: [note, JSON.stringify(params.todos, null, 2)].join("\n\n"),
             metadata: {
               todos: params.todos,
             },

--- a/packages/opencode/test/session/reminders.test.ts
+++ b/packages/opencode/test/session/reminders.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+import type { SessionV1 } from "@opencode-ai/core/v1/session"
+import { TODO_STALE_STEPS, todoReminder, todoStaleSteps } from "../../src/session/reminders"
+
+function user(id: string): SessionV1.WithParts {
+  return { info: { id, role: "user" }, parts: [] } as unknown as SessionV1.WithParts
+}
+
+function assistant(id: string, tools: string[]): SessionV1.WithParts {
+  return {
+    info: { id, role: "assistant" },
+    parts: tools.map((tool, i) => ({
+      id: `${id}-${i}`,
+      type: "tool",
+      tool,
+      callID: `${id}-${i}`,
+      state: { status: "completed" },
+    })),
+  } as unknown as SessionV1.WithParts
+}
+
+describe("SessionReminders.todoStaleSteps", () => {
+  test("returns undefined without a user message", () => {
+    expect(todoStaleSteps([assistant("a1", ["bash"])])).toBeUndefined()
+  })
+
+  test("is zero at the start of a turn", () => {
+    expect(todoStaleSteps([user("u1")])).toBe(0)
+  })
+
+  test("counts tool-using steps since the last todowrite in the current turn", () => {
+    const messages = [
+      user("u1"),
+      assistant("a1", ["todowrite"]),
+      assistant("a2", ["bash"]),
+      assistant("a3", []),
+      assistant("a4", ["read", "edit"]),
+    ]
+    expect(todoStaleSteps(messages)).toBe(2)
+  })
+
+  test("resets when todowrite is called", () => {
+    const messages = [user("u1"), assistant("a1", ["bash"]), assistant("a2", ["bash"]), assistant("a3", ["todowrite"])]
+    expect(todoStaleSteps(messages)).toBe(0)
+  })
+
+  test("ignores steps from earlier turns", () => {
+    const messages = [
+      user("u1"),
+      assistant("a1", ["bash"]),
+      assistant("a2", ["bash"]),
+      user("u2"),
+      assistant("a3", ["bash"]),
+    ]
+    expect(todoStaleSteps(messages)).toBe(1)
+  })
+
+  test("reaches the reminder threshold after enough unrelated tool steps", () => {
+    const messages = [user("u1"), ...Array.from({ length: TODO_STALE_STEPS }, (_, i) => assistant(`a${i}`, ["bash"]))]
+    expect(todoStaleSteps(messages)).toBeGreaterThanOrEqual(TODO_STALE_STEPS)
+  })
+})
+
+describe("SessionReminders.todoReminder", () => {
+  test("returns nothing when every todo is closed", () => {
+    expect(
+      todoReminder([
+        { content: "done", status: "completed", priority: "high" },
+        { content: "dropped", status: "cancelled", priority: "low" },
+      ]),
+    ).toBeUndefined()
+  })
+
+  test("lists only open todos", () => {
+    const text = todoReminder([
+      { content: "done", status: "completed", priority: "high" },
+      { content: "working", status: "in_progress", priority: "high" },
+      { content: "later", status: "pending", priority: "low" },
+    ])
+    expect(text).toContain("2 open item(s)")
+    expect(text).toContain("- [in_progress] working")
+    expect(text).toContain("- [pending] later")
+    expect(text).not.toContain("done")
+  })
+})


### PR DESCRIPTION
Fixes #27560

Models that don't get the Anthropic prompt never receive an instruction to update todos, so items stay `in_progress` after the work is done. Reproduced with Qwen3 via an OpenAI-compatible provider: `default.txt`, `gpt.txt`, `gemini.txt`, `kimi.txt`, `codex.txt`, `trinity.txt` and `gpt-astra.txt` contain no todo guidance at all.

Changes:
- Add a short task-management section to those prompts (same rule as `anthropic.txt`: mark completed immediately, don't batch).
- Prefix the `todowrite` result with a one-line note about open items so the model gets feedback every time it uses the tool.
- In `SessionReminders`, when a turn has run 3+ tool-using steps without calling `todowrite` and the session still has open todos, append a synthetic reminder listing them to the user message for that step. Ephemeral, re-evaluated per step, resets on the next `todowrite`.

Unit tests for the step counter and reminder text in `test/session/reminders.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4niqFJFKZHpiAC8YUCsRM