### PR TITLE
fix(core): normalize github cache identity

### DIFF
--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -124,12 +124,16 @@ export function isRemote(reference: Reference): reference is RemoteReference {
  * percent-encoded because valid branch names may contain `/`.
  */
 export function cachePath(root: string, reference: Reference, branch?: string): string {
-  const base = path.join(root, ...reference.host.split(":"), ...reference.segments)
+  const base = path.join(
+    root,
+    ...reference.host.split(":"),
+    ...reference.segments.map((segment) => (reference.host === "github.com" ? segment.toLowerCase() : segment)),
+  )
   return branch ? `${base}@${encodeURIComponent(branch)}` : base
 }
 
 export function cacheIdentity(reference: Reference): string {
-  return `${reference.host}/${reference.path}`
+  return `${reference.host}/${reference.host === "github.com" ? reference.path.toLowerCase() : reference.path}`
 }
 
 export function same(left: Reference, right: Reference): boolean {

--- a/packages/core/test/repository.test.ts
+++ b/packages/core/test/repository.test.ts
@@ -68,4 +68,17 @@ describe("Repository", () => {
     expect(Repository.same(shorthand, Repository.parseRemote("https://github.com/owner/repo.git"))).toBe(true)
     expect(Repository.same(shorthand, Repository.parseRemote("github.com/owner/repo"))).toBe(true)
   })
+
+  test("normalizes GitHub casing only for cache identity", () => {
+    const canonical = Repository.parseRemote("github.com/owner/repo")
+    const cased = Repository.parseRemote("GitHub.com/Owner/Repo")
+    const gitlab = Repository.parseRemote("GitLab.com/Group/Repo")
+
+    expect(Repository.same(canonical, cased)).toBe(true)
+    expect(Repository.cachePath("/cache", cased)).toBe(Repository.cachePath("/cache", canonical))
+    expect(cased.label).toBe("Owner/Repo")
+    expect(cased.remote).toBe("https://github.com/Owner/Repo.git")
+    expect(Repository.cacheIdentity(gitlab)).toBe("gitlab.com/Group/Repo")
+    expect(Repository.cachePath("/cache", gitlab)).toBe(path.join("/cache", "gitlab.com", "Group", "Repo"))
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #48767

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Normalizes GitHub owner and repository casing when constructing cache identities and checkout paths. Labels, remote URLs, local paths, and non-GitHub repository paths keep their original casing.

### How did you verify your code works?

Verified differently cased paths resolve to the same repository through GitHub's API, added identity/cache-path regression coverage, and ran `bun test test/repository.test.ts` from `packages/core`: 6 tests passed with 25 assertions.

### Screenshots / recordings

Not applicable; this is a non-UI repository identity fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR