### PR TITLE
fix(core): validate git branch names

### DIFF
--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -103,10 +103,19 @@ export function parseRemote(input: string): RemoteReference {
 }
 
 export function validateBranch(branch: string): void {
-  if (/^[A-Za-z0-9/_.-]+$/.test(branch) && !branch.startsWith("-") && !branch.includes("..")) return
+  if (
+    /^[A-Za-z0-9/_.-]+$/.test(branch) &&
+    !branch.startsWith("-") &&
+    !branch.includes("..") &&
+    !branch.endsWith(".") &&
+    branch
+      .split("/")
+      .every((component) => component.length > 0 && !component.startsWith(".") && !component.endsWith(".lock"))
+  )
+    return
   throw new InvalidBranchError({
     branch,
-    message: "Branch must contain only alphanumeric characters, /, _, ., and -, and cannot start with - or contain ..",
+    message: "Branch must be a valid Git branch name using only alphanumeric characters, /, _, ., and -",
   })
 }
 

--- a/packages/core/test/repository.test.ts
+++ b/packages/core/test/repository.test.ts
@@ -56,10 +56,22 @@ describe("Repository", () => {
   test("rejects unsafe remote references and branches with typed errors", () => {
     expect(() => Repository.parseRemote("not-a-repo")).toThrow(Repository.InvalidReferenceError)
     expect(() => Repository.parseRemote("git@github.com:../../../etc/passwd")).toThrow(Repository.InvalidReferenceError)
-    expect(() => Repository.validateBranch("feature/docs.v1")).not.toThrow()
-    expect(() => Repository.validateBranch("-bad")).toThrow(Repository.InvalidBranchError)
-    expect(() => Repository.validateBranch("bad..branch")).toThrow(Repository.InvalidBranchError)
-    expect(() => Repository.validateBranch("bad branch")).toThrow(Repository.InvalidBranchError)
+    ;["feature/docs.v1", "topic./child", "topic.LOCK"].forEach((branch) =>
+      expect(() => Repository.validateBranch(branch)).not.toThrow(),
+    )
+    ;[
+      "-bad",
+      "bad..branch",
+      "bad branch",
+      "/topic",
+      "topic/",
+      "topic//child",
+      ".topic",
+      "topic/.child",
+      "topic.",
+      "topic.lock",
+      "topic.lock/child",
+    ].forEach((branch) => expect(() => Repository.validateBranch(branch)).toThrow(Repository.InvalidBranchError))
   })
 
   test("compares cache identity independent of input spelling", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #48763

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Rejects branch structures that Git cannot use: empty or dot-prefixed path components, lowercase `.lock` component suffixes, and names ending in a dot. Existing character and traversal checks remain in place.

### How did you verify your code works?

Compared the affected names with `git check-ref-format --branch`, added valid and invalid branch cases to the repository tests, and ran `bun test test/repository.test.ts` from `packages/core`: 5 tests passed with 29 assertions.

### Screenshots / recordings

Not applicable; this is a non-UI validation fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR