### PR TITLE
fix(tui): preserve slash skill arguments

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1150,6 +1150,7 @@ export function Prompt(props: PromptProps) {
       (data.location.skill.list(currentLocation.ref) ?? []).some(
         (skill) => skill.slash === true && skill.id === slashHead.name,
       )
+    const isSkillPrompt = isSkill && slashHead.arguments.trim().length > 0
     const isCommand =
       slashHead !== undefined &&
       (data.location.command.list(currentLocation.ref) ?? []).some((command) => command.name === slashHead.name)
@@ -1170,7 +1171,7 @@ export function Prompt(props: PromptProps) {
       void promptModelWarning()
       return false
     }
-    const usesModel = !props.sessionID || (store.mode !== "shell" && !isSkill)
+    const usesModel = !props.sessionID || (store.mode !== "shell" && (!isSkill || isSkillPrompt))
     if (usesModel && !local.model.available(selection)) {
       toast.show({
         title: "Model unavailable",
@@ -1311,7 +1312,7 @@ export function Prompt(props: PromptProps) {
         toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
         restoreEntry()
       })
-    } else if (isSkill) {
+    } else if (isSkill && !isSkillPrompt) {
       move.startSubmit()
       dispatch(() => client.api.session.skill({ sessionID: target, skill: slashHead.name }))
     } else {
@@ -1365,10 +1366,14 @@ export function Prompt(props: PromptProps) {
       data.session
         .prompt({
           sessionID: target,
-          text: inputText,
+          text: isSkillPrompt ? slashHead.arguments : inputText,
           files: entry.files,
           agents: entry.agents,
-          skills: entry.skills?.length ? entry.skills : undefined,
+          skills: isSkillPrompt
+            ? [...(entry.skills ?? []), { id: slashHead.name }]
+            : entry.skills?.length
+              ? entry.skills
+              : undefined,
           delivery,
           gate: newSession?.gate,
           // Commit the captured selection after earlier admissions, including

--- a/packages/tui/src/mini/stream-v2.transport.ts
+++ b/packages/tui/src/mini/stream-v2.transport.ts
@@ -1734,19 +1734,26 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
     const messageID = next.prompt.messageID
     if (!messageID) throw new Error("Prompt message ID is required")
     const command = next.prompt.command
-    const attachments = await prepareAttachments(next, command ? "command" : "prompt", input.readTextFile)
+    const skill = command?.source === "skill" && command.arguments.trim() ? command : undefined
+    const attachments = await prepareAttachments(next, command && !skill ? "command" : "prompt", input.readTextFile)
     const agents = promptAgents(next)
     const skills = promptSkills(next)
-    if (!command) {
+    if (!command || skill) {
       input.trace?.write("send.prompt", { sessionID: input.sessionID, messageID, delivery })
       return client.session.prompt(
         {
           sessionID: input.sessionID,
           id: messageID,
-          text: [next.prompt.text, ...attachments.text].join("\n\n"),
+          text: [skill?.arguments ?? next.prompt.text, ...attachments.text].join("\n\n"),
           files: attachments.files.length ? attachments.files : undefined,
           agents: agents.length ? agents : undefined,
-          skills: skills.length ? skills : undefined,
+          skills: skill
+            ? skills.some((item) => item.id === skill.name)
+              ? skills
+              : [...skills, { id: skill.name }]
+            : skills.length
+              ? skills
+              : undefined,
           delivery,
         },
         { signal: next.signal },
@@ -1828,7 +1835,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       if (!messageID) throw new Error("Prompt message ID is required")
 
       const command = next.prompt.command
-      if (command?.source === "skill") {
+      if (command?.source === "skill" && !command.arguments.trim()) {
         if (next.agent)
           await client.session.switchAgent({ sessionID: input.sessionID, agent: next.agent }, { signal: next.signal })
         input.trace?.write("send.skill", { sessionID: input.sessionID, messageID, skill: command.name })
@@ -1845,7 +1852,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
         )
         return
       }
-      if (command) {
+      if (command && command.source !== "skill") {
         await admitPrompt(next, client, next.prompt.delivery ?? "steer")
         admitted?.()
         return

--- a/packages/tui/test/mini/stream-v2.transport.test.ts
+++ b/packages/tui/test/mini/stream-v2.transport.test.ts
@@ -712,9 +712,9 @@ describe("V2 mini transport", () => {
     })
 
     while (!ui.commits.some((commit) => commit.text === "Done.")) await Bun.sleep(0)
-    expect(ui.commits.filter((commit) => commit.kind === "assistant" || commit.kind === "tool").map((commit) => commit.text)).toEqual([
-      "Done.",
-    ])
+    expect(
+      ui.commits.filter((commit) => commit.kind === "assistant" || commit.kind === "tool").map((commit) => commit.text),
+    ).toEqual(["Done."])
     await transport.close()
   })
 
@@ -742,7 +742,11 @@ describe("V2 mini transport", () => {
               model: { providerID: "test", id: "model" },
               content: [
                 { type: "text", text: "I'll check." },
-                canonicalToolPart("read", { status: "completed", input: {}, content: [{ type: "text", text: "file" }] }),
+                canonicalToolPart("read", {
+                  status: "completed",
+                  input: {},
+                  content: [{ type: "text", text: "file" }],
+                }),
               ],
               time: { created: 2, completed: 3 },
             },
@@ -759,7 +763,9 @@ describe("V2 mini transport", () => {
 
     while (!ui.commits.some((commit) => commit.text === "Done.")) await Bun.sleep(0)
     expect(
-      ui.commits.filter((commit) => commit.kind === "user" || commit.kind === "assistant" || commit.kind === "tool").map((commit) => commit.text),
+      ui.commits
+        .filter((commit) => commit.kind === "user" || commit.kind === "assistant" || commit.kind === "tool")
+        .map((commit) => commit.text),
     ).toEqual(["what happened", "Done."])
     await transport.close()
   })
@@ -3474,6 +3480,66 @@ describe("V2 mini transport", () => {
     expect(ui.commits).toContainEqual(
       expect.objectContaining({ kind: "system", text: '→ Skill "tigerstyle"', messageID: "msg_skill" }),
     )
+    await transport.close()
+  })
+
+  test("preserves trailing skill arguments as a user prompt", async () => {
+    const events = feed()
+    events.push(connected())
+    const client = sdk({ streams: [events] })
+    const ui = footer()
+    const transport = await createSessionTransport({
+      sdk: client,
+      sessionID: "ses_1",
+      thinking: false,
+      footer: ui.api,
+    })
+    let request: Parameters<OpenCodeClient["session"]["prompt"]>[0] | undefined
+    const command = spyOn(client.session, "command")
+    const skill = spyOn(client.session, "skill")
+    spyOn(client.session, "prompt").mockImplementation((input) => {
+      request = input
+      queueMicrotask(() => {
+        events.push({
+          id: "evt_prompted",
+          created: 0,
+          type: "session.inbox.delivered",
+          durable: durable("ses_1"),
+          data: { sessionID: "ses_1", inboxID: "msg_skill" },
+        })
+        events.push({
+          id: "evt_settled",
+          created: 0,
+          type: "session.execution.succeeded",
+          durable: durable("ses_1"),
+          data: { sessionID: "ses_1" },
+        })
+      })
+      return ok({ data: { id: "msg_skill", sessionID: "ses_1", delivery: "steer", created: 0 } }) as never
+    })
+
+    await transport.runPromptTurn({
+      agent: "review",
+      model: undefined,
+      variant: undefined,
+      prompt: {
+        messageID: "msg_skill",
+        text: "/tigerstyle review this change",
+        parts: [],
+        command: { name: "tigerstyle", arguments: "review this change", source: "skill" },
+      },
+      files: [],
+      includeFiles: true,
+    })
+
+    expect(request).toMatchObject({
+      sessionID: "ses_1",
+      id: "msg_skill",
+      text: "review this change",
+      skills: [{ id: "tigerstyle" }],
+    })
+    expect(command).not.toHaveBeenCalled()
+    expect(skill).not.toHaveBeenCalled()
     await transport.close()
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #48720

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Slash-invoked skills with trailing text now submit that text as a normal user prompt with the selected skill attached. This keeps the request first-class in both the full and Mini TUI transports, while an argument-free `/skill` still uses the existing standalone activation path.

### How did you verify your code works?

- `cd packages/tui && bun test test/mini/stream-v2.transport.test.ts --timeout 30000 --only-failures` — 69 pass, 0 fail
- `cd packages/tui && bun typecheck`
- Prettier check on the three changed files

### Screenshots / recordings

N/A — transport behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
