### PR TITLE
feat(v2): allow disabling Anthropic thinking block binding

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -59,6 +59,8 @@ export type ThinkingInput =
       readonly type: "adaptive"
       readonly display?: "summarized" | "omitted"
       readonly block_binding?: ThinkingBlockBinding
+      /** OpenCode-only opt-out; consumed before the request is serialized. */
+      readonly blockBinding?: false
     }
   | {
       readonly type: "disabled"
@@ -67,6 +69,8 @@ export type ThinkingInput =
       readonly type: "enabled"
       readonly display?: "summarized" | "omitted"
       readonly block_binding?: ThinkingBlockBinding
+      /** OpenCode-only opt-out; consumed before the request is serialized. */
+      readonly blockBinding?: false
     } & (
       | { readonly budgetTokens: number; readonly budget_tokens?: number }
       | { readonly budgetTokens?: number; readonly budget_tokens: number }
@@ -1042,8 +1046,9 @@ const resolveOptions = Effect.fn("AnthropicMessages.resolveOptions")(function* (
           ...(outputConfigFormat === undefined ? {} : { format: outputConfigFormat }),
         }
   const thinking = yield* resolveThinking(input?.thinking)
+  const blockBindingOptOut = ProviderShared.isRecord(input?.thinking) && input.thinking.blockBinding === false
   return {
-    thinking: applyThinkingBindingDefault(request.model, thinking),
+    thinking: blockBindingOptOut ? thinking : applyThinkingBindingDefault(request.model, thinking),
     effort: outputConfigEffort,
     output_config,
     service_tier,

--- a/packages/ai/test/provider/anthropic-thinking-binding.test.ts
+++ b/packages/ai/test/provider/anthropic-thinking-binding.test.ts
@@ -80,3 +80,21 @@ it.effect("allows model compatibility to disable thinking block binding", () =>
     expect(prepared.request.headers["anthropic-beta"]).toBe("existing-beta,interleaved-thinking-2025-05-14")
   }),
 )
+
+it.effect("allows provider options to opt out of thinking block binding", () =>
+  Effect.gen(function* () {
+    const request = LLM.request({
+      model: AnthropicMessages.route.model({ id: "claude-fable-5-1" }),
+      prompt: "Hello",
+      providerOptions: {
+        thinking: { type: "adaptive", blockBinding: false },
+      },
+      http: { headers: { "anthropic-beta": "existing-beta" } },
+    })
+    const compiled = yield* compileRequest(request)
+    const prepared = yield* AnthropicMessages.route.prepareTransport(compiled.body, request)
+
+    expect(compiled.body.thinking).toEqual({ type: "adaptive" })
+    expect(prepared.request.headers["anthropic-beta"]).toBe("existing-beta,interleaved-thinking-2025-05-14")
+  }),
+)

--- a/packages/ai/test/provider/anthropic-thinking-binding.test.ts
+++ b/packages/ai/test/provider/anthropic-thinking-binding.test.ts
@@ -62,3 +62,21 @@ it.effect("preserves explicit thinking settings and combines required beta heade
     }
   }),
 )
+
+it.effect("allows model compatibility to disable thinking block binding", () =>
+  Effect.gen(function* () {
+    const request = LLM.request({
+      model: AnthropicMessages.route.model({
+        id: "claude-fable-5-1",
+        compatibility: { supportsThinkingBlockBinding: false },
+      }),
+      prompt: "Hello",
+      http: { headers: { "anthropic-beta": "existing-beta" } },
+    })
+    const compiled = yield* compileRequest(request)
+    const prepared = yield* AnthropicMessages.route.prepareTransport(compiled.body, request)
+
+    expect(compiled.body.thinking).toBeUndefined()
+    expect(prepared.request.headers["anthropic-beta"]).toBe("existing-beta,interleaved-thinking-2025-05-14")
+  }),
+)

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -837,6 +837,26 @@ describe("Config", () => {
     expect(migrated.providers?.custom?.models?.boolean?.compatibility).toBeUndefined()
   })
 
+  test("preserves v1 thinking block binding opt-outs in model settings", () => {
+    const migrated = ConfigMigrateV1.migrate({
+      provider: {
+        anthropic: {
+          models: {
+            claude: {
+              options: {
+                thinking: { type: "adaptive", blockBinding: false },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(migrated.providers?.anthropic?.models?.claude?.settings).toEqual({
+      thinking: { type: "adaptive", blockBinding: false },
+    })
+  })
+
   for (const subtask of [true, false]) {
     test(`migrates v1 command configuration with subtask: ${subtask}`, () => {
       expect(

--- a/packages/core/test/config/provider.test.ts
+++ b/packages/core/test/config/provider.test.ts
@@ -491,6 +491,7 @@ describe("ConfigProviderPlugin.Plugin", () => {
                         reasoningField: "vendor_reasoning",
                         maxTokensField: "max_completion_tokens",
                         requireFinishReason: false,
+                        supportsThinkingBlockBinding: false,
                       },
                       capabilities: { tools: true, input: ["text"], output: ["text"] },
                       disabled: true,
@@ -589,6 +590,7 @@ describe("ConfigProviderPlugin.Plugin", () => {
           reasoningField: "vendor_reasoning",
           maxTokensField: "max_completion_tokens",
           requireFinishReason: false,
+          supportsThinkingBlockBinding: false,
         })
         expect(model.capabilities).toEqual({ tools: true, input: ["text"], output: ["text"] })
         expect(model.enabled).toBe(false)

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -60,6 +60,8 @@ export const Compatibility = Schema.Struct({
   maxTokensField: MaxTokensField.pipe(optional),
   requireFinishReason: Schema.Boolean.pipe(optional),
   requireAssistantAfterTool: Schema.Boolean.pipe(optional),
+  /** Whether Anthropic thinking-prefix binding controls are supported by the deployment. */
+  supportsThinkingBlockBinding: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Model.Compatibility" })
 
 export interface Capabilities extends Schema.Schema.Type<typeof Capabilities> {}

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -44,6 +44,7 @@ describe("Model.Compatibility", () => {
         maxTokensField: "max_completion_tokens",
         requireFinishReason: false,
         requireAssistantAfterTool: true,
+        supportsThinkingBlockBinding: false,
       }),
     ).toEqual({
       reasoningField: "vendor_reasoning",
@@ -51,6 +52,7 @@ describe("Model.Compatibility", () => {
       maxTokensField: "max_completion_tokens",
       requireFinishReason: false,
       requireAssistantAfterTool: true,
+      supportsThinkingBlockBinding: false,
     })
   })
 })


### PR DESCRIPTION
Fixes #48757### Issue for this PR### Type of change- [x] Bug fix- [x] New feature### What does this PR do?V2 supports the V1-compatible blockBinding opt-out.### How did you verify your code works?Tests and typechecks pass.### Screenshots / recordingsNot applicable.### Checklist- [x] I have tested my changes locally- [x] I have not included unrelated changes in this PR