### PR TITLE
fix(session): keep session path relative for non-git projects on Windows

### DIFF
--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -40,5 +40,6 @@ export const migrations = (
     import("./migration/20260622142730_simplify_session_context_epoch"),
     import("./migration/20260622170816_reset_v2_session_state"),
     import("./migration/20260622202450_simplify_session_input"),
+    import("./migration/20260913055146_normalize_session_subpath"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260913055146_normalize_session_subpath.ts
+++ b/packages/core/src/database/migration/20260913055146_normalize_session_subpath.ts
@@ -1,0 +1,47 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260913055146_normalize_session_subpath",
+  up(tx) {
+    return Effect.gen(function* () {
+      // Non-git projects resolve to "/" as their directory. On Windows "/" follows the
+      // current process drive, so path.relative() returned the directory unchanged when
+      // the session lived on another drive. Those sessions stored an absolute `path`,
+      // which the session list filter never matches. Rewrite them relative to the drive
+      // root, the same base the writer now uses. UNC paths ("//host/share") have the same
+      // shape with a different root and are left alone.
+      yield* tx.run(`DROP TABLE IF EXISTS session_path_fix;`)
+      yield* tx.run(`
+        CREATE TEMP TABLE session_path_fix AS
+        SELECT id AS session_id, path AS absolute, substr(path, 4) AS relative
+        FROM session
+        WHERE path GLOB '[A-Za-z]:/*';
+      `)
+      yield* tx.run(`UPDATE session SET path = substr(path, 4) WHERE path GLOB '[A-Za-z]:/*';`)
+      // The same value is embedded in each session's events, so a projection rebuild
+      // would otherwise write the absolute path back. Cover both serializer spacings.
+      yield* tx.run(`
+        UPDATE event
+        SET data = replace(
+          data,
+          '"path":"' || (SELECT absolute FROM session_path_fix WHERE session_id = event.aggregate_id) || '"',
+          '"path":"' || (SELECT relative FROM session_path_fix WHERE session_id = event.aggregate_id) || '"'
+        )
+        WHERE type IN ('session.created.1', 'session.updated.1')
+          AND instr(data, '"path":"' || (SELECT absolute FROM session_path_fix WHERE session_id = event.aggregate_id) || '"') > 0;
+      `)
+      yield* tx.run(`
+        UPDATE event
+        SET data = replace(
+          data,
+          '"path": "' || (SELECT absolute FROM session_path_fix WHERE session_id = event.aggregate_id) || '"',
+          '"path": "' || (SELECT relative FROM session_path_fix WHERE session_id = event.aggregate_id) || '"'
+        )
+        WHERE type IN ('session.created.1', 'session.updated.1')
+          AND instr(data, '"path": "' || (SELECT absolute FROM session_path_fix WHERE session_id = event.aggregate_id) || '"') > 0;
+      `)
+      yield* tx.run(`DROP TABLE session_path_fix;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -210,6 +210,10 @@ const layer = Layer.effect(
         const recorded = yield* store.get(sessionID)
         if (recorded) return recorded
         const project = yield* projects.resolve(input.location.directory)
+        // Non-git projects resolve to "/" as their directory. On Windows "/" follows the
+        // current process drive, so path.relative() returns an absolute path when the session
+        // directory sits on another drive. Anchor to that directory's own root instead.
+        const base = project.vcs ? project.directory : path.parse(input.location.directory).root
         yield* db
           .insert(ProjectTable)
           .values({ id: project.id, worktree: project.directory, vcs: project.vcs?.type, sandboxes: [] })
@@ -223,7 +227,7 @@ const layer = Layer.effect(
           version: InstallationVersion,
           projectID: project.id,
           directory: input.location.directory,
-          path: path.relative(project.directory, input.location.directory).replaceAll("\\", "/"),
+          path: path.relative(base, input.location.directory).replaceAll("\\", "/"),
           workspaceID: input.location.workspaceID ? WorkspaceV2.ID.make(input.location.workspaceID) : undefined,
           title: `New session - ${new Date(now).toISOString()}`,
           agent: input.agent,


### PR DESCRIPTION
### Issue for this PR

Closes #48762

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two commits.

**1. `fix(session): keep session path relative for non-git projects on Windows`**

Non-git projects resolve to `/` as their project directory. On Windows `/` follows the current process drive, so `path.relative("/", "E:/work")` is a cross-drive relative and Node returns the absolute path unchanged. The session row then gets `path === directory`, and the session picker — which filters on the relative value — never matches it, so those sessions are missing from the list even though they are in the DB.

This bases the relative path on the session directory's own root when the project has no VCS:

```ts
const base = project.vcs ? project.directory : path.parse(input.location.directory).root
...
path: path.relative(base, input.location.directory).replaceAll("\\", "/"),
```

Git projects are untouched.

**2. `fix(session): normalize session paths stored absolute by non-git projects`**

Repairs rows already written before the fix. `session.path` is rewritten relative to its drive root, and the copy embedded in `session.created.1` / `session.updated.1` events is rewritten as well — otherwise a projection rebuild puts the absolute value straight back. Pure `UPDATE`s guarded by `WHERE path GLOB '[A-Za-z]:/*'`, so this is a no-op on a healthy database and on a second run.

It is the half `20260601010001_normalize_storage_paths` missed: that one normalized backslashes only (`instr(path, char(92)) > 0`), so a row like `E:/Desktop/x` — already forward-slashed, merely absolute — slipped through.

UNC paths (`//host/share/...`) have the same shape with a different root; they are out of scope here and left alone.

### How did you verify your code works?

Expression check with Node on Windows 11:

```
path.relative("/", "E:/Desktop/mytests/modeltest/workspace")
  -> "E:\\Desktop\\mytests\\modeltest\\workspace"     # absolute -> bug
path.parse("E:/Desktop/mytests/modeltest/workspace").root
  -> "E:/"
path.relative("E:/", "E:/Desktop/mytests/modeltest/workspace")
  -> "Desktop\\mytests\\modeltest\\workspace"         # relative -> fixed
```

`C:` is unaffected: `Users\y2278\proj` before and after.

Migration: imported the new file and ran its exported `up()` against a real database that has the bug (26 sessions, 1464 events), with a stub `tx.run` that executes the captured statements in SQLite. After it runs: 0 absolute rows remain, the picker's own query for one affected directory goes from 0 to 9 matches, a session that was already relative is unchanged, and a `message.part.updated.1` row whose tool arguments happen to contain the same absolute path is untouched. A second run changes nothing.

`bun typecheck` passes, 30/30.

Limits: no test suite run, and the migration was exercised through a stubbed `tx.run` rather than the real drizzle transaction wrapper.

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Note: the same writer expression is also on `beta` (`packages/core/src/session.ts` line 254, as `subpath:`), in case it needs the same change there.
