### PR TITLE
fix(ai): normalize Bedrock document labels

### DIFF
--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -288,7 +288,10 @@ const lowerToolCall = (part: ToolCallPart): BedrockToolUseBlock => ({
   },
 })
 
-const lowerToolResultContent = Effect.fn("BedrockConverse.lowerToolResultContent")(function* (part: ToolResultPart) {
+const lowerToolResultContent = Effect.fn("BedrockConverse.lowerToolResultContent")(function* (
+  part: ToolResultPart,
+  documentNames: Set<string>,
+) {
   if (part.result.type === "text" || part.result.type === "error")
     return [{ text: ProviderShared.toolResultText(part) }]
   if (part.result.type === "json") return [{ json: part.result.value }]
@@ -299,22 +302,28 @@ const lowerToolResultContent = Effect.fn("BedrockConverse.lowerToolResultContent
       content.push({ text: item.text })
       continue
     }
-    const media = yield* BedrockMedia.lower({
-      type: "media",
-      mediaType: item.mime,
-      data: item.uri,
-      filename: item.name,
-    })
+    const media = yield* BedrockMedia.lower(
+      {
+        type: "media",
+        mediaType: item.mime,
+        data: item.uri,
+        filename: item.name,
+      },
+      documentNames,
+    )
     content.push(media)
   }
   return content
 })
 
-const lowerToolResult = Effect.fn("BedrockConverse.lowerToolResult")(function* (part: ToolResultPart) {
+const lowerToolResult = Effect.fn("BedrockConverse.lowerToolResult")(function* (
+  part: ToolResultPart,
+  documentNames: Set<string>,
+) {
   return {
     toolResult: {
       toolUseId: part.id,
-      content: yield* lowerToolResultContent(part),
+      content: yield* lowerToolResultContent(part, documentNames),
       status: part.result.type === "error" ? "error" : "success",
     },
   } satisfies BedrockToolResultBlock
@@ -325,6 +334,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
   breakpoints: BedrockCache.Breakpoints,
 ) {
   const messages: BedrockMessage[] = []
+  const documentNames = new Set<string>()
   const providerMetadataKey = request.model.route.providerMetadataKey ?? String(request.model.provider)
 
   for (const message of request.messages) {
@@ -348,7 +358,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
           continue
         }
         if (part.type === "media") {
-          content.push(yield* BedrockMedia.lower(part))
+          content.push(yield* BedrockMedia.lower(part, documentNames))
           continue
         }
       }
@@ -401,7 +411,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
     for (const part of message.content) {
       if (!ProviderShared.supportsContent(part, ["tool-result"]))
         return yield* ProviderShared.unsupportedContent("Bedrock Converse", "tool", ["tool-result"])
-      content.push(yield* lowerToolResult(part))
+      content.push(yield* lowerToolResult(part, documentNames))
       const cachePoint = BedrockCache.block(breakpoints, part.cache)
       if (cachePoint) content.push(cachePoint)
     }

--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -311,7 +311,7 @@ const lowerToolResultContent = Effect.fn("BedrockConverse.lowerToolResultContent
       },
       documentNames,
     )
-    content.push(media)
+    content.push(...media)
   }
   return content
 })
@@ -358,7 +358,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
           continue
         }
         if (part.type === "media") {
-          content.push(yield* BedrockMedia.lower(part, documentNames))
+          content.push(...(yield* BedrockMedia.lower(part, documentNames)))
           continue
         }
       }

--- a/packages/ai/src/protocols/utils/bedrock-media.ts
+++ b/packages/ai/src/protocols/utils/bedrock-media.ts
@@ -95,13 +95,22 @@ export const lower = Effect.fn("BedrockMedia.lower")(function* (part: MediaPart,
   const mime = part.mediaType.toLowerCase()
   const imageFormat = IMAGE_FORMATS[mime as keyof typeof IMAGE_FORMATS]
   if (imageFormat) {
-    return { image: { format: imageFormat, source: { bytes: yield* mediaBase64(part) } } } satisfies ImageBlock
+    return [{ image: { format: imageFormat, source: { bytes: yield* mediaBase64(part) } } } satisfies ImageBlock]
   }
   if (mime.startsWith("image/"))
     return yield* ProviderShared.invalidRequest(`Bedrock Converse does not support image media type ${part.mediaType}`)
   const documentFormat = DOCUMENT_FORMATS[mime as keyof typeof DOCUMENT_FORMATS]
   if (documentFormat) {
-    return documentBlock(documentName(part.filename, documentNames), documentFormat, yield* mediaBase64(part))
+    const name = documentName(part.filename, documentNames)
+    const block = documentBlock(name, documentFormat, yield* mediaBase64(part))
+    return part.filename !== undefined && part.filename !== name
+      ? [
+          {
+            text: `Attached file ${ProviderShared.encodeJson(part.filename)} has document label ${ProviderShared.encodeJson(name)}.`,
+          },
+          block,
+        ]
+      : [block]
   }
   return yield* ProviderShared.invalidRequest(`Bedrock Converse does not support media type ${part.mediaType}`)
 })

--- a/packages/ai/src/protocols/utils/bedrock-media.ts
+++ b/packages/ai/src/protocols/utils/bedrock-media.ts
@@ -57,6 +57,25 @@ const documentBlock = (name: string, format: DocumentFormat, bytes: string): Doc
   },
 })
 
+function documentName(filename: string | undefined, names: Set<string>) {
+  const base =
+    (filename ?? "")
+      .replace(/\.[^.]*$/, "")
+      .replace(/[^a-zA-Z0-9 ()[\]-]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 200)
+      .trim() || "document"
+  let name = base
+  // Converse requires labels to be unique across the entire request, including tool results.
+  for (let index = 2; names.has(name); index++) {
+    const suffix = ` ${index}`
+    name = `${base.slice(0, 200 - suffix.length).trimEnd()}${suffix}`
+  }
+  names.add(name)
+  return name
+}
+
 const mediaBase64 = Effect.fn("BedrockMedia.mediaBase64")(function* (part: MediaPart) {
   const media = ProviderShared.normalizeMedia(part)
   const bytes = yield* Effect.fromResult(Encoding.decodeBase64(media.base64)).pipe(
@@ -72,7 +91,7 @@ const mediaBase64 = Effect.fn("BedrockMedia.mediaBase64")(function* (part: Media
 // document block. Image MIME types not in `IMAGE_FORMATS` (e.g. `image/svg+xml`)
 // get an image-specific error so the caller knows it's a format-support issue,
 // not a kind-detection issue.
-export const lower = Effect.fn("BedrockMedia.lower")(function* (part: MediaPart) {
+export const lower = Effect.fn("BedrockMedia.lower")(function* (part: MediaPart, documentNames: Set<string>) {
   const mime = part.mediaType.toLowerCase()
   const imageFormat = IMAGE_FORMATS[mime as keyof typeof IMAGE_FORMATS]
   if (imageFormat) {
@@ -82,9 +101,7 @@ export const lower = Effect.fn("BedrockMedia.lower")(function* (part: MediaPart)
     return yield* ProviderShared.invalidRequest(`Bedrock Converse does not support image media type ${part.mediaType}`)
   const documentFormat = DOCUMENT_FORMATS[mime as keyof typeof DOCUMENT_FORMATS]
   if (documentFormat) {
-    if (!part.filename)
-      return yield* ProviderShared.invalidRequest("Bedrock Converse document media requires a filename")
-    return documentBlock(part.filename, documentFormat, yield* mediaBase64(part))
+    return documentBlock(documentName(part.filename, documentNames), documentFormat, yield* mediaBase64(part))
   }
   return yield* ProviderShared.invalidRequest(`Bedrock Converse does not support media type ${part.mediaType}`)
 })

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -1765,25 +1765,129 @@ describe("Bedrock Converse route", () => {
             role: "user",
             content: [
               { text: "Summarize these documents." },
-              { document: { format: "pdf", name: "report.pdf", source: { bytes: "UERGREFUQQ==" } } },
-              { document: { format: "csv", name: "data.csv", source: { bytes: "Q1NWREFUQQ==" } } },
+              { document: { format: "pdf", name: "report", source: { bytes: "UERGREFUQQ==" } } },
+              { document: { format: "csv", name: "data", source: { bytes: "Q1NWREFUQQ==" } } },
             ],
           },
         ],
       })
     }),
   )
+  ;[
+    {
+      label: "filename punctuation",
+      filename: "report_v1.2?.pdf",
+      expected: "report v1 2",
+      duplicate: "report v1 2 2",
+    },
+    {
+      label: "repeated whitespace",
+      filename: "  Quarterly\t \n report.txt",
+      expected: "Quarterly report",
+      duplicate: "Quarterly report 2",
+    },
+    {
+      label: "allowed characters",
+      filename: "Report - Final (v2) [2026]",
+      expected: "Report - Final (v2) [2026]",
+      duplicate: "Report - Final (v2) [2026] 2",
+    },
+    { label: "accented filename", filename: "résumé.pdf", expected: "r sum", duplicate: "r sum 2" },
+    { label: "non-Latin filename", filename: "報告書.pdf", expected: "document", duplicate: "document 2" },
+    { label: "missing filename", filename: undefined, expected: "document", duplicate: "document 2" },
+    { label: "empty filename", filename: "", expected: "document", duplicate: "document 2" },
+    { label: "blank filename", filename: " \t\n", expected: "document", duplicate: "document 2" },
+    { label: "extension-only filename", filename: ".pdf", expected: "document", duplicate: "document 2" },
+    { label: "symbols-only filename", filename: "@@@.pdf", expected: "document", duplicate: "document 2" },
+    {
+      label: "overlong filename",
+      filename: `${"a".repeat(201)}.txt`,
+      expected: "a".repeat(200),
+      duplicate: `${"a".repeat(198)} 2`,
+    },
+    {
+      label: "maximum-length label",
+      filename: "a".repeat(200),
+      expected: "a".repeat(200),
+      duplicate: `${"a".repeat(198)} 2`,
+    },
+    {
+      label: "whitespace at truncation",
+      filename: `${"a".repeat(199)} b.txt`,
+      expected: "a".repeat(199),
+      duplicate: `${"a".repeat(198)} 2`,
+    },
+  ].forEach((item) => {
+    it.effect(`normalizes ${item.label} in user and tool-result documents`, () =>
+      Effect.gen(function* () {
+        const request = LLM.request({
+          model,
+          cache: "none",
+          messages: [
+            Message.user([
+              { type: "text", text: "Read this document" },
+              { type: "media", mediaType: "application/pdf", data: "UERGREFUQQ==", filename: item.filename },
+            ]),
+            Message.assistant([ToolCallPart.make({ id: "call_read", name: "read", input: {} })]),
+            Message.tool({
+              id: "call_read",
+              name: "read",
+              result: {
+                type: "content",
+                value: [
+                  { type: "text", text: "Read successfully" },
+                  {
+                    type: "file",
+                    uri: "data:application/pdf;base64,UERGREFUQQ==",
+                    mime: "application/pdf",
+                    name: item.filename,
+                  },
+                ],
+              },
+            }),
+          ],
+        })
+        const original = JSON.stringify(request.messages)
+        const first = yield* compileRequest(request)
+        const second = yield* compileRequest(request)
+        const expected = { format: "pdf", name: item.expected, source: { bytes: "UERGREFUQQ==" } }
 
-  it.effect("requires names for document media", () =>
+        expect(first.body.messages[0].content[1].document).toEqual(expected)
+        expect(first.body.messages[2].content[0].toolResult.content[1].document).toEqual({
+          ...expected,
+          name: item.duplicate,
+        })
+        expect(second.body).toEqual(first.body)
+        expect(JSON.stringify(request.messages)).toBe(original)
+      }),
+    )
+  })
+
+  it.effect("keeps colliding document labels distinct within a request", () =>
     Effect.gen(function* () {
-      const error = yield* compileRequest(
+      const prepared = yield* compileRequest(
         LLM.request({
           model,
-          messages: [Message.user({ type: "media", mediaType: "application/pdf", data: "UERGREFUQQ==" })],
+          cache: "none",
+          messages: [
+            Message.user([
+              { type: "text", text: "Read these documents" },
+              ...["report_v1.txt", "report#v1.txt", "report v1 2.txt", "report v1.txt"].map((filename) => ({
+                type: "media" as const,
+                mediaType: "text/plain",
+                data: "SGVsbG8=",
+                filename,
+              })),
+            ]),
+          ],
         }),
-      ).pipe(Effect.flip)
-
-      expect(error.message).toContain("document media requires a filename")
+      )
+      expect(prepared.body.messages[0].content.slice(1).map((part) => part.document.name)).toEqual([
+        "report v1",
+        "report v1 2",
+        "report v1 2 2",
+        "report v1 3",
+      ])
     }),
   )
 
@@ -1807,7 +1911,7 @@ describe("Bedrock Converse route", () => {
       expect(prepared.body.messages).toEqual([
         {
           role: "user",
-          content: [{ document: { format: "pdf", name: "report.pdf", source: { bytes: "UERGREFUQQ==" } } }],
+          content: [{ document: { format: "pdf", name: "report", source: { bytes: "UERGREFUQQ==" } } }],
         },
       ])
     }),

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -1765,7 +1765,9 @@ describe("Bedrock Converse route", () => {
             role: "user",
             content: [
               { text: "Summarize these documents." },
+              { text: 'Attached file "report.pdf" has document label "report".' },
               { document: { format: "pdf", name: "report", source: { bytes: "UERGREFUQQ==" } } },
+              { text: 'Attached file "data.csv" has document label "data".' },
               { document: { format: "csv", name: "data", source: { bytes: "Q1NWREFUQQ==" } } },
             ],
           },
@@ -1852,8 +1854,10 @@ describe("Bedrock Converse route", () => {
         const second = yield* compileRequest(request)
         const expected = { format: "pdf", name: item.expected, source: { bytes: "UERGREFUQQ==" } }
 
-        expect(first.body.messages[0].content[1].document).toEqual(expected)
-        expect(first.body.messages[2].content[0].toolResult.content[1].document).toEqual({
+        expect(first.body.messages[0].content.find((part) => "document" in part)?.document).toEqual(expected)
+        expect(
+          first.body.messages[2].content[0].toolResult.content.find((part) => "document" in part)?.document,
+        ).toEqual({
           ...expected,
           name: item.duplicate,
         })
@@ -1882,16 +1886,20 @@ describe("Bedrock Converse route", () => {
           ],
         }),
       )
-      expect(prepared.body.messages[0].content.slice(1).map((part) => part.document.name)).toEqual([
-        "report v1",
-        "report v1 2",
-        "report v1 2 2",
-        "report v1 3",
+      expect(prepared.body.messages[0].content.slice(1)).toEqual([
+        { text: 'Attached file "report_v1.txt" has document label "report v1".' },
+        { document: { format: "txt", name: "report v1", source: { bytes: "SGVsbG8=" } } },
+        { text: 'Attached file "report#v1.txt" has document label "report v1 2".' },
+        { document: { format: "txt", name: "report v1 2", source: { bytes: "SGVsbG8=" } } },
+        { text: 'Attached file "report v1 2.txt" has document label "report v1 2 2".' },
+        { document: { format: "txt", name: "report v1 2 2", source: { bytes: "SGVsbG8=" } } },
+        { text: 'Attached file "report v1.txt" has document label "report v1 3".' },
+        { document: { format: "txt", name: "report v1 3", source: { bytes: "SGVsbG8=" } } },
       ])
     }),
   )
 
-  it.effect("passes named document-only messages through for provider validation", () =>
+  it.effect("annotates renamed document-only messages with their original filename", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(
         LLM.request({
@@ -1911,8 +1919,40 @@ describe("Bedrock Converse route", () => {
       expect(prepared.body.messages).toEqual([
         {
           role: "user",
-          content: [{ document: { format: "pdf", name: "report", source: { bytes: "UERGREFUQQ==" } } }],
+          content: [
+            { text: 'Attached file "report.pdf" has document label "report".' },
+            { document: { format: "pdf", name: "report", source: { bytes: "UERGREFUQQ==" } } },
+          ],
         },
+      ])
+    }),
+  )
+
+  it.effect("quotes original filenames in annotations and omits redundant mappings", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          cache: "none",
+          messages: [
+            Message.user([
+              { type: "text", text: "Read these documents" },
+              ...["report", undefined, 'report "final"\n.pdf'].map((filename) => ({
+                type: "media" as const,
+                mediaType: "text/plain",
+                data: "SGVsbG8=",
+                filename,
+              })),
+            ]),
+          ],
+        }),
+      )
+      expect(prepared.body.messages[0].content).toEqual([
+        { text: "Read these documents" },
+        { document: { format: "txt", name: "report", source: { bytes: "SGVsbG8=" } } },
+        { document: { format: "txt", name: "document", source: { bytes: "SGVsbG8=" } } },
+        { text: 'Attached file "report \\"final\\"\\n.pdf" has document label "report final".' },
+        { document: { format: "txt", name: "report final", source: { bytes: "SGVsbG8=" } } },
       ])
     }),
   )
@@ -1936,7 +1976,7 @@ describe("Bedrock Converse route", () => {
                     type: "file",
                     uri: "data:application/pdf;base64,UERGREFUQQ==",
                     mime: "application/pdf",
-                    name: "report",
+                    name: "report.pdf",
                   },
                 ],
               },
@@ -1959,6 +1999,7 @@ describe("Bedrock Converse route", () => {
                 status: "success",
                 content: [
                   { text: "Read successfully" },
+                  { text: 'Attached file "report.pdf" has document label "report".' },
                   { document: { format: "pdf", name: "report", source: { bytes: "UERGREFUQQ==" } } },
                 ],
               },


### PR DESCRIPTION
## Problem

Bedrock Converse rejects document labels containing ordinary filename characters such as dots and underscores. It also rejects consecutive whitespace, labels longer than 200 characters, and duplicate labels anywhere in a request, including across user messages and tool results.

Sending the original filename directly as `document.name` therefore makes ordinary document attachments fail with HTTP 400. Missing filenames currently fail during local request construction.

## Change

Build valid document labels while serializing Converse media:

- Remove the filename extension.
- Replace disallowed characters with spaces, collapse whitespace, and trim.
- Limit the label to 200 characters.
- Use `document` when no usable label remains.
- Resolve collisions with deterministic numeric suffixes (`document 2`, `document 3`, etc.), keeping the length limit when adding a suffix.
- When a supplied filename differs from the document label, add a text annotation immediately before the document block, in the same user message or tool result:

  ```text
  Attached file "report_v1.pdf" has document label "report v1".
  ```

  This lets the model match the user's original filename to the provider label, including collision suffixes. Filenames are JSON-quoted so embedded quotes and line breaks are unambiguous. Annotations are omitted when the label already matches or there is no original filename.

One request-local set tracks labels across user documents and tool-result documents. Rebuilding the same request produces the same labels. Tests verify that the source messages retain their original filenames and document bytes.

## Validation

Live checks used `global.anthropic.claude-sonnet-5` through Converse in `us-east-1`. All 16 post-fix cases returned HTTP 200 and `OK`.

| Case | Before | After |
| --- | --- | --- |
| `report_v1.txt` | HTTP 400 | `report v1`, HTTP 200 |
| `report.txt` | HTTP 400 | `report`, HTTP 200 |
| Repeated whitespace | HTTP 400 | Collapsed whitespace, HTTP 200 |
| Accented or non-Latin characters | HTTP 400 | Valid label or fallback, HTTP 200 |
| Empty or missing filename | Local request-construction error | `document`, HTTP 200 |
| Extension-only or symbols-only filename | HTTP 400 | `document`, HTTP 200 |
| 201-character label | HTTP 400 | 200-character label, HTTP 200 |
| Duplicate labels in one message | HTTP 400 | `document`, `document 2`, HTTP 200 |
| Duplicate labels across user and tool-result messages | HTTP 400 | Unique labels, HTTP 200 |
| Document returned by a tool with `report_v1.txt` | HTTP 400 | `report v1`, HTTP 200 |

Valid-character and 200-character controls succeeded both before and after. An additional post-fix collision case verified unique labels when sanitized filenames collide with an existing numeric suffix.

After adding filename mappings, four additional live requests used actual PDFs with different verification codes. Each request named the target by its original filename. All returned HTTP 200 and the correct code:

- Two filenames that sanitize to the same base label.
- The same attachments in reverse order.
- Non-Latin and symbols-only filenames that require fallback labels.
- One attached PDF and one PDF returned by a tool.

### Matched annotation comparison

Ran seven paired live scenarios (14 requests). Each pair used identical PDF bytes, prompts, sanitized document labels, ordering, model, and output limit; the only request-body difference was the filename annotations. Saved request bodies were compared to verify that isolation.

Two scenarios demonstrated selection of the wrong PDF without the mapping:

| Scenario | Requested file / correct code | Without annotations | With annotations |
| --- | --- | --- | --- |
| `report_v1.pdf` and `report#v1.pdf` attached together | `report#v1.pdf` / `BRAVO` | Returned `ALPHA` from the other PDF | Returned `BRAVO` |
| First PDF attached, second returned by a tool | `report#v1.pdf` / `BRAVO` | Returned `ALPHA` from the other PDF | Identified `BRAVO` (with extra prose) |

The single-PDF and distinct-filename controls selected the correct code with or without annotations. Other no-annotation cases produced incomplete or absent answers under the 128-token output cap; these are not counted as demonstrated wrong-file selections. This comparison establishes a concrete benefit for ambiguous labels, not a general accuracy rate or a claim that every renamed attachment requires an annotation.

### Automated checks

- All 14 new normalization/collision regressions failed before the fix.
- Five annotation expectations failed before the mapping change.
- `bun test test/provider/bedrock-converse.test.ts` from `packages/ai` — 101 passed.
- `bun test test/provider/pdf.recorded.test.ts --test-name-pattern 'Bedrock'` from `packages/ai` — 2 passed.
- `bun typecheck` from `packages/ai` — passed.
- Prettier and `git diff --check` — passed.
