### PR TITLE
fix(core): keep locations with running terminals out of eviction

### DIFF
--- a/packages/core/src/location-activity.ts
+++ b/packages/core/src/location-activity.ts
@@ -1,9 +1,10 @@
 export * as LocationActivity from "./location-activity.js"
 
-import { Clock, Context, Duration, Effect, Layer, RcMap, Schema } from "effect"
+import { Clock, Context, Duration, Effect, Layer, Option, RcMap, Schema } from "effect"
 import { Bus } from "./bus.js"
 import { Location } from "./location.js"
 import { LocationServiceMap } from "./location-service-map.js"
+import { Pty } from "./pty.js"
 import { SessionEvent } from "./session/event.js"
 import { SessionExecution } from "./session/execution.js"
 import { SessionStore } from "./session/store.js"
@@ -29,6 +30,15 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
         Effect.sync(() => {
           entries.set(key(ref), { ref, expiresAt: clock.currentTimeMillisUnsafe() + timeToLive })
         })
+      // Terminals are user-owned processes and the Pty finalizer kills them with the graph.
+      const terminals = Effect.fn("LocationActivity.terminals")(function* (ref: Location.Ref) {
+        const context = yield* locations.contextEffectOption(ref)
+        if (Option.isNone(context)) return false
+        const pty = Context.getOption(context.value, Pty.Service)
+        if (Option.isNone(pty)) return false
+        const infos = yield* pty.value.list()
+        return infos.some((info) => info.status === "running")
+      })
 
       const unsubscribe = yield* bus.listen((event) => {
         if (!isSessionEvent(event)) return Effect.void
@@ -55,6 +65,15 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
           expired,
           (entry) =>
             Effect.gen(function* () {
+              // A graph that failed to build owns no terminals.
+              const busy = yield* terminals(entry.ref).pipe(
+                Effect.scoped,
+                Effect.orElseSucceed(() => false),
+              )
+              if (busy) {
+                yield* touch(entry.ref)
+                return
+              }
               const owners = active.flatMap((session) =>
                 session && key(session.location) === key(entry.ref) ? [session] : [],
               )

--- a/packages/core/test/location-activity.test.ts
+++ b/packages/core/test/location-activity.test.ts
@@ -12,6 +12,7 @@ import { LocationActivity } from "@opencode/core/location-activity"
 import { LocationServiceMap, type LocationServices } from "@opencode/core/location-services"
 import { Project } from "@opencode/core/project"
 import { ProjectTable } from "@opencode/core/project/sql"
+import { Pty } from "@opencode/core/pty"
 import { AbsolutePath } from "@opencode/core/schema"
 import { Session } from "@opencode/core/session"
 import { SessionExecution } from "@opencode/core/session/execution"
@@ -20,7 +21,40 @@ import { SessionRunner } from "@opencode/core/session/runner/index"
 import { SessionTable } from "@opencode/core/session/sql"
 import { SessionStore } from "@opencode/core/session/store"
 import { Workspace } from "@opencode/core/workspace"
+import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
+
+const fixtureMap = (lookup: (ref: Location.Ref) => Layer.Layer<LocationServices>) =>
+  Effect.map(LayerMap.make(lookup, { idleTimeToLive: Duration.infinity }), (map) => ({
+    ...map,
+    get: (ref: Location.Ref) => map.get(LocationServiceMap.canonical(ref)),
+    contextEffect: (ref: Location.Ref) => map.contextEffect(LocationServiceMap.canonical(ref)),
+    contextEffectOption: (ref: Location.Ref) => map.contextEffectOption(LocationServiceMap.canonical(ref)),
+    invalidate: (ref: Location.Ref) => map.invalidate(LocationServiceMap.canonical(ref)),
+  }))
+
+const harness = (locations: Layer.Layer<LocationServiceMap.Service, never, Bus.Service>) =>
+  testEffect(
+    AppNodeBuilder.build(
+      LayerNode.group([
+        Database.node,
+        Bus.node,
+        SessionStore.node,
+        LocationServiceMap.node,
+        SessionExecution.node,
+        LocationActivity.node,
+      ]),
+      [
+        LocationServiceMap.node.replace(
+          makeGlobalNode({
+            service: LocationServiceMap.Service,
+            layer: locations,
+            deps: [Bus.node],
+          }),
+        ),
+      ],
+    ),
+  )
 
 // Keep real execution ownership, location caching, forms, and eviction. The fixture
 // runner waits on a form instead of making a model request before asking a question.
@@ -28,7 +62,7 @@ const locations = Layer.effect(
   LocationServiceMap.Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
-    const map = yield* LayerMap.make(
+    return yield* fixtureMap(
       (ref: Location.Ref) =>
         // The fixture only exercises these three Location services.
         // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
@@ -66,39 +100,30 @@ const locations = Layer.effect(
           Layer.provide(Layer.succeed(Bus.Service, bus)),
           Layer.fresh,
         ) as unknown as Layer.Layer<LocationServices>,
-      { idleTimeToLive: Duration.infinity },
     )
-    return {
-      ...map,
-      get: (ref: Location.Ref) => map.get(LocationServiceMap.canonical(ref)),
-      contextEffect: (ref: Location.Ref) => map.contextEffect(LocationServiceMap.canonical(ref)),
-      contextEffectOption: (ref: Location.Ref) => map.contextEffectOption(LocationServiceMap.canonical(ref)),
-      invalidate: (ref: Location.Ref) => map.invalidate(LocationServiceMap.canonical(ref)),
-    }
   }),
 )
 
-const it = testEffect(
-  AppNodeBuilder.build(
-    LayerNode.group([
-      Database.node,
-      Bus.node,
-      SessionStore.node,
-      LocationServiceMap.node,
-      SessionExecution.node,
-      LocationActivity.node,
-    ]),
-    [
-      LocationServiceMap.node.replace(
-        makeGlobalNode({
-          service: LocationServiceMap.Service,
-          layer: locations,
-          deps: [Bus.node],
-        }),
-      ),
-    ],
-  ),
+// Real terminals: the location graph is the compiled Pty node over the fixture Location.
+const terminalLocations = Layer.effect(
+  LocationServiceMap.Service,
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+    return yield* fixtureMap(
+      (ref: Location.Ref) =>
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+        LayerNode.compile(Pty.node, {
+          replacements: [
+            Location.node.replace(Layer.succeed(Location.Service, Location.Service.of(location(ref)))),
+            Bus.node.replace(Layer.succeed(Bus.Service, bus)),
+          ],
+        }).pipe(Layer.fresh) as unknown as Layer.Layer<LocationServices>,
+    )
+  }),
 )
+
+const it = harness(locations)
+const terminalIt = harness(terminalLocations)
 
 describe("LocationActivity eviction", () => {
   for (const [count, admission] of [
@@ -218,4 +243,28 @@ describe("LocationActivity eviction", () => {
         }),
     )
   }
+})
+
+describe("LocationActivity terminals", () => {
+  const terminalTest = process.platform === "win32" ? terminalIt.effect.skip : terminalIt.effect
+  terminalTest("retains a location while a terminal runs and evicts it after the terminal is removed", () =>
+    Effect.gen(function* () {
+      const map = yield* LocationServiceMap.Service
+      const ref = LocationServiceMap.canonical({ directory: AbsolutePath.make("/tmp") })
+      const context = yield* map.contextEffect(ref).pipe(Effect.scoped)
+      const pty = Context.get(context, Pty.Service)
+      const info = yield* pty.create({ command: "cat", cwd: "/tmp", env: { TERM: "xterm-256color" } })
+      yield* Effect.addFinalizer(() => pty.remove(info.id).pipe(Effect.ignore))
+
+      // The first sweep adopts the cached location; the deadline then passes with no session activity.
+      yield* TestClock.adjust("1 minute")
+      yield* TestClock.adjust("62 minutes")
+      expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual([ref])
+      expect((yield* pty.get(info.id)).status).toBe("running")
+
+      yield* pty.remove(info.id)
+      yield* TestClock.adjust("62 minutes")
+      expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual([])
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48691

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`LocationActivity` evicts a location 60 minutes after its last durable session event. Terminals produce no session events, so a location whose only activity is a running terminal is invalidated on schedule and the Pty finalizer kills every terminal in it: blank pane, scrollback gone, and the desktop app recreates empty terminals.

Before evicting an expired location, the sweep now asks that location's Pty service for running sessions and renews the deadline while any exist. The probe uses `contextEffectOption`, so it only reads the cached graph and never boots a location. A graph that failed to build counts as having no terminals, so failed locations are still cleaned up as before, and running executions are only interrupted when the location is actually going to be evicted.

### How did you verify your code works?

- New test in `packages/core/test/location-activity.test.ts`: a location built from the real `Pty` node with a running `cat` terminal stays cached when its deadline passes (terminal still running); once the terminal is removed, the next deadline evicts it. The test fails without the fix.
- Existing `LocationActivity` eviction tests pass unchanged; `packages/core` typecheck, the pty and location suites, oxlint and prettier are clean.
- On my dev-based daily build the same eviction (there driven by the LayerMap idle TTL) killed the terminals every hour on the dot, which is how I found this.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
