### PR TITLE
fix(server): surface session creation errors

### DIFF
--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -316,7 +316,7 @@ export function make(options: ClientOptions) {
               location: input?.["location"],
             },
             successStatus: 200,
-            declaredStatuses: [401, 400],
+            declaredStatuses: [500, 401, 400],
             empty: false,
           },
           requestOptions,

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -25,6 +25,14 @@ export type InvalidCursorError = { readonly _tag: "InvalidCursorError"; readonly
 export const isInvalidCursorError = (value: unknown): value is InvalidCursorError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "InvalidCursorError"
 
+export type UnknownError = {
+  readonly _tag: "UnknownError"
+  readonly message: string
+  readonly ref?: string | undefined
+}
+export const isUnknownError = (value: unknown): value is UnknownError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnknownError"
+
 export type SessionNotFoundError = {
   readonly _tag: "SessionNotFoundError"
   readonly sessionID: string
@@ -57,14 +65,6 @@ export type MessageNotFoundError = {
 }
 export const isMessageNotFoundError = (value: unknown): value is MessageNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "MessageNotFoundError"
-
-export type UnknownError = {
-  readonly _tag: "UnknownError"
-  readonly message: string
-  readonly ref?: string | undefined
-}
-export const isUnknownError = (value: unknown): value is UnknownError =>
-  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnknownError"
 
 export type ProviderNotFoundError = {
   readonly _tag: "ProviderNotFoundError"

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { isSessionNotFoundError, isUnauthorizedError, OpenCode } from "../src"
+import { isSessionNotFoundError, isUnauthorizedError, isUnknownError, OpenCode } from "../src"
 
 test("exposes every standard HTTP API group", () => {
   const client = OpenCode.make({ baseUrl: "http://localhost:3000" })
@@ -52,6 +52,25 @@ test("sessions.get returns the wire projection", async () => {
   const result = await client.sessions.get({ sessionID: "ses_test" })
 
   expect(result.time.created).toBe(1_717_171_717_000)
+})
+
+test("sessions.create preserves server errors", async () => {
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async () =>
+      Response.json(
+        { _tag: "UnknownError", message: "Unexpected server error. Check server logs for details.", ref: "err_test" },
+        { status: 500 },
+      ),
+  })
+
+  try {
+    await client.sessions.create({ location: { directory: "/tmp/project" } })
+    throw new Error("Expected request to fail")
+  } catch (error) {
+    expect(isUnknownError(error)).toBe(true)
+    expect(error).toMatchObject({ ref: "err_test" })
+  }
 })
 
 test("events.subscribe exposes the Promise event stream wire projection", async () => {

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -664,6 +664,31 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "returns a structured error when session creation hits a mismatched database",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const { db } = yield* Database.Service
+        yield* db.run("ALTER TABLE session DROP COLUMN title")
+
+        const response = yield* request("/api/session", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ location: { directory: test.directory } }),
+        })
+        const body = yield* responseJson(response)
+
+        expect(response.status).toBe(500)
+        expect(body).toMatchObject({
+          _tag: "UnknownError",
+          message: "Unexpected server error. Check server logs for details.",
+        })
+        expect((body as { ref?: unknown }).ref).toMatch(/^err_[0-9a-f-]{8}$/)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "returns safe v2 unknown errors for corrupt projected messages",
     () =>
       Effect.gen(function* () {

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -134,6 +134,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           location: Location.Ref.pipe(Schema.optional),
         }),
         success: Schema.Struct({ data: Session.Info }),
+        error: UnknownError,
       }).annotateMerge(
         OpenApi.annotations({
           identifier: "v2.session.create",

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -68,12 +68,29 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
         "session.create",
         Effect.fn(function* (ctx) {
           return {
-            data: yield* session.create({
-              id: ctx.payload.id,
-              agent: ctx.payload.agent,
-              model: ctx.payload.model,
-              location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
-            }),
+            data: yield* session
+              .create({
+                id: ctx.payload.id,
+                agent: ctx.payload.agent,
+                model: ctx.payload.model,
+                location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
+              })
+              .pipe(
+                Effect.catchCause((cause) => {
+                  const ref = `err_${crypto.randomUUID().slice(0, 8)}`
+                  return Effect.logError("failed to create session", { cause }).pipe(
+                    Effect.annotateLogs({ ref }),
+                    Effect.andThen(
+                      Effect.fail(
+                        new UnknownError({
+                          message: "Unexpected server error. Check server logs for details.",
+                          ref,
+                        }),
+                      ),
+                    ),
+                  )
+                }),
+              ),
           }
         }),
       )

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1013,7 +1013,8 @@ export function Prompt(props: PromptProps) {
         console.log("Creating a session failed:", res.error)
 
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          title: "Creating a session failed",
+          message: errorMessage(res.error),
           variant: "error",
         })
 


### PR DESCRIPTION
### Issue for this PR

Closes #39775

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A database write failure during V2 session creation became an empty 500, while the TUI replaced the client error with generic copy.

This declares the safe `UnknownError` response, logs the full server cause with a short reference, regenerates the Promise client, and shows the decoded message in the creation toast. The implementation follows the diagnosis in the closed #39877 by @xinyuan0801, adapted to the current server and client architecture.

### How did you verify your code works?

- Simulated schema drift by dropping `session.title` from a real SQLite test database; `POST /api/session` returns a structured 500 with an `err_...` reference
- `packages/opencode` targeted regression: 1 passed
- `packages/client` Promise tests: 8 passed
- Typechecks passed in `packages/protocol`, `packages/server`, `packages/client`, `packages/tui`, and `packages/opencode`
- Generated client output, Prettier, and `git diff --check` verified

### Screenshots / recordings

Not included. The visible change is the session-creation toast showing the decoded server error instead of generic copy.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR