### PR TITLE
fix(tui): finalize streamed markdown responses

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1691,9 +1691,9 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
       <box ref={(el: BoxRenderable) => alwaysSeparate.add(el)} paddingLeft={3} marginTop={1} flexShrink={0}>
         <markdown
           syntaxStyle={syntax()}
-          streaming={true}
-          internalBlockMode="top-level"
           content={props.part.text.trim()}
+          streaming={props.message.time.completed === undefined}
+          internalBlockMode="top-level"
           tableOptions={{ style: "grid" }}
           conceal={ctx.conceal()}
           fg={theme.markdownText}


### PR DESCRIPTION
### Issue for this PR

Closes #48714

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Assistant text currently leaves OpenTUI's Markdown renderer in streaming mode after the message has completed. That keeps the trailing parse state unstable, allowing a transient list layout or highlight state to remain on screen.

This change derives `streaming` from `message.time.completed` and applies the final content before switching modes, so OpenTUI performs its final parse and layout. It mirrors the completion behavior already accepted on the v2 branch in #45102.

### How did you verify your code works?

- `cd packages/tui && bun run typecheck`
- `cd packages/tui && bun test test/cli/tui` — 43 passed, 1 skipped
- `prettier --check packages/tui/src/routes/session/index.tsx`
- `git diff --check`

### Screenshots / recordings

Not included; the failure is a timing-dependent terminal redraw artifact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
