### PR TITLE
refactor(codemode): materialize interpreter failures once and locate them at the call boundary

### DIFF
--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -440,3 +440,9 @@ ultimate source of truth. Upstream test262 files run verbatim from `test/test262
 - [x] Failures raised by the interpreter are `TypeError`s unless JavaScript names them otherwise (`RangeError`,
       `ReferenceError`, `SyntaxError`, `URIError`), so `e instanceof TypeError` and `e.constructor === TypeError`
       hold. Unsupported syntax reached at runtime is a `SyntaxError`; awaited tool failures stay plain `Error`.
+      Host errors escaping a built-in (`(1).toFixed(200)`) become the same-named program error at the call.
+- [x] One failure is one error object: every `catch`, rejection handler, and `allSettled` reason for the same
+      failure sees the identical value, so `a === b` holds after awaiting the same rejected promise twice.
+- [x] Rethrowing an interpreter failure keeps its diagnostic: `catch (e) { throw e }` still reports the original
+      kind and source location. An uncaught program `Error` reports as `name: message` (`TypeError: bad input`);
+      other thrown values report as `Uncaught: <value>`.

--- a/packages/codemode/src/interpreter/errors.ts
+++ b/packages/codemode/src/interpreter/errors.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import type { Diagnostic } from "../codemode.js"
 import { ToolError } from "../tool-error.js"
 import { toData, ToolRuntimeError } from "../data.js"
-import { type AstNode, formatLocation, InterpreterRuntimeError, ProgramThrow, sourceLocation } from "./model.js"
+import { type AstNode, formatLocation, PendingThrow, ProgramThrow, sourceLocation, typeError } from "./model.js"
 import { containsRuntimeReference } from "./references.js"
 import { createErrorValue, type ErrorType, isErrorType } from "./intrinsics.js"
 import { constructor, methods, prototypeFrom, receiver } from "./native.js"
@@ -20,7 +20,7 @@ import { type Runner } from "./runner.js"
 import { coerceToString } from "../stdlib/value.js"
 
 export const normalizeError = (error: unknown): Diagnostic => {
-  if (error instanceof InterpreterRuntimeError) {
+  if (error instanceof PendingThrow) {
     return {
       kind: error.kind,
       message: `${error.message}${formatLocation(error.node)}`,
@@ -43,14 +43,15 @@ export const normalizeError = (error: unknown): Diagnostic => {
 
   if (error instanceof ProgramThrow) {
     const value = error.value
+    if (value instanceof ProgramError) {
+      return value.host ? normalizeError(value.host) : { kind: "ExecutionFailure", message: errorToString(value) }
+    }
     let message: string
     if (containsRuntimeReference(value)) {
       // Never expose runtime reference internals through thrown values.
       message = "a non-data value"
     } else if (typeof value === "string") {
       message = value
-    } else if (value instanceof ProgramObject && typeof get(value, "message") === "string") {
-      message = get(value, "message") as string
     } else {
       try {
         message = JSON.stringify(toData(value, "Thrown value")) ?? String(value)
@@ -81,12 +82,45 @@ export const normalizeError = (error: unknown): Diagnostic => {
   }
 }
 
-export const caughtErrorValue = <R>(runner: Runner<R>, thrown: unknown): unknown => {
+/**
+ * Gives a failure the source location of the expression that raised it, keeping the first one attached. Host errors
+ * that escape a built-in become the equivalent program error here.
+ */
+export const locate = (error: unknown, node?: AstNode): unknown => {
+  if (error instanceof PendingThrow) {
+    if (error.node === undefined && node) error.node = node
+    return error
+  }
+  if (error instanceof Error && !(error instanceof ToolError) && !(error instanceof ToolRuntimeError)) {
+    return new PendingThrow(isErrorType(error.name) ? error.name : "Error", error.message, node)
+  }
+  return error
+}
+
+/** The program value a handler receives for a failure; one failure always yields the same value. */
+export const materialize = <R>(runner: Runner<R>, thrown: unknown): unknown => {
   if (thrown instanceof ProgramThrow) return thrown.value
   const prototypes = runner.prototypes
-  if (thrown instanceof InterpreterRuntimeError) return createErrorValue(prototypes[thrown.type], thrown.message)
+  if (thrown instanceof PendingThrow) {
+    if (thrown.value === undefined) {
+      thrown.value = createErrorValue(prototypes[thrown.type], thrown.message)
+      thrown.value.host = thrown
+    }
+    return thrown.value
+  }
   const type = thrown instanceof Error && isErrorType(thrown.name) ? thrown.name : "Error"
   return createErrorValue(prototypes[type], normalizeError(thrown).message)
+}
+
+/** Error.prototype.toString: `name: message`, omitting whichever side is empty. */
+const errorToString = (self: ProgramObject): string => {
+  const name = get(self, "name")
+  const message = get(self, "message")
+  const shownName = name === undefined ? "Error" : coerceToString(name)
+  const shownMessage = message === undefined ? "" : coerceToString(message)
+  if (shownMessage === "") return shownName
+  if (shownName === "") return shownMessage
+  return `${shownName}: ${shownMessage}`
 }
 
 export const createAggregateErrorValue = <R>(
@@ -104,13 +138,10 @@ const constructAggregateErrorValue = <R>(
   runner: Runner<R>,
   args: Array<unknown>,
   proto: ProgramObject,
-  node: AstNode,
 ): Effect.Effect<ProgramError, unknown, R> =>
   Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(args[0], node)
-    if (cursor === undefined) {
-      throw new InterpreterRuntimeError("new AggregateError(...) expects a synchronous iterable of errors.", node)
-    }
+    const cursor = yield* runner.syncIterator(args[0])
+    if (cursor === undefined) throw typeError("new AggregateError(...) expects a synchronous iterable of errors.")
     const errors: Array<unknown> = []
     while (true) {
       const step = yield* cursor.next
@@ -125,34 +156,21 @@ const constructAggregateErrorValue = <R>(
 export const errorGlobal = <R>(type: ErrorType, runner: Runner<R>) => {
   const protos = runner.prototypes
   const prototype = protos[type]
-  const construct = (args: Array<unknown>, newTarget: Callable, node: AstNode) => {
+  const construct = (args: Array<unknown>, newTarget: Callable) => {
     const proto = prototypeFrom(newTarget, prototype)
     return type === "AggregateError"
-      ? constructAggregateErrorValue(runner, args, proto, node)
+      ? constructAggregateErrorValue(runner, args, proto)
       : Effect.sync(() => createErrorValue(proto, args[0] === undefined ? undefined : coerceToString(args[0])))
   }
   const ctor: NativeFunction<R> = constructor<R>(protos, prototype, {
     name: type,
     length: type === "AggregateError" ? 2 : 1,
-    call: (_, args, node) => construct(args, ctor, node),
+    call: (_, args) => construct(args, ctor),
     construct,
   })
   if (type === "Error") {
     methods(protos, prototype, [
-      [
-        "toString",
-        0,
-        (thisValue, _, node) => {
-          const self = receiver(ProgramObject, thisValue, "Error.prototype.toString", node)
-          const name = get(self, "name")
-          const message = get(self, "message")
-          const shownName = name === undefined ? "Error" : coerceToString(name)
-          const shownMessage = message === undefined ? "" : coerceToString(message)
-          if (shownMessage === "") return shownName
-          if (shownName === "") return shownMessage
-          return `${shownName}: ${shownMessage}`
-        },
-      ],
+      ["toString", 0, (thisValue) => errorToString(receiver(ProgramObject, thisValue, "Error.prototype.toString"))],
     ])
   }
   return ctor

--- a/packages/codemode/src/interpreter/execute.ts
+++ b/packages/codemode/src/interpreter/execute.ts
@@ -9,7 +9,7 @@ import { ToolRuntime } from "../tool-runtime.js"
 import { normalizeError } from "./errors.js"
 import { createPrototypes } from "./intrinsics.js"
 import type { Host } from "./globals.js"
-import { InterpreterRuntimeError } from "./model.js"
+import { PendingThrow } from "./model.js"
 import { PromiseRuntime } from "./promises.js"
 import { Runtime } from "./runtime.js"
 
@@ -122,7 +122,7 @@ const parseProgram = (code: string): Program => {
   const transpiled = transpile(`async function __codemode__() {\n${code}\n}`)
 
   if (transpiled.error !== undefined) {
-    throw new InterpreterRuntimeError(`Failed to parse TypeScript: ${transpiled.error}`, undefined, "ParseError")
+    throw new PendingThrow("SyntaxError", `Failed to parse TypeScript: ${transpiled.error}`, undefined, "ParseError")
   }
 
   const bodyStart = transpiled.outputText.indexOf("{") + 1

--- a/packages/codemode/src/interpreter/generators.ts
+++ b/packages/codemode/src/interpreter/generators.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { fn, type Method, methods, receiver } from "./native.js"
-import { type AstNode, AsyncIteratorSymbol, type GeneratorRequestKind, IteratorSymbol } from "./model.js"
+import { AsyncIteratorSymbol, type GeneratorRequestKind, IteratorSymbol } from "./model.js"
 import { define, hidden, ProgramGenerator } from "./objects.js"
 import type { PromiseRuntime } from "./promises.js"
 import type { Runner } from "./runner.js"
@@ -14,9 +14,9 @@ export const generatorGlobals = <R>(runner: Runner<R>, promises: PromiseRuntime<
     const request = (kind: GeneratorRequestKind): Method => [
       kind,
       1,
-      (thisValue: unknown, args: Array<unknown>, node: AstNode) => {
-        const generator = receiver(ProgramGenerator, thisValue, `${label}.prototype.${kind}`, node)
-        const requested = generator.request(kind, args[0], node) as Effect.Effect<unknown, unknown, R>
+      (thisValue: unknown, args: Array<unknown>) => {
+        const generator = receiver(ProgramGenerator, thisValue, `${label}.prototype.${kind}`)
+        const requested = generator.request(kind, args[0]) as Effect.Effect<unknown, unknown, R>
         return generator.asynchronous ? promises.create(requested) : requested
       },
     ]

--- a/packages/codemode/src/interpreter/globals.ts
+++ b/packages/codemode/src/interpreter/globals.ts
@@ -16,7 +16,7 @@ import { ToolReference } from "../tool-runtime.js"
 import { errorGlobal } from "./errors.js"
 import { errorTypes } from "./intrinsics.js"
 import { constants, constructor, native } from "./native.js"
-import { type AstNode, AsyncIteratorSymbol, InterpreterRuntimeError, IteratorSymbol } from "./model.js"
+import { AsyncIteratorSymbol, IteratorSymbol, typeError } from "./model.js"
 import { generatorGlobals } from "./generators.js"
 import { promiseGlobal, type PromiseRuntime } from "./promises.js"
 import type { Runner } from "./runner.js"
@@ -32,27 +32,24 @@ export type Host<R> = {
 
 // Function.prototype.constructor exists so `fn.constructor === Function` holds; dynamic code is unsupported.
 const functionGlobal = <R>(runner: Runner<R>) => {
-  const reject = (_: unknown, __: Array<unknown>, node: AstNode) =>
+  const reject = () =>
     Effect.sync(() => {
-      throw new InterpreterRuntimeError("The Function constructor is not supported; write the function inline.", node)
+      throw typeError("The Function constructor is not supported; write the function inline.")
     })
   return constructor<R>(runner.prototypes, runner.prototypes.Function, {
     name: "Function",
     length: 1,
     call: reject,
-    construct: (args, _, node) => reject(undefined, args, node),
+    construct: reject,
   })
 }
 
 const symbolGlobal = <R>(runner: Runner<R>) => {
   const symbol = native<R>(runner.prototypes, {
     name: "Symbol",
-    call: (_, __, node) =>
+    call: () =>
       Effect.sync(() => {
-        throw new InterpreterRuntimeError(
-          "Symbol is not callable; only Symbol.asyncIterator and Symbol.iterator are available.",
-          node,
-        )
+        throw typeError("Symbol is not callable; only Symbol.asyncIterator and Symbol.iterator are available.")
       }),
     callback: false,
   })

--- a/packages/codemode/src/interpreter/model.ts
+++ b/packages/codemode/src/interpreter/model.ts
@@ -1,6 +1,7 @@
 import type { Node } from "acorn"
 import type { ErrorType } from "./intrinsics.js"
 import type { DiagnosticKind } from "../codemode.js"
+import type { ProgramError } from "./objects.js"
 
 /** Any parsed node; the interpreter narrows on `type` and reads `loc` for diagnostics. */
 export type AstNode = Node
@@ -33,32 +34,31 @@ export class GeneratorReturn {
 
 export const OptionalShortCircuit: unique symbol = Symbol("codemode.optional-short-circuit")
 
-export class InterpreterRuntimeError extends Error {
-  readonly node?: AstNode
+/**
+ * A failure raised by the interpreter or a built-in. It travels as a defect and becomes one program Error object
+ * the first time a handler observes it, so every observer of the same failure sees the same value.
+ */
+export class PendingThrow {
+  node?: AstNode
+  value?: ProgramError
 
   constructor(
-    message: string,
+    /** The JS error class a program sees when it catches this failure. */
+    readonly type: ErrorType,
+    readonly message: string,
     node?: AstNode,
     readonly kind: DiagnosticKind = "ExecutionFailure",
     readonly suggestions?: ReadonlyArray<string>,
-    /** The JS error class a program sees when it catches this failure. */
-    readonly type: ErrorType = "TypeError",
   ) {
-    super(message)
-    this.name = "InterpreterRuntimeError"
     if (node) this.node = node
   }
 }
 
-/** Attaches a source location to a failure raised where none was known, such as inside a property accessor. */
-export const locate = (error: unknown, node: AstNode): unknown =>
-  error instanceof InterpreterRuntimeError && error.node === undefined
-    ? new InterpreterRuntimeError(error.message, node, error.kind, error.suggestions, error.type)
-    : error
+const failure = (type: ErrorType, kind?: DiagnosticKind) => (message: string, node?: AstNode) =>
+  new PendingThrow(type, message, node, kind)
 
-const failure = (type: ErrorType) => (message: string, node?: AstNode) =>
-  new InterpreterRuntimeError(message, node, "ExecutionFailure", undefined, type)
-
+export const typeError = failure("TypeError")
+export const invalidData = failure("TypeError", "InvalidDataValue")
 export const rangeError = failure("RangeError")
 export const referenceError = failure("ReferenceError")
 export const syntaxError = failure("SyntaxError")
@@ -68,13 +68,13 @@ export const uriError = failure("URIError")
 export const supportedSyntaxMessage =
   "This is a restricted JavaScript-like language. Supported: plain and async functions, data literals, destructuring, standard control flow, await and Promise, and built-ins such as Array, Object, Math, JSON, Date, RegExp, Map, Set, and URL. Unsupported: classes, this, getters/setters, tagged templates, BigInt, and custom Symbols. Use plain functions and data objects instead."
 
-export const unsupportedSyntax = (kind: string, node: AstNode): InterpreterRuntimeError =>
-  new InterpreterRuntimeError(
+export const unsupportedSyntax = (kind: string, node: AstNode): PendingThrow =>
+  new PendingThrow(
+    "SyntaxError",
     `Syntax '${kind}' is not supported. ${supportedSyntaxMessage}`,
     node,
     "UnsupportedSyntax",
     [supportedSyntaxMessage],
-    "SyntaxError",
   )
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/packages/codemode/src/interpreter/native.ts
+++ b/packages/codemode/src/interpreter/native.ts
@@ -1,17 +1,17 @@
 import { Effect } from "effect"
 import type { Prototypes } from "./intrinsics.js"
-import { type AstNode, InterpreterRuntimeError } from "./model.js"
+import { typeError } from "./model.js"
 import { type Callable, define, frozen, hidden, NativeFunction, type NativeOptions, ProgramObject } from "./objects.js"
 import { describeValue } from "./references.js"
 
-/** A native function body: a plain value, a thrown `InterpreterRuntimeError`, or an Effect. */
-export type Impl = (thisValue: unknown, args: Array<unknown>, node: AstNode) => unknown
+/** A native function body: a plain value, a thrown `PendingThrow`, or an Effect. */
+export type Impl = (thisValue: unknown, args: Array<unknown>) => unknown
 
 const lift =
   <R>(impl: Impl) =>
-  (thisValue: unknown, args: Array<unknown>, node: AstNode): Effect.Effect<unknown, unknown, R> =>
+  (thisValue: unknown, args: Array<unknown>): Effect.Effect<unknown, unknown, R> =>
     Effect.suspend(() => {
-      const result = impl(thisValue, args, node)
+      const result = impl(thisValue, args)
       return Effect.isEffect(result) ? (result as Effect.Effect<unknown, unknown, R>) : Effect.succeed(result)
     })
 
@@ -44,12 +44,10 @@ export const constructor = <R>(
 }
 
 /** The `call` of a constructor that JS requires to be invoked with `new`. */
-export const requiresNew =
-  (name: string) =>
-  (_: unknown, __: Array<unknown>, node: AstNode): Effect.Effect<never, unknown, never> =>
-    Effect.sync(() => {
-      throw new InterpreterRuntimeError(`Constructor ${name} requires 'new'.`, node)
-    })
+export const requiresNew = (name: string) => (): Effect.Effect<never, unknown, never> =>
+  Effect.sync(() => {
+    throw typeError(`Constructor ${name} requires 'new'.`)
+  })
 
 /** The instance prototype for `new` via `newTarget.prototype`, falling back to the built-in's own. */
 export const prototypeFrom = (newTarget: Callable, fallback: ProgramObject): ProgramObject => {
@@ -62,8 +60,7 @@ export const receiver = <T extends ProgramObject>(
   cls: abstract new (...args: never) => T,
   thisValue: unknown,
   method: string,
-  node?: AstNode,
 ): T => {
   if (thisValue instanceof cls) return thisValue
-  throw new InterpreterRuntimeError(`${method} called on incompatible receiver ${describeValue(thisValue)}.`, node)
+  throw typeError(`${method} called on incompatible receiver ${describeValue(thisValue)}.`)
 }

--- a/packages/codemode/src/interpreter/objects.ts
+++ b/packages/codemode/src/interpreter/objects.ts
@@ -1,6 +1,12 @@
 import type { BlockStatement, Expression, Pattern } from "acorn"
 import type { Effect, Fiber } from "effect"
-import { type AstNode, AsyncIteratorSymbol, type Binding, type GeneratorRequestKind, IteratorSymbol } from "./model.js"
+import {
+  AsyncIteratorSymbol,
+  type Binding,
+  type GeneratorRequestKind,
+  IteratorSymbol,
+  type PendingThrow,
+} from "./model.js"
 
 /** Property attributes, as in a JS property descriptor. */
 export type Attributes = {
@@ -42,7 +48,10 @@ export class ProgramArray extends ProgramObject {
 }
 
 /** An object with the [[ErrorData]] slot: what `Error.prototype.toString` and the host boundary recognize as an error. */
-export class ProgramError extends ProgramObject {}
+export class ProgramError extends ProgramObject {
+  /** The interpreter failure this error materialized from, so rethrowing it keeps the diagnostic kind and location. */
+  host?: PendingThrow
+}
 
 export abstract class Callable extends ProgramObject {
   constructor(proto: ProgramObject, name: string, length: number) {
@@ -67,16 +76,8 @@ export class ProgramFunction extends Callable {
   }
 }
 
-export type NativeCall<R> = (
-  thisValue: unknown,
-  args: Array<unknown>,
-  node: AstNode,
-) => Effect.Effect<unknown, unknown, R>
-export type NativeConstruct<R> = (
-  args: Array<unknown>,
-  newTarget: Callable,
-  node: AstNode,
-) => Effect.Effect<unknown, unknown, R>
+export type NativeCall<R> = (thisValue: unknown, args: Array<unknown>) => Effect.Effect<unknown, unknown, R>
+export type NativeConstruct<R> = (args: Array<unknown>, newTarget: Callable) => Effect.Effect<unknown, unknown, R>
 
 export type NativeOptions<R> = {
   readonly name: string
@@ -114,11 +115,7 @@ export class ProgramGenerator extends ProgramObject {
   constructor(
     proto: ProgramObject,
     readonly asynchronous: boolean,
-    readonly request: (
-      kind: GeneratorRequestKind,
-      value: unknown,
-      node: AstNode,
-    ) => Effect.Effect<unknown, unknown, unknown>,
+    readonly request: (kind: GeneratorRequestKind, value: unknown) => Effect.Effect<unknown, unknown, unknown>,
   ) {
     super(proto)
   }

--- a/packages/codemode/src/interpreter/promises.ts
+++ b/packages/codemode/src/interpreter/promises.ts
@@ -1,6 +1,6 @@
 import { Cause, Deferred, Effect, Exit, Fiber, Scope } from "effect"
 import type { Diagnostic } from "../codemode.js"
-import { type AstNode, InterpreterRuntimeError, ProgramThrow } from "./model.js"
+import { ProgramThrow, typeError } from "./model.js"
 import {
   Callable,
   define,
@@ -13,7 +13,7 @@ import {
   record,
 } from "./objects.js"
 import { constructor, fn, methods, native, receiver, requiresNew } from "./native.js"
-import { caughtErrorValue, createAggregateErrorValue, normalizeError } from "./errors.js"
+import { createAggregateErrorValue, materialize, normalizeError } from "./errors.js"
 import { typeofValue } from "./references.js"
 import { applyCollectionCallback, isSupportedCallback, type Runner } from "./runner.js"
 
@@ -105,16 +105,14 @@ export class PromiseRuntime<R> {
   }
 }
 
-export const selfResolutionError = (node?: AstNode): InterpreterRuntimeError =>
-  new InterpreterRuntimeError("Chaining cycle detected: a promise cannot resolve with itself.", node)
-
 export const resolvePromiseValue = <R>(
   runner: Runner<R>,
   value: unknown,
-  node: AstNode,
   own?: { promise?: ProgramPromise },
 ): Effect.Effect<unknown, unknown, R> => {
-  if (own?.promise !== undefined && value === own.promise) return Effect.fail(selfResolutionError(node))
+  if (own?.promise !== undefined && value === own.promise) {
+    return Effect.die(typeError("Chaining cycle detected: a promise cannot resolve with itself."))
+  }
   if (value instanceof ProgramPromise) return runner.settlePromise(value)
   if (!(value instanceof ProgramObject)) return Effect.succeed(value)
   const then = get(value, "then")
@@ -128,12 +126,12 @@ export const resolvePromiseValue = <R>(
     const reject = capability(runner, "reject", (reason) =>
       Deferred.doneUnsafe(deferred, Exit.fail(new ProgramThrow(reason))),
     )
-    const executed = yield* Effect.exit(runner.invokeCallable(then, value, [resolve, reject], node))
+    const executed = yield* Effect.exit(runner.invokeCallable(then, value, [resolve, reject]))
     if (!Exit.isSuccess(executed)) {
       if (Cause.hasInterruptsOnly(executed.cause)) return yield* Effect.failCause(executed.cause)
       Deferred.doneUnsafe(deferred, Exit.fail(Cause.squash(executed.cause)))
     }
-    return yield* resolvePromiseValue(runner, yield* Deferred.await(deferred), node, own)
+    return yield* resolvePromiseValue(runner, yield* Deferred.await(deferred), own)
   })
 }
 
@@ -141,10 +139,9 @@ export const resolvePromise = <R>(
   runner: Runner<R>,
   promises: PromiseRuntime<R>,
   value: unknown,
-  node: AstNode,
 ): Effect.Effect<ProgramPromise, never, R> => {
   if (value instanceof ProgramPromise) return Effect.succeed(value)
-  return promises.createWithSelf((self) => resolvePromiseValue(runner, value, node, self))
+  return promises.createWithSelf((self) => resolvePromiseValue(runner, value, self))
 }
 
 const promiseStatics = ["all", "allSettled", "race", "any", "resolve", "reject"] as const
@@ -154,10 +151,9 @@ const invokePromiseMethod = <R>(
   promises: PromiseRuntime<R>,
   name: (typeof promiseStatics)[number],
   args: Array<unknown>,
-  node: AstNode,
 ): Effect.Effect<unknown, unknown, R> => {
   if (name === "resolve") {
-    return resolvePromise(runner, promises, args[0], node)
+    return resolvePromise(runner, promises, args[0])
   }
   if (name === "reject") {
     return promises.create(Effect.fail(new ProgramThrow(args[0])))
@@ -165,15 +161,13 @@ const invokePromiseMethod = <R>(
 
   return promises.create(
     Effect.gen(function* () {
-      const cursor = yield* runner.syncIterator(args[0], node)
-      if (cursor === undefined) {
-        throw new InterpreterRuntimeError(`Promise.${name} expects an array or other synchronous iterable.`, node)
-      }
+      const cursor = yield* runner.syncIterator(args[0])
+      if (cursor === undefined) throw typeError(`Promise.${name} expects an array or other synchronous iterable.`)
       const items: Array<ProgramPromise> = []
       while (true) {
         const step = yield* cursor.next
         if (step.done) break
-        const item = yield* resolvePromise(runner, promises, step.value, node)
+        const item = yield* resolvePromise(runner, promises, step.value)
         promises.markObserved(item)
         items.push(item)
       }
@@ -201,7 +195,7 @@ const invokePromiseMethod = <R>(
           outcomes.push(
             record(runner.prototypes.Object, {
               status: "rejected",
-              reason: caughtErrorValue(runner, Cause.squash(exit.cause)),
+              reason: materialize(runner, Cause.squash(exit.cause)),
             }),
           )
         }
@@ -210,10 +204,7 @@ const invokePromiseMethod = <R>(
       }
       if (name === "race") {
         if (items.length === 0) {
-          throw new InterpreterRuntimeError(
-            "Promise.race([]) would never settle; provide at least one promise or value.",
-            node,
-          )
+          throw typeError("Promise.race([]) would never settle; provide at least one promise or value.")
         }
         return yield* settleAfterTurn(Effect.flatten(Effect.raceAll(items.map((item) => promises.await(item)))))
       }
@@ -221,7 +212,7 @@ const invokePromiseMethod = <R>(
         Effect.flatMap(promises.await(item), (exit) => {
           if (Exit.isSuccess(exit)) return Effect.fail(new PromiseAnyFulfilled(exit.value))
           if (Cause.hasInterruptsOnly(exit.cause)) return Effect.failCause(exit.cause)
-          return Effect.succeed(caughtErrorValue(runner, Cause.squash(exit.cause)))
+          return Effect.succeed(materialize(runner, Cause.squash(exit.cause)))
         }),
       )
       return yield* settleAfterTurn(
@@ -244,41 +235,36 @@ const instanceMethod = <R>(
   name: "then" | "catch" | "finally",
   thisValue: unknown,
   args: Array<unknown>,
-  node: AstNode,
 ): Effect.Effect<ProgramPromise, unknown, R> => {
   const method = `Promise.prototype.${name}`
-  const promise = receiver(ProgramPromise, thisValue, method, node)
+  const promise = receiver(ProgramPromise, thisValue, method)
   promises.markObserved(promise)
   if (name === "finally") {
-    return chainFinally(runner, promises, promise, reactionHandler(args[0], method, node), method, node)
+    return chainFinally(runner, promises, promise, reactionHandler(args[0], method), method)
   }
-  const onFulfilled = name === "then" ? reactionHandler(args[0], method, node) : undefined
-  const onRejected = reactionHandler(name === "then" ? args[1] : args[0], method, node)
-  return chainReaction(runner, promises, promise, onFulfilled, onRejected, method, node)
+  const onFulfilled = name === "then" ? reactionHandler(args[0], method) : undefined
+  const onRejected = reactionHandler(name === "then" ? args[1] : args[0], method)
+  return chainReaction(runner, promises, promise, onFulfilled, onRejected, method)
 }
 
 const constructPromise = <R>(
   runner: Runner<R>,
   promises: PromiseRuntime<R>,
   executor: unknown,
-  node: AstNode,
 ): Effect.Effect<ProgramPromise, unknown, R> => {
   if (!(executor instanceof ProgramFunction)) {
-    throw new InterpreterRuntimeError(
-      "new Promise(...) expects an executor function (e.g. new Promise((resolve, reject) => { ... })).",
-      node,
-    )
+    throw typeError("new Promise(...) expects an executor function (e.g. new Promise((resolve, reject) => { ... })).")
   }
   return Effect.gen(function* () {
     const deferred = Deferred.makeUnsafe<unknown, unknown>()
     const promise = yield* promises.createWithSelf((self) =>
-      Effect.flatMap(Deferred.await(deferred), (value) => resolvePromiseValue(runner, value, node, self)),
+      Effect.flatMap(Deferred.await(deferred), (value) => resolvePromiseValue(runner, value, self)),
     )
     const resolve = capability(runner, "resolve", (value) => Deferred.doneUnsafe(deferred, Exit.succeed(value)))
     const reject = capability(runner, "reject", (value) =>
       Deferred.doneUnsafe(deferred, Exit.fail(new ProgramThrow(value))),
     )
-    const executed = yield* Effect.exit(runner.invokeCallable(executor, undefined, [resolve, reject], node))
+    const executed = yield* Effect.exit(runner.invokeCallable(executor, undefined, [resolve, reject]))
     if (!Exit.isSuccess(executed)) {
       if (Cause.hasInterruptsOnly(executed.cause)) return yield* Effect.failCause(executed.cause)
       Deferred.doneUnsafe(deferred, Exit.fail(Cause.squash(executed.cause)))
@@ -295,12 +281,11 @@ class PromiseAnyFulfilled {
   constructor(readonly value: unknown) {}
 }
 
-const reactionHandler = (value: unknown, method: string, node: AstNode): Callable | undefined => {
+const reactionHandler = (value: unknown, method: string): Callable | undefined => {
   if (isSupportedCallback(value)) return value
   if (typeofValue(value) === "function") {
-    throw new InterpreterRuntimeError(
+    throw typeError(
       `${method} cannot use this callable as a handler; wrap it in an arrow function, e.g. (value) => tools.ns.tool(value).`,
-      node,
     )
   }
   return undefined
@@ -325,16 +310,15 @@ const chainReaction = <R>(
   onFulfilled: Callable | undefined,
   onRejected: Callable | undefined,
   method: string,
-  node: AstNode,
 ): Effect.Effect<ProgramPromise, never, R> => {
   return promises.createWithSelf((self) =>
     Effect.gen(function* () {
       const exit = yield* reactionExit(promises, source)
       const handler = Exit.isSuccess(exit) ? onFulfilled : onRejected
       if (handler === undefined) return yield* exit
-      const input = Exit.isSuccess(exit) ? exit.value : caughtErrorValue(runner, Cause.squash(exit.cause))
-      const result = yield* applyCollectionCallback(runner, handler, method, node)([input])
-      return yield* resolvePromiseValue(runner, result, node, self)
+      const input = Exit.isSuccess(exit) ? exit.value : materialize(runner, Cause.squash(exit.cause))
+      const result = yield* applyCollectionCallback(runner, handler, method)([input])
+      return yield* resolvePromiseValue(runner, result, self)
     }),
   )
 }
@@ -345,16 +329,15 @@ const chainFinally = <R>(
   source: ProgramPromise,
   cleanup: Callable | undefined,
   method: string,
-  node: AstNode,
 ): Effect.Effect<ProgramPromise, never, R> =>
   promises.create(
     Effect.gen(function* () {
       const exit = yield* reactionExit(promises, source)
       if (cleanup !== undefined) {
-        const result = yield* applyCollectionCallback(runner, cleanup, method, node)([])
+        const result = yield* applyCollectionCallback(runner, cleanup, method)([])
         const intermediate = yield* promises.create(
           Effect.gen(function* () {
-            yield* runner.settlePromise(yield* resolvePromise(runner, promises, result, node))
+            yield* runner.settlePromise(yield* resolvePromise(runner, promises, result))
             return yield* exit
           }),
         )
@@ -371,7 +354,7 @@ export const promiseGlobal = <R>(runner: Runner<R>, promises: PromiseRuntime<R>)
     name: "Promise",
     length: 1,
     call: requiresNew("Promise"),
-    construct: (args, _, node) => constructPromise(runner, promises, args[0], node),
+    construct: (args) => constructPromise(runner, promises, args[0]),
   })
   // Combinators are not callbacks: `[p].map(Promise.resolve)` must ask for an arrow function.
   for (const name of promiseStatics) {
@@ -381,16 +364,16 @@ export const promiseGlobal = <R>(runner: Runner<R>, promises: PromiseRuntime<R>)
       native<R>(protos, {
         name,
         length: 1,
-        call: (_, args, node) => invokePromiseMethod(runner, promises, name, args, node),
+        call: (_, args) => invokePromiseMethod(runner, promises, name, args),
         callback: false,
       }),
       hidden,
     )
   }
   methods(protos, proto, [
-    ["then", 2, (thisValue, args, node) => instanceMethod(runner, promises, "then", thisValue, args, node)],
-    ["catch", 1, (thisValue, args, node) => instanceMethod(runner, promises, "catch", thisValue, args, node)],
-    ["finally", 1, (thisValue, args, node) => instanceMethod(runner, promises, "finally", thisValue, args, node)],
+    ["then", 2, (thisValue, args) => instanceMethod(runner, promises, "then", thisValue, args)],
+    ["catch", 1, (thisValue, args) => instanceMethod(runner, promises, "catch", thisValue, args)],
+    ["finally", 1, (thisValue, args) => instanceMethod(runner, promises, "finally", thisValue, args)],
   ])
   return promise
 }

--- a/packages/codemode/src/interpreter/references.ts
+++ b/packages/codemode/src/interpreter/references.ts
@@ -1,5 +1,5 @@
 import { ToolReference } from "../tool-runtime.js"
-import { type AstNode, InterpreterRuntimeError } from "./model.js"
+import { invalidData } from "./model.js"
 import {
   Callable,
   getOwn,
@@ -66,11 +66,10 @@ export const rejectCircularInsertion = (
   container: object,
   value: unknown,
   label: string,
-  node: AstNode,
   seen = new Set<object>(),
 ): void => {
   if (find(value, (current) => current === container, isRuntimeReference, seen)) {
-    throw new InterpreterRuntimeError(`${label} contains a circular value.`, node, "InvalidDataValue")
+    throw invalidData(`${label} contains a circular value.`)
   }
 }
 

--- a/packages/codemode/src/interpreter/runner.ts
+++ b/packages/codemode/src/interpreter/runner.ts
@@ -1,7 +1,7 @@
 import { Effect, Exit } from "effect"
 import { coerceToNumber, coerceToString } from "../stdlib/value.js"
 import type { Prototypes } from "./intrinsics.js"
-import { type AstNode, InterpreterRuntimeError } from "./model.js"
+import { typeError } from "./model.js"
 import { Callable, get, NativeFunction, ProgramDate, ProgramObject, ProgramPromise } from "./objects.js"
 import { typeofValue } from "./references.js"
 
@@ -16,10 +16,9 @@ export type Runner<R> = {
     callable: unknown,
     thisValue: unknown,
     args: Array<unknown>,
-    node: AstNode,
   ) => Effect.Effect<unknown, unknown, R>
   readonly settlePromise: (promise: ProgramPromise) => Effect.Effect<unknown, unknown, never>
-  readonly syncIterator: (value: unknown, node: AstNode) => Effect.Effect<IteratorCursor<R> | undefined, unknown, R>
+  readonly syncIterator: (value: unknown) => Effect.Effect<IteratorCursor<R> | undefined, unknown, R>
   readonly prototypes: Prototypes
 }
 
@@ -41,7 +40,6 @@ export const toPrimitive = <R>(
   runner: Runner<R>,
   value: unknown,
   hint: "number" | "string" | "default",
-  node: AstNode,
 ): Effect.Effect<unknown, unknown, R> => {
   if (!(value instanceof ProgramObject)) return Effect.succeed(value)
   const asString = hint === "string" || (hint === "default" && value instanceof ProgramDate)
@@ -50,18 +48,18 @@ export const toPrimitive = <R>(
     for (const method of order) {
       const callable = get(value, method)
       if (!(callable instanceof Callable)) continue
-      const result = yield* runner.invokeCallable(callable, value, [], node)
+      const result = yield* runner.invokeCallable(callable, value, [])
       if (result === null || (typeof result !== "object" && typeof result !== "function")) return result
     }
-    throw new InterpreterRuntimeError("Cannot convert object to primitive value.", node)
+    throw typeError("Cannot convert object to primitive value.")
   })
 }
 
-export const toPrimitiveString = <R>(runner: Runner<R>, value: unknown, node: AstNode) =>
-  Effect.map(toPrimitive(runner, value, "string", node), coerceToString)
+export const toPrimitiveString = <R>(runner: Runner<R>, value: unknown) =>
+  Effect.map(toPrimitive(runner, value, "string"), coerceToString)
 
-export const toPrimitiveNumber = <R>(runner: Runner<R>, value: unknown, node: AstNode) =>
-  Effect.map(toPrimitive(runner, value, "number", node), coerceToNumber)
+export const toPrimitiveNumber = <R>(runner: Runner<R>, value: unknown) =>
+  Effect.map(toPrimitive(runner, value, "number"), coerceToNumber)
 
 // The single acceptance list for callbacks: collections, sort, string replacers,
 // Array.from mappers, and promise reactions all admit exactly these callables.
@@ -74,16 +72,14 @@ export const applyCollectionCallback = <R>(
   runner: Runner<R>,
   callback: unknown,
   name: string,
-  node: AstNode,
 ): ((args: Array<unknown>) => Effect.Effect<unknown, unknown, R>) => {
   if (!isSupportedCallback(callback)) {
     if (typeofValue(callback) === "function") {
-      throw new InterpreterRuntimeError(
+      throw typeError(
         `${name} cannot use this callable as a callback; wrap it in an arrow function, e.g. (value) => tools.ns.tool(value).`,
-        node,
       )
     }
-    throw new InterpreterRuntimeError(`${name} expects a function callback.`, node)
+    throw typeError(`${name} expects a function callback.`)
   }
-  return (callbackArgs) => runner.invokeCallable(callback, undefined, callbackArgs, node)
+  return (callbackArgs) => runner.invokeCallable(callback, undefined, callbackArgs)
 }

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -50,16 +50,16 @@ import {
   type Binding,
   type GeneratorRequestKind,
   GeneratorReturn,
-  InterpreterRuntimeError,
   IteratorSymbol,
-  locate,
   OptionalShortCircuit,
+  invalidData,
   ProgramThrow,
   rangeError,
   type StatementResult,
+  typeError,
   unsupportedSyntax,
 } from "./model.js"
-import { caughtErrorValue } from "./errors.js"
+import { locate, materialize } from "./errors.js"
 import type { Prototypes } from "./intrinsics.js"
 import { globals, type Host } from "./globals.js"
 import {
@@ -124,11 +124,11 @@ const calleeDescription = (callee: Expression | Super | undefined): string => {
 // OrdinaryHasInstance: walk the left operand's chain looking for the constructor's `prototype`.
 const instanceofValue = (lhs: unknown, rhs: unknown, node: AstNode): boolean => {
   if (!(rhs instanceof Callable)) {
-    throw new InterpreterRuntimeError("The right-hand side of 'instanceof' is not callable.", node)
+    throw typeError("The right-hand side of 'instanceof' is not callable.", node)
   }
   const prototype = get(rhs, "prototype")
   if (!(prototype instanceof ProgramObject)) {
-    throw new InterpreterRuntimeError("The right-hand side of 'instanceof' has no 'prototype' object.", node)
+    throw typeError("The right-hand side of 'instanceof' has no 'prototype' object.", node)
   }
   return hasPrototype(lhs, prototype)
 }
@@ -207,7 +207,7 @@ const loopDeclaration = (left: VariableDeclaration | Pattern, statement: "for...
   if (left.type !== "VariableDeclaration") return undefined
   const declaration = left.declarations.length === 1 ? left.declarations[0] : undefined
   if (declaration === undefined) {
-    throw new InterpreterRuntimeError(`${statement} supports one declared binding.`, left)
+    throw typeError(`${statement} supports one declared binding.`, left)
   }
   const kind = left.kind
   return {
@@ -246,8 +246,6 @@ type GeneratorState = {
   available?: Deferred.Deferred<void>
 }
 
-const promiseResolutionNode: AstNode = { type: "PromiseResolution", start: 0, end: 0 }
-
 /** One program execution: the tool bridge, promise scheduler, captured logs, and the global scope built once. */
 export class Runtime<R> {
   readonly runner: Runner<R>
@@ -266,9 +264,9 @@ export class Runtime<R> {
     // Calling back into the program never reads frame state, so any frame serves; the root is always alive.
     this.root = new Frame(this, new ScopeStack([globalScope]))
     this.runner = {
-      invokeCallable: (callable, thisValue, args, node) => this.root.invokeCallable(callable, thisValue, args, node),
+      invokeCallable: (callable, thisValue, args) => this.root.invokeCallable(callable, thisValue, args),
       settlePromise: (promise) => this.root.settlePromise(promise),
-      syncIterator: (value, node) => this.root.syncIterator(value, node),
+      syncIterator: (value) => this.root.syncIterator(value),
       prototypes,
     }
     for (const [name, value] of [...globals(this), ...extraGlobals(this)]) {
@@ -313,12 +311,12 @@ class Frame<R> {
         }
 
         if (result.kind === "break" || result.kind === "continue") {
-          throw new InterpreterRuntimeError(`Unexpected '${result.kind}' outside of a loop.`, statement)
+          throw typeError(`Unexpected '${result.kind}' outside of a loop.`, statement)
         }
       }
 
       // The implicit async body adopts returned promises before copy-out.
-      value = yield* resolvePromiseValue(self.runtime.runner, value, program)
+      value = yield* resolvePromiseValue(self.runtime.runner, value)
       return value
     }).pipe(Effect.ensuring(Effect.sync(() => self.scopes.pop())))
   }
@@ -483,7 +481,7 @@ class Frame<R> {
     return Effect.gen(function* () {
       const discriminant = yield* self.evaluateExpression(node.discriminant)
       if (containsOpaqueReference(discriminant)) {
-        throw new InterpreterRuntimeError("Switch discriminants must be data values.", node, "InvalidDataValue")
+        throw invalidData("Switch discriminants must be data values.", node)
       }
       self.scopes.push()
       return yield* Effect.gen(function* () {
@@ -501,7 +499,7 @@ class Frame<R> {
           }
           const candidate = yield* self.evaluateExpression(test)
           if (containsOpaqueReference(candidate)) {
-            throw new InterpreterRuntimeError("Switch case values must be data values.", test, "InvalidDataValue")
+            throw invalidData("Switch case values must be data values.", test)
           }
           if (candidate === discriminant) {
             selected = index
@@ -624,7 +622,7 @@ class Frame<R> {
       const iterator = yield* self.customIterator(right, node, awaiting)
       const cursor = iterator === undefined ? yield* self.syncIterator(right, node) : undefined
       if (iterator === undefined && cursor === undefined) {
-        throw new InterpreterRuntimeError(
+        throw invalidData(
           `${awaiting ? "for await...of" : "for...of"} requires an array, string, Map, Set, or URLSearchParams, or custom iterator value.`,
           node,
         )
@@ -637,7 +635,7 @@ class Frame<R> {
             : (cursor?.close ?? Effect.void)
 
       if (left.type === "RestElement" || left.type === "AssignmentPattern") {
-        throw new InterpreterRuntimeError("Unsupported for...of binding.", left)
+        throw typeError("Unsupported for...of binding.", left)
       }
       const assignment = left.type === "VariableDeclaration" ? undefined : left
 
@@ -664,7 +662,7 @@ class Frame<R> {
       while (true) {
         const current = iterator
           ? yield* self.nextIteratorResult(iterator, node, awaiting)
-          : yield* cursor?.next ?? Effect.fail(new InterpreterRuntimeError("Iterator is unavailable.", node))
+          : yield* cursor?.next ?? Effect.die(typeError("Iterator is unavailable.", node))
         const step = cursor && awaiting ? { done: current.done, value: yield* self.awaitValue(current.value) } : current
         if (step.done) return { kind: "none" } satisfies StatementResult
         const bodyExit = yield* Effect.exit(evaluateBody(step.value))
@@ -690,8 +688,8 @@ class Frame<R> {
     )
   }
 
-  private awaitValue(value: unknown, node: AstNode = promiseResolutionNode): Effect.Effect<unknown, unknown, R> {
-    return Effect.flatMap(resolvePromise(this.runtime.runner, this.runtime.promises, value, node), (promise) =>
+  private awaitValue(value: unknown): Effect.Effect<unknown, unknown, R> {
+    return Effect.flatMap(resolvePromise(this.runtime.runner, this.runtime.promises, value), (promise) =>
       this.settlePromise(promise),
     )
   }
@@ -699,7 +697,7 @@ class Frame<R> {
   private awaitAsyncFromSyncValue(
     iterator: CustomIterator,
     value: unknown,
-    node: AstNode,
+    node: AstNode | undefined,
     closeOnRejection: boolean,
   ): Effect.Effect<unknown, unknown, R> {
     const self = this
@@ -713,7 +711,7 @@ class Frame<R> {
     })
   }
 
-  syncIterator(value: unknown, node: AstNode) {
+  syncIterator(value: unknown, node?: AstNode) {
     const iterator =
       value instanceof ProgramArray
         ? value.items[Symbol.iterator]()
@@ -750,7 +748,7 @@ class Frame<R> {
     )
   }
 
-  private customIterator(value: unknown, node: AstNode, allowAsync = true) {
+  private customIterator(value: unknown, node: AstNode | undefined, allowAsync = true) {
     if (!(value instanceof ProgramObject)) return Effect.undefined
     const asyncMethod = allowAsync ? get(value, AsyncIteratorSymbol) : undefined
     const method = asyncMethod ?? get(value, IteratorSymbol)
@@ -769,7 +767,7 @@ class Frame<R> {
     )
   }
 
-  private nextIteratorResult(iterator: CustomIterator, node: AstNode, awaiting: boolean) {
+  private nextIteratorResult(iterator: CustomIterator, node: AstNode | undefined, awaiting: boolean) {
     const self = this
     return Effect.gen(function* () {
       if (iterator.asynchronous) {
@@ -805,7 +803,11 @@ class Frame<R> {
     })
   }
 
-  private closeIterator(iterator: CustomIterator, node: AstNode, awaiting = true): Effect.Effect<void, unknown, R> {
+  private closeIterator(
+    iterator: CustomIterator,
+    node: AstNode | undefined,
+    awaiting = true,
+  ): Effect.Effect<void, unknown, R> {
     const close = get(iterator.iterator, "return")
     if (close === undefined || close === null) return iterator.asynchronous || !awaiting ? Effect.void : Effect.yieldNow
     const self = this
@@ -836,14 +838,14 @@ class Frame<R> {
     })
   }
 
-  private requireIteratorObject(value: unknown, context: string, node: AstNode): ProgramObject {
+  private requireIteratorObject(value: unknown, context: string, node?: AstNode): ProgramObject {
     if (value instanceof ProgramObject) return value
-    throw new InterpreterRuntimeError(`${context} must be an object.`, node)
+    throw typeError(`${context} must be an object.`, node)
   }
 
-  private requireIteratorMethod(value: unknown, context: string, node: AstNode): unknown {
+  private requireIteratorMethod(value: unknown, context: string, node?: AstNode): unknown {
     if (typeofValue(value) === "function") return value
-    throw new InterpreterRuntimeError(`${context} must be a function.`, node)
+    throw typeError(`${context} must be a function.`, node)
   }
 
   // for...in over null/undefined iterates nothing, like JS.
@@ -869,7 +871,7 @@ class Frame<R> {
       const keys = self.enumerableKeys(right, node.right)
 
       if (left.type !== "Identifier" && left.type !== "VariableDeclaration") {
-        throw new InterpreterRuntimeError("Unsupported for...in binding.", left)
+        throw typeError("Unsupported for...in binding.", left)
       }
       const assignmentName = left.type === "Identifier" ? left.name : undefined
 
@@ -955,7 +957,7 @@ class Frame<R> {
           return Effect.failCause(cause)
         }
 
-        const caught = caughtErrorValue(self.runtime.runner, Cause.squash(cause))
+        const caught = materialize(self.runtime.runner, Cause.squash(cause))
         const parameter = handler.param
         self.scopes.push()
         return Effect.gen(function* () {
@@ -991,7 +993,7 @@ class Frame<R> {
     return Effect.gen(function* () {
       for (const declaration of node.declarations) {
         if (declaration.type !== "VariableDeclarator") {
-          throw new InterpreterRuntimeError("Unsupported variable declaration shape.", declaration)
+          throw typeError("Unsupported variable declaration shape.", declaration)
         }
 
         const init = declaration.init
@@ -1033,10 +1035,9 @@ class Frame<R> {
 
       if (pattern.type === "ObjectPattern") {
         if (!(value instanceof ProgramObject)) {
-          throw new InterpreterRuntimeError(
+          throw typeError(
             `Object destructuring requires a data object or array value, received ${describeValue(value)}.`,
             pattern,
-            "InvalidDataValue",
           )
         }
 
@@ -1051,7 +1052,13 @@ class Frame<R> {
 
           const key = yield* self.destructuringPropertyKey(property)
           consumed.add(typeof key === "symbol" ? key : String(key))
-          yield* self.declarePattern(property.value, get(value, key), mutable, property, initialize)
+          yield* self.declarePattern(
+            property.value,
+            self.readProperty(value, key, property),
+            mutable,
+            property,
+            initialize,
+          )
         }
         return
       }
@@ -1062,7 +1069,7 @@ class Frame<R> {
         )
       }
 
-      throw new InterpreterRuntimeError(`Unsupported binding pattern '${pattern.type}'.`, pattern)
+      throw typeError(`Unsupported binding pattern '${pattern.type}'.`, pattern)
     })
   }
 
@@ -1087,10 +1094,9 @@ class Frame<R> {
 
       if (pattern.type === "ObjectPattern") {
         if (!(value instanceof ProgramObject)) {
-          throw new InterpreterRuntimeError(
+          throw invalidData(
             `Object destructuring requires a data object or array value, received ${describeValue(value)}.`,
             pattern,
-            "InvalidDataValue",
           )
         }
 
@@ -1104,7 +1110,7 @@ class Frame<R> {
           }
           const key = yield* self.destructuringPropertyKey(property)
           consumed.add(typeof key === "symbol" ? key : String(key))
-          yield* self.assignPattern(property.value, get(value, key), property)
+          yield* self.assignPattern(property.value, self.readProperty(value, key, property), property)
         }
         return
       }
@@ -1115,7 +1121,7 @@ class Frame<R> {
         )
       }
 
-      throw new InterpreterRuntimeError(`Unsupported assignment pattern '${pattern.type}'.`, node)
+      throw typeError(`Unsupported assignment pattern '${pattern.type}'.`, node)
     })
   }
 
@@ -1134,7 +1140,7 @@ class Frame<R> {
     return Effect.gen(function* () {
       const cursor = yield* self.syncIterator(value, pattern)
       if (cursor === undefined) {
-        throw new InterpreterRuntimeError("Array destructuring requires a supported iterable value.", pattern)
+        throw typeError("Array destructuring requires a supported iterable value.", pattern)
       }
       let done = false
       for (const element of pattern.elements) {
@@ -1171,7 +1177,7 @@ class Frame<R> {
 
   private destructuringPropertyKey(property: Property | AssignmentProperty): Effect.Effect<PropertyKey, unknown, R> {
     if (property.type !== "Property" || property.kind !== "init") {
-      throw new InterpreterRuntimeError("Unsupported object destructuring property.", property)
+      throw typeError("Unsupported object destructuring property.", property)
     }
     const keyNode = property.key
     if (property.computed) {
@@ -1186,8 +1192,7 @@ class Frame<R> {
     switch (node.type) {
       case "Literal": {
         const regex = node.regex
-        if (regex)
-          return Effect.sync(() => constructRegExp(this.runtime.prototypes, [regex.pattern, regex.flags], node))
+        if (regex) return Effect.sync(() => constructRegExp(this.runtime.prototypes, [regex.pattern, regex.flags]))
         return Effect.sync(() => toProgram(this.runtime.prototypes, node.value, "Literal"))
       }
       case "Identifier":
@@ -1233,7 +1238,7 @@ class Frame<R> {
         return this.evaluateUpdateExpression(node)
       case "AwaitExpression": {
         // Await always suspends, including for plain values.
-        return Effect.flatMap(this.evaluateExpression(node.argument), (value) => this.awaitValue(value, node))
+        return Effect.flatMap(this.evaluateExpression(node.argument), (value) => this.awaitValue(value))
       }
       case "YieldExpression":
         return this.evaluateYieldExpression(node)
@@ -1261,10 +1266,12 @@ class Frame<R> {
             : callee instanceof NativeFunction
               ? `new ${name}(...) is not supported; call ${name}(...) without new instead.`
               : `${name} is not a constructor.`
-        throw new InterpreterRuntimeError(message, node)
+        throw typeError(message, node)
       }
       const args = yield* self.evaluateCallArguments(node.arguments)
-      return yield* construct(args, callee as NativeFunction<R>, node)
+      return yield* Effect.catchDefect(construct(args, callee as NativeFunction<R>), (defect) =>
+        Effect.die(locate(defect, node)),
+      )
     })
   }
 
@@ -1292,7 +1299,7 @@ class Frame<R> {
       return has(rhs, lhs !== null && typeof lhs === "object" ? coerceToString(lhs) : (lhs as PropertyKey))
     }
     if (containsOpaqueReference(lhs) || containsOpaqueReference(rhs)) {
-      throw new InterpreterRuntimeError("Binary operators require data values.", node, "InvalidDataValue")
+      throw invalidData("Binary operators require data values.", node)
     }
     // Null-prototype data needs explicit primitive coercion; identity and `in` retain raw objects.
     // Dates use their default string hint for addition and loose equality, and epoch time elsewhere.
@@ -1344,11 +1351,11 @@ class Frame<R> {
         return (l as number) >>> (r as number)
       case "in":
         if (!(rhs instanceof ProgramObject)) {
-          throw new InterpreterRuntimeError("The 'in' operator requires a data object on the right-hand side.", node)
+          throw typeError("The 'in' operator requires a data object on the right-hand side.", node)
         }
         return has(rhs, coerceOperand(lhs) as PropertyKey)
       default:
-        throw new InterpreterRuntimeError(`Unsupported binary operator '${operator}'.`, node)
+        throw typeError(`Unsupported binary operator '${operator}'.`, node)
     }
   }
 
@@ -1359,7 +1366,7 @@ class Frame<R> {
       if (operator === "||") return left ? Effect.succeed(left) : this.evaluateExpression(node.right)
       if (operator === "??")
         return left !== null && left !== undefined ? Effect.succeed(left) : this.evaluateExpression(node.right)
-      throw new InterpreterRuntimeError(`Unsupported logical operator '${operator}'.`, node)
+      throw typeError(`Unsupported logical operator '${operator}'.`, node)
     })
   }
 
@@ -1376,7 +1383,7 @@ class Frame<R> {
       if (operator === "!") return !value
       if (operator === "void") return undefined
       if (containsOpaqueReference(value)) {
-        throw new InterpreterRuntimeError("Unary operators require data values.", node, "InvalidDataValue")
+        throw invalidData("Unary operators require data values.", node)
       }
       const operand =
         value instanceof ProgramDate
@@ -1396,7 +1403,7 @@ class Frame<R> {
           result = ~(operand as number)
           break
         default:
-          throw new InterpreterRuntimeError(`Unsupported unary operator '${operator}'.`, node)
+          throw typeError(`Unsupported unary operator '${operator}'.`, node)
       }
       return toProgram(this.runtime.prototypes, result, "Unary expression result")
     })
@@ -1443,7 +1450,7 @@ class Frame<R> {
           }),
         )
       }
-      throw new InterpreterRuntimeError("Assignment target must be an Identifier or MemberExpression.", left)
+      throw typeError("Assignment target must be an Identifier or MemberExpression.", left)
     })
   }
 
@@ -1475,7 +1482,7 @@ class Frame<R> {
           : Effect.succeed({ write: false, next: current, result: current }),
       )
     }
-    throw new InterpreterRuntimeError("Assignment target must be an Identifier or MemberExpression.", left)
+    throw typeError("Assignment target must be an Identifier or MemberExpression.", left)
   }
 
   private evaluateUpdateExpression(node: UpdateExpression): Effect.Effect<unknown, unknown, R> {
@@ -1486,14 +1493,14 @@ class Frame<R> {
     const increment = operator === "++" ? 1 : operator === "--" ? -1 : undefined
 
     if (increment === undefined) {
-      throw new InterpreterRuntimeError(`Unsupported update operator '${operator}'.`, node)
+      throw typeError(`Unsupported update operator '${operator}'.`, node)
     }
 
     // CodeMode numeric coercion, not host Number(): null-prototype data objects would make
     // the host throw during ToPrimitive, and opaque runtime references must reject clearly.
     const operand = (current: unknown): number => {
       if (containsOpaqueReference(current)) {
-        throw new InterpreterRuntimeError(`'${operator}' requires a data value.`, argument, "InvalidDataValue")
+        throw invalidData(`'${operator}' requires a data value.`, argument)
       }
       return coerceToNumber(current)
     }
@@ -1516,7 +1523,7 @@ class Frame<R> {
       })
     }
 
-    throw new InterpreterRuntimeError("Update target must be an Identifier or MemberExpression.", argument)
+    throw typeError("Update target must be an Identifier or MemberExpression.", argument)
   }
 
   // EvaluateCall: a member callee supplies its base object as `this`; anything else calls with undefined.
@@ -1552,20 +1559,24 @@ class Frame<R> {
     callable: unknown,
     thisValue: unknown,
     args: Array<unknown>,
-    node: AstNode,
+    node?: AstNode,
     callee?: Expression,
   ): Effect.Effect<unknown, unknown, R> {
     const self = this
     return Effect.gen(function* () {
       if (callable instanceof ToolReference) {
         if (callable.path.length === 0) {
-          throw new InterpreterRuntimeError("The tools root is not callable.", callee ?? node)
+          throw typeError("The tools root is not callable.", callee ?? node)
         }
         return yield* self.createToolCallPromise(callable.path, args)
       }
       if (callable instanceof ProgramFunction) return yield* self.invokeFunction(callable, args)
-      if (callable instanceof NativeFunction) return yield* (callable as NativeFunction<R>).call(thisValue, args, node)
-      throw new InterpreterRuntimeError(`${calleeDescription(callee)} is not a function.`, callee ?? node)
+      if (callable instanceof NativeFunction) {
+        return yield* Effect.catchDefect((callable as NativeFunction<R>).call(thisValue, args), (defect) =>
+          Effect.die(locate(defect, node)),
+        )
+      }
+      throw typeError(`${calleeDescription(callee)} is not a function.`, callee ?? node)
     })
   }
 
@@ -1579,8 +1590,7 @@ class Frame<R> {
         if (argNode.type === "SpreadElement") {
           const spread = yield* self.evaluateExpression(argNode.argument)
           const cursor = yield* self.syncIterator(spread, argNode)
-          if (cursor === undefined)
-            throw new InterpreterRuntimeError("Spread arguments require a synchronous iterable.", argNode)
+          if (cursor === undefined) throw typeError("Spread arguments require a synchronous iterable.", argNode)
           while (true) {
             const step = yield* cursor.next
             if (step.done) break
@@ -1631,7 +1641,7 @@ class Frame<R> {
     if (fn.generator) return Effect.succeed(this.createGenerator(invocation, run, fn.async))
     if (!fn.async) return run
     return this.runtime.promises.createWithSelf((self) =>
-      Effect.flatMap(run, (value) => resolvePromiseValue(invocation.runtime.runner, value, fn.body, self)),
+      Effect.flatMap(run, (value) => resolvePromiseValue(invocation.runtime.runner, value, self)),
     )
   }
 
@@ -1645,11 +1655,9 @@ class Frame<R> {
     invocation.generatorAsync = asynchronous
     const protos = this.runtime.prototypes
     const result = (value: unknown, done: boolean) => record(protos.Object, { value, done })
-    const request = (kind: GeneratorRequestKind, value: unknown, node: AstNode) => {
+    const request = (kind: GeneratorRequestKind, value: unknown) => {
       const request = { kind, value, response: Deferred.makeUnsafe<unknown, unknown>() }
-      if (!asynchronous && state.active) {
-        return Effect.fail(new InterpreterRuntimeError("Generator is already running.", node))
-      }
+      if (!asynchronous && state.active) return Effect.die(typeError("Generator is already running."))
       if (asynchronous && (state.completed || (!state.started && kind !== "next"))) {
         state.started = true
         state.completed = true
@@ -1769,7 +1777,7 @@ class Frame<R> {
     const argument = node.argument
     const self = this
     return Effect.gen(function* () {
-      if (!self.generatorState) throw new InterpreterRuntimeError("yield is only valid inside a generator.", node)
+      if (!self.generatorState) throw typeError("yield is only valid inside a generator.", node)
       if (node.delegate) {
         const value = argument ? yield* self.evaluateExpression(argument) : undefined
         return yield* self.delegateYield(value, node)
@@ -1782,7 +1790,7 @@ class Frame<R> {
 
   private suspendGenerator(value: unknown, node: AstNode): Effect.Effect<unknown, unknown, R> {
     const state = this.generatorState
-    if (!state?.active) throw new InterpreterRuntimeError("Generator has no active request.", node)
+    if (!state?.active) throw typeError("Generator has no active request.", node)
     Deferred.doneUnsafe(
       state.active.response,
       Exit.succeed(record(this.runtime.prototypes.Object, { value, done: false })),
@@ -1809,7 +1817,7 @@ class Frame<R> {
         value instanceof ProgramURLSearchParams
       ) {
         const cursor = yield* self.syncIterator(value, node)
-        if (!cursor) throw new InterpreterRuntimeError("Built-in iterator is unavailable.", node)
+        if (!cursor) throw typeError("Built-in iterator is unavailable.", node)
         while (true) {
           const step = yield* cursor.next
           if (step.done) return undefined
@@ -1824,14 +1832,14 @@ class Frame<R> {
           }
           if (error instanceof ProgramThrow) {
             yield* cursor.close
-            throw new InterpreterRuntimeError("The delegated iterator does not provide a throw() method.", node)
+            throw typeError("The delegated iterator does not provide a throw() method.", node)
           }
           return yield* Effect.failCause(resumed.cause)
         }
       }
 
       const iterator = yield* self.customIterator(value, node, self.generatorAsync)
-      if (!iterator) throw new InterpreterRuntimeError("yield* requires a compatible iterable value.", node)
+      if (!iterator) throw typeError("yield* requires a compatible iterable value.", node)
       let kind: GeneratorRequestKind = "next"
       let input: unknown = undefined
       while (true) {
@@ -1839,7 +1847,7 @@ class Frame<R> {
         if (method === undefined || method === null) {
           if (kind === "return") return yield* Effect.fail(new GeneratorReturn(input))
           yield* self.closeIterator(iterator, node, self.generatorAsync)
-          throw new InterpreterRuntimeError("The delegated iterator does not provide a throw() method.", node)
+          throw typeError("The delegated iterator does not provide a throw() method.", node)
         }
         const called = yield* self.invokeCallable(
           self.requireIteratorMethod(method, `Iterator ${kind}`, node),
@@ -1891,7 +1899,7 @@ class Frame<R> {
         }
 
         if (property.kind !== "init") {
-          throw new InterpreterRuntimeError("Only init object properties are supported.", property)
+          throw typeError("Only init object properties are supported.", property)
         }
 
         const keyNode = property.key
@@ -1905,7 +1913,7 @@ class Frame<R> {
         } else if (keyNode.type === "Literal") {
           key = self.toPropertyKey(keyNode.value, keyNode)
         } else {
-          throw new InterpreterRuntimeError("Unsupported object property key shape.", keyNode)
+          throw typeError("Unsupported object property key shape.", keyNode)
         }
 
         const name =
@@ -1935,8 +1943,7 @@ class Frame<R> {
         if (element.type === "SpreadElement") {
           const spread = yield* self.evaluateExpression(element.argument)
           const cursor = yield* self.syncIterator(spread, element)
-          if (cursor === undefined)
-            throw new InterpreterRuntimeError("Array spread requires a synchronous iterable.", element)
+          if (cursor === undefined) throw typeError("Array spread requires a synchronous iterable.", element)
           while (true) {
             const step = yield* cursor.next
             if (step.done) break
@@ -1962,7 +1969,7 @@ class Frame<R> {
         const quasi = quasis[index]!
         // acorn only omits `cooked` for invalid escapes in tagged templates, which are unsupported.
         if (typeof quasi.value.cooked !== "string") {
-          throw new InterpreterRuntimeError("Invalid template literal quasi.", quasi)
+          throw typeError("Invalid template literal quasi.", quasi)
         }
         output += quasi.value.cooked
 
@@ -1984,7 +1991,7 @@ class Frame<R> {
 
   private applyCompoundAssignment(operator: string, current: unknown, incoming: unknown, node: AstNode): unknown {
     if (!compoundOperators.has(operator)) {
-      throw new InterpreterRuntimeError(`Unsupported assignment operator '${operator}'.`, node)
+      throw typeError(`Unsupported assignment operator '${operator}'.`, node)
     }
     return this.applyBinaryOperator(operator.slice(0, -1), current, incoming, node)
   }
@@ -2010,7 +2017,7 @@ class Frame<R> {
 
       if (objectValue instanceof ToolReference) {
         if (typeof key !== "string") {
-          throw new InterpreterRuntimeError("Tool paths must use string property names.", propertyNode)
+          throw typeError("Tool paths must use string property names.", propertyNode)
         }
         return new ToolReference([...objectValue.path, key])
       }
@@ -2029,26 +2036,27 @@ class Frame<R> {
       if (typeof objectValue === "boolean") return { target: protos.Boolean, key, receiver: objectValue }
 
       if (objectValue === null || objectValue === undefined) {
-        throw new InterpreterRuntimeError(
-          `Cannot read properties of ${objectValue} (reading '${String(key)}').`,
-          objectNode,
-        )
+        throw typeError(`Cannot read properties of ${objectValue} (reading '${String(key)}').`, objectNode)
       }
-      throw new InterpreterRuntimeError("Cannot access a property on a non-object value.", objectNode)
+      throw typeError("Cannot access a property on a non-object value.", objectNode)
     })
   }
 
   private readReference(reference: MemberReference, node: MemberExpression): unknown {
     // Reject unknown promise properties so a missing await cannot hide.
     if (reference.target instanceof ProgramPromise && !has(reference.target, reference.key)) {
-      throw new InterpreterRuntimeError(
+      throw invalidData(
         "This value is an un-awaited Promise; await it first - e.g. `const result = await tools.ns.tool(...)`.",
         node.object,
-        "InvalidDataValue",
       )
     }
+    return this.readProperty(reference.target, reference.key, node, reference.receiver)
+  }
+
+  // Accessors throw without a location; the member or pattern that read them supplies it.
+  private readProperty(target: ProgramObject, key: PropertyKey, node: AstNode, receiver: unknown = target): unknown {
     try {
-      return get(reference.target, reference.key, reference.receiver)
+      return get(target, key, receiver)
     } catch (error) {
       throw locate(error, node)
     }
@@ -2070,15 +2078,15 @@ class Frame<R> {
   private evaluateDeleteExpression(argument: Expression): Effect.Effect<boolean, unknown, R> {
     const target = argument.type === "ChainExpression" ? argument.expression : argument
     if (target.type !== "MemberExpression") {
-      throw new InterpreterRuntimeError("Only data fields may be deleted.", argument)
+      throw typeError("Only data fields may be deleted.", argument)
     }
     return Effect.map(this.getMemberReference(target), (reference) => {
       if (reference === OptionalShortCircuit) return true
       if (reference instanceof ToolReference || "value" in reference || reference.receiver !== reference.target) {
-        throw new InterpreterRuntimeError("Only data fields may be deleted.", target, "InvalidDataValue")
+        throw invalidData("Only data fields may be deleted.", target)
       }
       if (remove(reference.target, reference.key)) return true
-      throw new InterpreterRuntimeError(`Cannot delete property '${String(reference.key)}'.`, target)
+      throw typeError(`Cannot delete property '${String(reference.key)}'.`, target)
     })
   }
 
@@ -2091,10 +2099,10 @@ class Frame<R> {
     return Effect.gen(function* () {
       const reference = yield* self.getMemberReference(node)
       if (reference === OptionalShortCircuit || reference instanceof ToolReference || "value" in reference) {
-        throw new InterpreterRuntimeError("Only data fields may be assigned.", node)
+        throw typeError("Only data fields may be assigned.", node)
       }
       if (reference.receiver !== reference.target) {
-        throw new InterpreterRuntimeError(
+        throw typeError(
           `Cannot create property '${String(reference.key)}' on ${typeof reference.receiver} '${String(reference.receiver)}'.`,
           node,
         )
@@ -2107,14 +2115,13 @@ class Frame<R> {
   }
 
   private assignToReference(target: ProgramObject, key: PropertyKey, next: unknown, node: AstNode): void {
-    rejectCircularInsertion(
-      target,
-      next,
-      target instanceof ProgramArray ? "Array assignment result" : "Object assignment result",
-      node,
-    )
     const written = (() => {
       try {
+        rejectCircularInsertion(
+          target,
+          next,
+          target instanceof ProgramArray ? "Array assignment result" : "Object assignment result",
+        )
         return set(target, key, next)
       } catch (error) {
         throw locate(error, node)
@@ -2122,7 +2129,7 @@ class Frame<R> {
     })()
     if (written) return
     if (target instanceof ProgramArray && key === "length") throw rangeError("Invalid array length", node)
-    throw new InterpreterRuntimeError(`Cannot assign to read only property '${String(key)}'.`, node)
+    throw typeError(`Cannot assign to read only property '${String(key)}'.`, node)
   }
 
   private toPropertyKey(value: unknown, node: AstNode): PropertyKey {
@@ -2131,9 +2138,6 @@ class Frame<R> {
     }
     if (value === AsyncIteratorSymbol || value === IteratorSymbol) return value
 
-    throw new InterpreterRuntimeError(
-      "Property key must be a string or number, or Symbol.asyncIterator/Symbol.iterator.",
-      node,
-    )
+    throw typeError("Property key must be a string or number, or Symbol.asyncIterator/Symbol.iterator.", node)
   }
 }

--- a/packages/codemode/src/interpreter/scope.ts
+++ b/packages/codemode/src/interpreter/scope.ts
@@ -1,4 +1,4 @@
-import { type AstNode, type Binding, InterpreterRuntimeError, referenceError } from "./model.js"
+import { type AstNode, type Binding, referenceError, typeError } from "./model.js"
 
 export class ScopeStack {
   private readonly scopes: Array<Map<string, Binding>>
@@ -10,7 +10,7 @@ export class ScopeStack {
   reserve(name: string, mutable: boolean, node: AstNode): void {
     const scope = this.current()
     if (scope.has(name)) {
-      throw new InterpreterRuntimeError(`Identifier '${name}' has already been declared.`, node)
+      throw typeError(`Identifier '${name}' has already been declared.`, node)
     }
     scope.set(name, { mutable, value: undefined, initialized: false })
   }
@@ -18,7 +18,7 @@ export class ScopeStack {
   initialize(name: string, value: unknown, node: AstNode): void {
     const binding = this.current().get(name)
     if (!binding || binding.initialized !== false) {
-      throw new InterpreterRuntimeError(`Identifier '${name}' has not been reserved for initialization.`, node)
+      throw typeError(`Identifier '${name}' has not been reserved for initialization.`, node)
     }
     binding.value = value
     binding.initialized = true
@@ -27,7 +27,7 @@ export class ScopeStack {
   declare(name: string, value: unknown, mutable: boolean, node: AstNode): void {
     const scope = this.current()
     if (scope.has(name)) {
-      throw new InterpreterRuntimeError(`Identifier '${name}' has already been declared.`, node)
+      throw typeError(`Identifier '${name}' has already been declared.`, node)
     }
     scope.set(name, { mutable, value, initialized: true })
   }
@@ -58,7 +58,7 @@ export class ScopeStack {
     }
 
     if (!binding.mutable) {
-      throw new InterpreterRuntimeError(`Cannot assign to constant '${name}'.`, node)
+      throw typeError(`Cannot assign to constant '${name}'.`, node)
     }
 
     binding.value = value
@@ -82,7 +82,7 @@ export class ScopeStack {
     const scope = this.scopes[this.scopes.length - 1]
 
     if (!scope) {
-      throw new InterpreterRuntimeError("Interpreter scope stack is empty.")
+      throw typeError("Interpreter scope stack is empty.")
     }
 
     return scope

--- a/packages/codemode/src/stdlib/array.ts
+++ b/packages/codemode/src/stdlib/array.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { constructor, type Method, methods, prototypeFrom, receiver } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError, rangeError } from "../interpreter/model.js"
+import { invalidData, rangeError, typeError } from "../interpreter/model.js"
 import { get, ProgramArray, ProgramGenerator, ProgramObject } from "../interpreter/objects.js"
 import { describeValue, rejectCircularInsertion } from "../interpreter/references.js"
 import { applyCollectionCallback, preserveConsumerError, type Runner } from "../interpreter/runner.js"
@@ -9,35 +9,30 @@ import { coerceToNumber, coerceToString } from "./value.js"
 
 const MAX_LENGTH = 4_294_967_295
 
-const arrayLikeSource = (
-  source: unknown,
-  node: AstNode,
-): { readonly length: number; readonly source: ProgramObject } => {
+const arrayLikeSource = (source: unknown): { readonly length: number; readonly source: ProgramObject } => {
   if (source instanceof ProgramObject && typeof get(source, "length") === "number") {
     const length = get(source, "length") as number
     const normalized = Number.isNaN(length) || length <= 0 ? 0 : Math.trunc(length)
     if (normalized > MAX_LENGTH) throw new RangeError("Invalid array length")
     return { length: normalized, source }
   }
-  throw new InterpreterRuntimeError(
+  throw invalidData(
     `Array.from expects an array, string, Map, Set, or array-like value, received ${describeValue(source)}.`,
-    node,
-    "InvalidDataValue",
   )
 }
 
-const arrayFrom = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): Effect.Effect<unknown, unknown, R> => {
+const arrayFrom = <R>(runner: Runner<R>, args: Array<unknown>): Effect.Effect<unknown, unknown, R> => {
   const source = args[0]
   const proto = runner.prototypes.Array
   const apply =
-    args.length < 2 || args[1] === undefined ? undefined : applyCollectionCallback(runner, args[1], "Array.from", node)
+    args.length < 2 || args[1] === undefined ? undefined : applyCollectionCallback(runner, args[1], "Array.from")
   return Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(source, node)
+    const cursor = yield* runner.syncIterator(source)
     if (cursor === undefined) {
       if (source instanceof ProgramGenerator) {
-        throw new InterpreterRuntimeError("Array.from expects a synchronous iterable or array-like value.", node)
+        throw typeError("Array.from expects a synchronous iterable or array-like value.")
       }
-      const arrayLike = arrayLikeSource(source, node)
+      const arrayLike = arrayLikeSource(source)
       const values: Array<unknown> = []
       for (let index = 0; index < arrayLike.length; index += 1) {
         const item = get(arrayLike.source, index)
@@ -61,12 +56,11 @@ export const sortArray = <R>(
   target: Array<unknown>,
   comparator: unknown,
   name: string,
-  node: AstNode,
 ): Effect.Effect<Array<unknown>, unknown, R> => {
   if (comparator === undefined) {
     return Effect.sync(() => [...target].sort((a, b) => compareText(coerceToString(a), coerceToString(b))))
   }
-  const apply = applyCollectionCallback(runner, comparator, name, node)
+  const apply = applyCollectionCallback(runner, comparator, name)
   const mergeSort = (items: Array<unknown>): Effect.Effect<Array<unknown>, unknown, R> => {
     if (items.length <= 1) return Effect.succeed(items)
     const midpoint = Math.floor(items.length / 2)
@@ -95,32 +89,31 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
   const protos = runner.prototypes
   const proto = protos.Array
   const wrap = (items: Array<unknown>) => new ProgramArray(proto, items)
-  const construct = (args: Array<unknown>, into: ProgramObject, node: AstNode): ProgramArray => {
+  const construct = (args: Array<unknown>, into: ProgramObject): ProgramArray => {
     if (args.length !== 1) return new ProgramArray(into, [...args])
     const first = args[0]
     if (typeof first !== "number") return new ProgramArray(into, [first])
-    if (!Number.isInteger(first) || first < 0 || first > MAX_LENGTH) throw rangeError("Invalid array length.", node)
+    if (!Number.isInteger(first) || first < 0 || first > MAX_LENGTH) throw rangeError("Invalid array length.")
     // Sparse like JS: Array(3) has holes, and combinator loops already skip them.
     return new ProgramArray(into, new Array(first))
   }
   const array = constructor<R>(protos, proto, {
     name: "Array",
     length: 1,
-    call: (_, args, node) => Effect.sync(() => construct(args, proto, node)),
-    construct: (args, newTarget, node) => Effect.sync(() => construct(args, prototypeFrom(newTarget, proto), node)),
+    call: (_, args) => Effect.sync(() => construct(args, proto)),
+    construct: (args, newTarget) => Effect.sync(() => construct(args, prototypeFrom(newTarget, proto))),
   })
   methods(protos, array, [
     ["isArray", 1, (_, args) => args[0] instanceof ProgramArray],
     ["of", 0, (_, args) => wrap([...args])],
-    ["from", 1, (_, args, node) => arrayFrom(runner, args, node)],
+    ["from", 1, (_, args) => arrayFrom(runner, args)],
   ])
 
-  const self = (thisValue: unknown, name: string, node: AstNode) =>
-    receiver(ProgramArray, thisValue, `Array.prototype.${name}`, node)
-  const optNumber = (name: string, value: unknown, label: string, node: AstNode): number | undefined => {
+  const self = (thisValue: unknown, name: string) => receiver(ProgramArray, thisValue, `Array.prototype.${name}`)
+  const optNumber = (name: string, value: unknown, label: string): number | undefined => {
     if (value === undefined) return undefined
     if (typeof value !== "number") {
-      throw new InterpreterRuntimeError(`Array.${name} expects ${label} to be a number.`, node)
+      throw typeError(`Array.${name} expects ${label} to be a number.`)
     }
     return value
   }
@@ -133,14 +126,13 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
       receiver: ProgramArray,
       apply: (args: Array<unknown>) => Effect.Effect<unknown, unknown, R>,
       args: Array<unknown>,
-      node: AstNode,
     ) => Effect.Effect<unknown, unknown, R>,
   ): Method => [
     name,
     length,
-    (thisValue, args, node) => {
-      const target = self(thisValue, name, node)
-      return body(target.items, target, applyCollectionCallback(runner, args[0], `Array.${name}`, node), args, node)
+    (thisValue, args) => {
+      const target = self(thisValue, name)
+      return body(target.items, target, applyCollectionCallback(runner, args[0], `Array.${name}`), args)
     },
   ]
 
@@ -148,10 +140,10 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
     [
       "join",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "join", node).items
+      (thisValue, args) => {
+        const target = self(thisValue, "join").items
         if (args.length > 1 || (args.length === 1 && typeof args[0] !== "string")) {
-          throw new InterpreterRuntimeError("Array.join expects zero arguments or one string separator.", node)
+          throw typeError("Array.join expects zero arguments or one string separator.")
         }
         return target.map((item) => coerceToString(item ?? "")).join(args.length === 0 ? "," : (args[0] as string))
       },
@@ -159,60 +151,56 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
     [
       "toString",
       0,
-      (thisValue, _, node) =>
-        self(thisValue, "toString", node)
+      (thisValue) =>
+        self(thisValue, "toString")
           .items.map((item) => coerceToString(item ?? ""))
           .join(","),
     ],
     [
       "includes",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "includes", node).items
+      (thisValue, args) => {
+        const target = self(thisValue, "includes").items
         if (args.length === 0 || args.length > 2) {
-          throw new InterpreterRuntimeError("Array.includes expects a value and optional start index.", node)
+          throw typeError("Array.includes expects a value and optional start index.")
         }
-        return target.includes(args[0], optNumber("includes", args[1], "start index", node))
+        return target.includes(args[0], optNumber("includes", args[1], "start index"))
       },
     ],
     [
       "indexOf",
       1,
-      (thisValue, args, node) =>
-        self(thisValue, "indexOf", node).items.indexOf(args[0], optNumber("indexOf", args[1], "start index", node)),
+      (thisValue, args) =>
+        self(thisValue, "indexOf").items.indexOf(args[0], optNumber("indexOf", args[1], "start index")),
     ],
     [
       "lastIndexOf",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "lastIndexOf", node).items
+      (thisValue, args) => {
+        const target = self(thisValue, "lastIndexOf").items
         return args[1] === undefined
           ? target.lastIndexOf(args[0])
-          : target.lastIndexOf(args[0], optNumber("lastIndexOf", args[1], "start index", node))
+          : target.lastIndexOf(args[0], optNumber("lastIndexOf", args[1], "start index"))
       },
     ],
-    [
-      "at",
-      1,
-      (thisValue, args, node) => self(thisValue, "at", node).items.at(optNumber("at", args[0], "index", node) ?? 0),
-    ],
+    ["at", 1, (thisValue, args) => self(thisValue, "at").items.at(optNumber("at", args[0], "index") ?? 0)],
     [
       "slice",
       2,
-      (thisValue, args, node) =>
+      (thisValue, args) =>
         wrap(
-          self(thisValue, "slice", node).items.slice(
-            optNumber("slice", args[0], "start", node),
-            optNumber("slice", args[1], "end", node),
+          self(thisValue, "slice").items.slice(
+            optNumber("slice", args[0], "start"),
+            optNumber("slice", args[1], "end"),
           ),
         ),
     ],
     [
       "concat",
       1,
-      (thisValue, args, node) =>
+      (thisValue, args) =>
         wrap(
-          self(thisValue, "concat", node).items.concat(
+          self(thisValue, "concat").items.concat(
             ...args.map((item) => (item instanceof ProgramArray ? item.items : item)),
           ),
         ),
@@ -220,17 +208,17 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
     [
       "flat",
       0,
-      (thisValue, args, node) => {
+      (thisValue, args) => {
         const flatten = (items: Array<unknown>, depth: number): Array<unknown> =>
           items.flatMap((item) => (item instanceof ProgramArray && depth > 0 ? flatten(item.items, depth - 1) : [item]))
-        return wrap(flatten(self(thisValue, "flat", node).items, optNumber("flat", args[0], "depth", node) ?? 1))
+        return wrap(flatten(self(thisValue, "flat").items, optNumber("flat", args[0], "depth") ?? 1))
       },
     ],
     [
       "reverse",
       0,
-      (thisValue, _, node) => {
-        const target = self(thisValue, "reverse", node)
+      (thisValue) => {
+        const target = self(thisValue, "reverse")
         target.items.reverse()
         return target
       },
@@ -238,13 +226,13 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
     [
       "sort",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "sort", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "sort")
         const items = target.items
         const length = items.length
         const holeCount = Array.from({ length }, (_, index) => Object.hasOwn(items, index)).filter((o) => !o).length
         const itemCount = length - holeCount
-        return Effect.map(sortArray(runner, items, args[0], "Array.sort", node), (sorted) => {
+        return Effect.map(sortArray(runner, items, args[0], "Array.sort"), (sorted) => {
           sorted.slice(0, itemCount).forEach((item, index) => {
             items[index] = item
           })
@@ -258,18 +246,18 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
     [
       "toSorted",
       1,
-      (thisValue, args, node) =>
-        Effect.map(sortArray(runner, self(thisValue, "toSorted", node).items, args[0], "Array.toSorted", node), wrap),
+      (thisValue, args) =>
+        Effect.map(sortArray(runner, self(thisValue, "toSorted").items, args[0], "Array.toSorted"), wrap),
     ],
-    ["toReversed", 0, (thisValue, _, node) => wrap([...self(thisValue, "toReversed", node).items].reverse())],
+    ["toReversed", 0, (thisValue) => wrap([...self(thisValue, "toReversed").items].reverse())],
     [
       "with",
       2,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "with", node).items
-        const index = optNumber("with", args[0], "index", node) ?? 0
+      (thisValue, args) => {
+        const target = self(thisValue, "with").items
+        const index = optNumber("with", args[0], "index") ?? 0
         const resolved = index < 0 ? target.length + index : index
-        if (resolved < 0 || resolved >= target.length) throw rangeError("Array.with index is out of range.", node)
+        if (resolved < 0 || resolved >= target.length) throw rangeError("Array.with index is out of range.")
         const copied = [...target]
         copied[resolved] = args[1]
         return wrap(copied)
@@ -278,80 +266,80 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
     [
       "push",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "push", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "push")
         // Validate all insertions before mutating to avoid partial cyclic updates.
-        for (const item of args) rejectCircularInsertion(target, item, "Array.push result", node)
+        for (const item of args) rejectCircularInsertion(target, item, "Array.push result")
         return target.items.push(...args)
       },
     ],
     [
       "unshift",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "unshift", node)
-        for (const item of args) rejectCircularInsertion(target, item, "Array.unshift result", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "unshift")
+        for (const item of args) rejectCircularInsertion(target, item, "Array.unshift result")
         return target.items.unshift(...args)
       },
     ],
-    ["pop", 0, (thisValue, _, node) => self(thisValue, "pop", node).items.pop()],
-    ["shift", 0, (thisValue, _, node) => self(thisValue, "shift", node).items.shift()],
+    ["pop", 0, (thisValue) => self(thisValue, "pop").items.pop()],
+    ["shift", 0, (thisValue) => self(thisValue, "shift").items.shift()],
     [
       "splice",
       2,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "splice", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "splice")
         if (args.length === 0) return wrap(target.items.splice(0, 0))
-        const start = optNumber("splice", args[0], "start", node) ?? 0
+        const start = optNumber("splice", args[0], "start") ?? 0
         if (args.length === 1) return wrap(target.items.splice(start))
-        const deleteCount = optNumber("splice", args[1], "delete count", node) ?? 0
+        const deleteCount = optNumber("splice", args[1], "delete count") ?? 0
         const inserted = args.slice(2)
-        for (const item of inserted) rejectCircularInsertion(target, item, "Array.splice result", node)
+        for (const item of inserted) rejectCircularInsertion(target, item, "Array.splice result")
         return wrap(target.items.splice(start, deleteCount, ...inserted))
       },
     ],
     [
       "toSpliced",
       2,
-      (thisValue, args, node) => {
-        const copied = [...self(thisValue, "toSpliced", node).items]
+      (thisValue, args) => {
+        const copied = [...self(thisValue, "toSpliced").items]
         if (args.length === 0) return wrap(copied)
-        const start = optNumber("toSpliced", args[0], "start", node) ?? 0
+        const start = optNumber("toSpliced", args[0], "start") ?? 0
         if (args.length === 1) copied.splice(start)
-        else copied.splice(start, optNumber("toSpliced", args[1], "delete count", node) ?? 0, ...args.slice(2))
+        else copied.splice(start, optNumber("toSpliced", args[1], "delete count") ?? 0, ...args.slice(2))
         return wrap(copied)
       },
     ],
     [
       "fill",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "fill", node)
-        rejectCircularInsertion(target, args[0], "Array.fill result", node)
-        target.items.fill(args[0], optNumber("fill", args[1], "start", node), optNumber("fill", args[2], "end", node))
+      (thisValue, args) => {
+        const target = self(thisValue, "fill")
+        rejectCircularInsertion(target, args[0], "Array.fill result")
+        target.items.fill(args[0], optNumber("fill", args[1], "start"), optNumber("fill", args[2], "end"))
         return target
       },
     ],
     [
       "copyWithin",
       2,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "copyWithin", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "copyWithin")
         target.items.copyWithin(
-          optNumber("copyWithin", args[0], "target index", node) ?? 0,
-          optNumber("copyWithin", args[1], "start", node) ?? 0,
-          optNumber("copyWithin", args[2], "end", node),
+          optNumber("copyWithin", args[0], "target index") ?? 0,
+          optNumber("copyWithin", args[1], "start") ?? 0,
+          optNumber("copyWithin", args[2], "end"),
         )
         return target
       },
     ],
-    ["keys", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "keys", node).items.keys()))],
-    ["values", 0, (thisValue, _, node) => wrap([...self(thisValue, "values", node).items])],
+    ["keys", 0, (thisValue) => wrap(Array.from(self(thisValue, "keys").items.keys()))],
+    ["values", 0, (thisValue) => wrap([...self(thisValue, "values").items])],
     [
       "entries",
       0,
-      (thisValue, _, node) =>
-        wrap(Array.from(self(thisValue, "entries", node).items.entries(), ([index, item]) => wrap([index, item]))),
+      (thisValue) =>
+        wrap(Array.from(self(thisValue, "entries").items.entries(), ([index, item]) => wrap([index, item]))),
     ],
     iterate("map", 1, (target, receiver, apply) =>
       Effect.gen(function* () {
@@ -455,7 +443,7 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
         return undefined
       }),
     ),
-    iterate("reduce", 1, (target, receiver, apply, args, node) =>
+    iterate("reduce", 1, (target, receiver, apply, args) =>
       Effect.gen(function* () {
         const length = target.length
         let start = 0
@@ -463,7 +451,7 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
         if (args.length < 2) {
           while (start < length && !(start in target)) start += 1
           if (start === length) {
-            throw new InterpreterRuntimeError("Array.reduce of an empty array with no initial value.", node)
+            throw typeError("Array.reduce of an empty array with no initial value.")
           }
           accumulator = target[start]
           start += 1
@@ -475,14 +463,14 @@ export const arrayGlobal = <R>(runner: Runner<R>) => {
         return accumulator
       }),
     ),
-    iterate("reduceRight", 1, (target, receiver, apply, args, node) =>
+    iterate("reduceRight", 1, (target, receiver, apply, args) =>
       Effect.gen(function* () {
         let start = target.length - 1
         let accumulator = args[1]
         if (args.length < 2) {
           while (start >= 0 && !(start in target)) start -= 1
           if (start < 0) {
-            throw new InterpreterRuntimeError("Array.reduceRight of an empty array with no initial value.", node)
+            throw typeError("Array.reduceRight of an empty array with no initial value.")
           }
           accumulator = target[start]
           start -= 1

--- a/packages/codemode/src/stdlib/collections.ts
+++ b/packages/codemode/src/stdlib/collections.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { constructor, fn, type Method, methods, prototypeFrom, receiver, requiresNew } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError } from "../interpreter/model.js"
+import { invalidData, typeError } from "../interpreter/model.js"
 import {
   define,
   defineAccessor,
@@ -24,35 +24,27 @@ import {
   toPrimitiveString,
 } from "../interpreter/runner.js"
 
-const coerceGroupByPropertyKey = <R>(
-  runner: Runner<R>,
-  value: unknown,
-  node: AstNode,
-): Effect.Effect<string, unknown, R> => {
+const coerceGroupByPropertyKey = <R>(runner: Runner<R>, value: unknown): Effect.Effect<string, unknown, R> => {
   if (value instanceof ProgramPromise) return Effect.succeed("[object Promise]")
   if (!isWrapper(value) && isRuntimeReference(value)) {
-    throw new InterpreterRuntimeError(
-      `Object.groupBy callback must return a data value, received ${describeValue(value)}.`,
-      node,
-      "InvalidDataValue",
-    )
+    throw invalidData(`Object.groupBy callback must return a data value, received ${describeValue(value)}.`)
   }
-  return toPrimitiveString(runner, value, node)
+  return toPrimitiveString(runner, value)
 }
 
 /** `Map.groupBy` and `Object.groupBy`: the same iteration, keyed into a Map or a data object. */
 export const groupBy = <R>(runner: Runner<R>, namespace: "Map" | "Object") =>
-  fn<R>(runner.prototypes, "groupBy", 2, (_, args, node) => {
+  fn<R>(runner.prototypes, "groupBy", 2, (_, args) => {
     const protos = runner.prototypes
     const source = args[0]
     if (source === null || source === undefined) {
-      throw new InterpreterRuntimeError(`${namespace}.groupBy expects an iterable collection.`, node)
+      throw typeError(`${namespace}.groupBy expects an iterable collection.`)
     }
-    const apply = applyCollectionCallback(runner, args[1], `${namespace}.groupBy`, node)
+    const apply = applyCollectionCallback(runner, args[1], `${namespace}.groupBy`)
     return Effect.gen(function* () {
-      const cursor = yield* runner.syncIterator(source, node)
+      const cursor = yield* runner.syncIterator(source)
       if (cursor === undefined) {
-        throw new InterpreterRuntimeError(`${namespace}.groupBy expects an iterable collection.`, node)
+        throw typeError(`${namespace}.groupBy expects an iterable collection.`)
       }
       if (namespace === "Map") {
         const result = new ProgramMap(protos.Map)
@@ -78,7 +70,7 @@ export const groupBy = <R>(runner: Runner<R>, namespace: "Map" | "Object") =>
         const item = step.value
         const key = yield* preserveConsumerError(
           cursor,
-          Effect.flatMap(apply([item, index]), (value) => coerceGroupByPropertyKey(runner, value, node)),
+          Effect.flatMap(apply([item, index]), (value) => coerceGroupByPropertyKey(runner, value)),
         )
         const group = getOwn(result, key)
         if (group === undefined) define(result, key, new ProgramArray(protos.Array, [item]))
@@ -88,13 +80,13 @@ export const groupBy = <R>(runner: Runner<R>, namespace: "Map" | "Object") =>
     })
   })
 
-const constructMap = <R>(runner: Runner<R>, init: unknown, proto: ProgramObject, node: AstNode) => {
+const constructMap = <R>(runner: Runner<R>, init: unknown, proto: ProgramObject) => {
   const target = new ProgramMap(proto)
   if (init === undefined || init === null) return Effect.succeed(target)
   return Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(init, node)
+    const cursor = yield* runner.syncIterator(init)
     if (cursor === undefined) {
-      throw new InterpreterRuntimeError("new Map(...) expects an iterable of [key, value] pairs or no argument.", node)
+      throw typeError("new Map(...) expects an iterable of [key, value] pairs or no argument.")
     }
     while (true) {
       const step = yield* cursor.next
@@ -103,7 +95,7 @@ const constructMap = <R>(runner: Runner<R>, init: unknown, proto: ProgramObject,
         cursor,
         Effect.sync(() => {
           if (!(step.value instanceof ProgramObject)) {
-            throw new InterpreterRuntimeError("new Map(...) expects [key, value] pairs as entry objects.", node)
+            throw typeError("new Map(...) expects [key, value] pairs as entry objects.")
           }
           target.map.set(getOwn(step.value, 0), getOwn(step.value, 1))
         }),
@@ -112,13 +104,13 @@ const constructMap = <R>(runner: Runner<R>, init: unknown, proto: ProgramObject,
   })
 }
 
-const constructSet = <R>(runner: Runner<R>, init: unknown, proto: ProgramObject, node: AstNode) => {
+const constructSet = <R>(runner: Runner<R>, init: unknown, proto: ProgramObject) => {
   const target = new ProgramSet(proto)
   if (init === undefined || init === null) return Effect.succeed(target)
   return Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(init, node)
+    const cursor = yield* runner.syncIterator(init)
     if (cursor === undefined) {
-      throw new InterpreterRuntimeError("new Set(...) expects a synchronous iterable or no argument.", node)
+      throw typeError("new Set(...) expects a synchronous iterable or no argument.")
     }
     while (true) {
       const step = yield* cursor.next
@@ -134,48 +126,46 @@ export const mapGlobal = <R>(runner: Runner<R>) => {
   const map = constructor<R>(protos, proto, {
     name: "Map",
     call: requiresNew("Map"),
-    construct: (args, newTarget, node) => constructMap(runner, args[0], prototypeFrom(newTarget, proto), node),
+    construct: (args, newTarget) => constructMap(runner, args[0], prototypeFrom(newTarget, proto)),
   })
   define(map, "groupBy", groupBy(runner, "Map"), hidden)
-  const self = (thisValue: unknown, name: string, node: AstNode) =>
-    receiver(ProgramMap, thisValue, `Map.prototype.${name}`, node)
+  const self = (thisValue: unknown, name: string) => receiver(ProgramMap, thisValue, `Map.prototype.${name}`)
   const wrap = (items: Array<unknown>) => new ProgramArray(protos.Array, items)
   defineAccessor(proto, "size", (thisValue) => receiver(ProgramMap, thisValue, "Map.prototype.size").map.size)
   methods(protos, proto, [
-    ["get", 1, (thisValue, args, node) => self(thisValue, "get", node).map.get(args[0])],
-    ["has", 1, (thisValue, args, node) => self(thisValue, "has", node).map.has(args[0])],
+    ["get", 1, (thisValue, args) => self(thisValue, "get").map.get(args[0])],
+    ["has", 1, (thisValue, args) => self(thisValue, "has").map.has(args[0])],
     [
       "set",
       2,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "set", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "set")
         target.map.set(args[0], args[1])
         return target
       },
     ],
-    ["delete", 1, (thisValue, args, node) => self(thisValue, "delete", node).map.delete(args[0])],
+    ["delete", 1, (thisValue, args) => self(thisValue, "delete").map.delete(args[0])],
     [
       "clear",
       0,
-      (thisValue, _, node) => {
-        self(thisValue, "clear", node).map.clear()
+      (thisValue) => {
+        self(thisValue, "clear").map.clear()
         return undefined
       },
     ],
-    ["keys", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "keys", node).map.keys()))],
-    ["values", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "values", node).map.values()))],
+    ["keys", 0, (thisValue) => wrap(Array.from(self(thisValue, "keys").map.keys()))],
+    ["values", 0, (thisValue) => wrap(Array.from(self(thisValue, "values").map.values()))],
     [
       "entries",
       0,
-      (thisValue, _, node) =>
-        wrap(Array.from(self(thisValue, "entries", node).map.entries(), ([key, item]) => wrap([key, item]))),
+      (thisValue) => wrap(Array.from(self(thisValue, "entries").map.entries(), ([key, item]) => wrap([key, item]))),
     ],
     [
       "forEach",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "forEach", node)
-        const apply = applyCollectionCallback(runner, args[0], "Map.forEach", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "forEach")
+        const apply = applyCollectionCallback(runner, args[0], "Map.forEach")
         return Effect.gen(function* () {
           for (const [key, item] of Array.from(target.map.entries())) yield* apply([item, key, target])
           return undefined
@@ -196,7 +186,6 @@ const loadSetRecord = <R>(
   runner: Runner<R>,
   source: unknown,
   name: string,
-  node: AstNode,
 ): Effect.Effect<SetRecord<R>, unknown, R> => {
   if (source instanceof ProgramSet) {
     return Effect.succeed({
@@ -213,25 +202,25 @@ const loadSetRecord = <R>(
     })
   }
   if (!(source instanceof ProgramObject)) {
-    throw new InterpreterRuntimeError(`Set.${name} expects a Set-like object.`, node)
+    throw typeError(`Set.${name} expects a Set-like object.`)
   }
   return Effect.gen(function* () {
-    const size = yield* toPrimitiveNumber(runner, get(source, "size"), node)
+    const size = yield* toPrimitiveNumber(runner, get(source, "size"))
     if (Number.isNaN(size)) {
-      throw new InterpreterRuntimeError(`Set.${name} received a Set-like object with an invalid size.`, node)
+      throw typeError(`Set.${name} received a Set-like object with an invalid size.`)
     }
     const has = get(source, "has")
     const keys = get(source, "keys")
     if (!isSupportedCallback(has) || !isSupportedCallback(keys)) {
-      throw new InterpreterRuntimeError(`Set.${name} expects callable 'has' and 'keys' methods.`, node)
+      throw typeError(`Set.${name} expects callable 'has' and 'keys' methods.`)
     }
     return {
       size: Math.max(Math.trunc(size), 0),
-      has: (item: unknown) => Effect.map(runner.invokeCallable(has, source, [item], node), Boolean),
+      has: (item: unknown) => Effect.map(runner.invokeCallable(has, source, [item]), Boolean),
       keys: () =>
-        Effect.flatMap(runner.invokeCallable(keys, source, [], node), (result) => {
+        Effect.flatMap(runner.invokeCallable(keys, source, []), (result) => {
           if (result instanceof ProgramArray) return Effect.succeed(result.items)
-          throw new InterpreterRuntimeError(`Set.${name} expected 'keys' to return an iterator.`, node)
+          throw typeError(`Set.${name} expected 'keys' to return an iterator.`)
         }),
     }
   })
@@ -242,10 +231,9 @@ const setOperation = <R>(
   target: ProgramSet,
   name: string,
   source: unknown,
-  node: AstNode,
 ): Effect.Effect<unknown, unknown, R> =>
   Effect.gen(function* () {
-    const other = yield* loadSetRecord(runner, source, name, node)
+    const other = yield* loadSetRecord(runner, source, name)
     const copy = () => {
       const result = new ProgramSet(runner.prototypes.Set)
       for (const item of target.set.values()) result.set.add(item)
@@ -320,51 +308,49 @@ export const setGlobal = <R>(runner: Runner<R>) => {
   const set = constructor<R>(protos, proto, {
     name: "Set",
     call: requiresNew("Set"),
-    construct: (args, newTarget, node) => constructSet(runner, args[0], prototypeFrom(newTarget, proto), node),
+    construct: (args, newTarget) => constructSet(runner, args[0], prototypeFrom(newTarget, proto)),
   })
-  const self = (thisValue: unknown, name: string, node: AstNode) =>
-    receiver(ProgramSet, thisValue, `Set.prototype.${name}`, node)
+  const self = (thisValue: unknown, name: string) => receiver(ProgramSet, thisValue, `Set.prototype.${name}`)
   const wrap = (items: Array<unknown>) => new ProgramArray(protos.Array, items)
   const operation = (name: string): Method => [
     name,
     1,
-    (thisValue, args, node) => setOperation(runner, self(thisValue, name, node), name, args[0], node),
+    (thisValue, args) => setOperation(runner, self(thisValue, name), name, args[0]),
   ]
   defineAccessor(proto, "size", (thisValue) => receiver(ProgramSet, thisValue, "Set.prototype.size").set.size)
   methods(protos, proto, [
-    ["has", 1, (thisValue, args, node) => self(thisValue, "has", node).set.has(args[0])],
+    ["has", 1, (thisValue, args) => self(thisValue, "has").set.has(args[0])],
     [
       "add",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "add", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "add")
         target.set.add(args[0])
         return target
       },
     ],
-    ["delete", 1, (thisValue, args, node) => self(thisValue, "delete", node).set.delete(args[0])],
+    ["delete", 1, (thisValue, args) => self(thisValue, "delete").set.delete(args[0])],
     [
       "clear",
       0,
-      (thisValue, _, node) => {
-        self(thisValue, "clear", node).set.clear()
+      (thisValue) => {
+        self(thisValue, "clear").set.clear()
         return undefined
       },
     ],
-    ["keys", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "keys", node).set.values()))],
-    ["values", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "values", node).set.values()))],
+    ["keys", 0, (thisValue) => wrap(Array.from(self(thisValue, "keys").set.values()))],
+    ["values", 0, (thisValue) => wrap(Array.from(self(thisValue, "values").set.values()))],
     [
       "entries",
       0,
-      (thisValue, _, node) =>
-        wrap(Array.from(self(thisValue, "entries", node).set.values(), (item) => wrap([item, item]))),
+      (thisValue) => wrap(Array.from(self(thisValue, "entries").set.values(), (item) => wrap([item, item]))),
     ],
     [
       "forEach",
       1,
-      (thisValue, args, node) => {
-        const target = self(thisValue, "forEach", node)
-        const apply = applyCollectionCallback(runner, args[0], "Set.forEach", node)
+      (thisValue, args) => {
+        const target = self(thisValue, "forEach")
+        const apply = applyCollectionCallback(runner, args[0], "Set.forEach")
         return Effect.gen(function* () {
           for (const item of Array.from(target.set.values())) yield* apply([item, item, target])
           return undefined

--- a/packages/codemode/src/stdlib/date.ts
+++ b/packages/codemode/src/stdlib/date.ts
@@ -1,16 +1,16 @@
 import { Effect } from "effect"
 import { constructor, type Method, methods, prototypeFrom, receiver } from "../interpreter/native.js"
-import { type AstNode, rangeError } from "../interpreter/model.js"
+import { rangeError } from "../interpreter/model.js"
 import { ProgramDate, ProgramObject } from "../interpreter/objects.js"
 import { type Runner, toPrimitive, toPrimitiveNumber } from "../interpreter/runner.js"
 import { coerceToNumber, coerceToString } from "./value.js"
 
-const constructDate = <R>(runner: Runner<R>, args: Array<unknown>, proto: ProgramObject, node: AstNode) => {
+const constructDate = <R>(runner: Runner<R>, args: Array<unknown>, proto: ProgramObject) => {
   if (args.length === 0) return Effect.succeed(new ProgramDate(proto, Date.now()))
   if (args.length === 1) {
     const arg = args[0]
     if (arg instanceof ProgramDate) return Effect.succeed(new ProgramDate(proto, arg.time))
-    return Effect.map(toPrimitive(runner, arg, "default", node), (value) =>
+    return Effect.map(toPrimitive(runner, arg, "default"), (value) =>
       typeof value === "string"
         ? new ProgramDate(proto, Date.parse(value))
         : new ProgramDate(proto, new Date(coerceToNumber(value)).getTime()),
@@ -74,7 +74,7 @@ export const dateGlobal = <R>(runner: Runner<R>) => {
     length: 7,
     // ISO instead of the host's locale string: date strings are deterministic and must not leak the host timezone.
     call: () => Effect.sync(() => new Date().toISOString()),
-    construct: (args, newTarget, node) => constructDate(runner, args, prototypeFrom(newTarget, proto), node),
+    construct: (args, newTarget) => constructDate(runner, args, prototypeFrom(newTarget, proto)),
   })
   methods(protos, date, [
     ["now", 0, () => Date.now()],
@@ -82,42 +82,39 @@ export const dateGlobal = <R>(runner: Runner<R>) => {
     ["UTC", 7, (_, args) => Date.UTC(...(args.map((arg) => coerceToNumber(arg)) as Parameters<typeof Date.UTC>))],
   ])
 
-  const self = (thisValue: unknown, name: string, node: AstNode) =>
-    receiver(ProgramDate, thisValue, `Date.prototype.${name}`, node)
-  const iso = (value: ProgramDate, node: AstNode) => {
-    if (!Number.isFinite(value.time)) throw rangeError("Invalid time value.", node)
+  const self = (thisValue: unknown, name: string) => receiver(ProgramDate, thisValue, `Date.prototype.${name}`)
+  const iso = (value: ProgramDate) => {
+    if (!Number.isFinite(value.time)) throw rangeError("Invalid time value.")
     return new Date(value.time).toISOString()
   }
   methods(protos, proto, [
-    ["getTime", 0, (thisValue, _, node) => self(thisValue, "getTime", node).time],
-    ["valueOf", 0, (thisValue, _, node) => self(thisValue, "valueOf", node).time],
-    ["toISOString", 0, (thisValue, _, node) => iso(self(thisValue, "toISOString", node), node)],
+    ["getTime", 0, (thisValue) => self(thisValue, "getTime").time],
+    ["valueOf", 0, (thisValue) => self(thisValue, "valueOf").time],
+    ["toISOString", 0, (thisValue) => iso(self(thisValue, "toISOString"))],
     [
       "toJSON",
       1,
-      (thisValue, _, node) => {
-        const value = self(thisValue, "toJSON", node)
-        return Number.isFinite(value.time) ? iso(value, node) : null
+      (thisValue) => {
+        const value = self(thisValue, "toJSON")
+        return Number.isFinite(value.time) ? iso(value) : null
       },
     ],
-    ["toString", 0, (thisValue, _, node) => coerceToString(self(thisValue, "toString", node))],
-    ["toDateString", 0, (thisValue, _, node) => new Date(self(thisValue, "toDateString", node).time).toDateString()],
-    ["toTimeString", 0, (thisValue, _, node) => new Date(self(thisValue, "toTimeString", node).time).toTimeString()],
-    ["toUTCString", 0, (thisValue, _, node) => new Date(self(thisValue, "toUTCString", node).time).toUTCString()],
-    ["toGMTString", 0, (thisValue, _, node) => new Date(self(thisValue, "toGMTString", node).time).toUTCString()],
-    ...getters.map(
-      (name): Method => [name, 0, (thisValue, _, node) => new Date(self(thisValue, name, node).time)[name]()],
-    ),
+    ["toString", 0, (thisValue) => coerceToString(self(thisValue, "toString"))],
+    ["toDateString", 0, (thisValue) => new Date(self(thisValue, "toDateString").time).toDateString()],
+    ["toTimeString", 0, (thisValue) => new Date(self(thisValue, "toTimeString").time).toTimeString()],
+    ["toUTCString", 0, (thisValue) => new Date(self(thisValue, "toUTCString").time).toUTCString()],
+    ["toGMTString", 0, (thisValue) => new Date(self(thisValue, "toGMTString").time).toUTCString()],
+    ...getters.map((name): Method => [name, 0, (thisValue) => new Date(self(thisValue, name).time)[name]()]),
     ...setters.map(
       ([name, length]): Method => [
         name,
         length,
-        (thisValue, args, node) => {
-          const target = self(thisValue, name, node)
+        (thisValue, args) => {
+          const target = self(thisValue, name)
           // Native setters read the current time before argument coercion, whose callbacks may mutate the Date.
           const hosted = new Date(target.time)
           return Effect.map(
-            Effect.forEach(args.slice(0, length), (arg) => toPrimitiveNumber(runner, arg, node), {
+            Effect.forEach(args.slice(0, length), (arg) => toPrimitiveNumber(runner, arg), {
               concurrency: 1,
             }),
             (values) => {

--- a/packages/codemode/src/stdlib/json.ts
+++ b/packages/codemode/src/stdlib/json.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { methods } from "../interpreter/native.js"
 import { applyCollectionCallback, type Runner } from "../interpreter/runner.js"
-import { type AstNode, InterpreterRuntimeError, syntaxError } from "../interpreter/model.js"
+import { syntaxError, typeError } from "../interpreter/model.js"
 import { typeofValue } from "../interpreter/references.js"
 import { fromData, toData, toProgram } from "../data.js"
 import { Callable, get, keys, ProgramArray, ProgramObject, record, remove, set } from "../interpreter/objects.js"
@@ -9,29 +9,26 @@ import { Callable, get, keys, ProgramArray, ProgramObject, record, remove, set }
 export const jsonGlobal = <R>(runner: Runner<R>) => {
   const json = new ProgramObject(runner.prototypes.Object)
   methods(runner.prototypes, json, [
-    ["parse", 2, (_, args, node) => parse(runner, args, node)],
-    ["stringify", 3, (_, args, node) => stringify(runner, args, node)],
+    ["parse", 2, (_, args) => parse(runner, args)],
+    ["stringify", 3, (_, args) => stringify(runner, args)],
   ])
   return json
 }
 
-const parse = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): Effect.Effect<unknown, unknown, R> => {
+const parse = <R>(runner: Runner<R>, args: Array<unknown>): Effect.Effect<unknown, unknown, R> => {
   const text = args[0]
-  if (typeof text !== "string") throw new InterpreterRuntimeError("JSON.parse expects a string.", node)
+  if (typeof text !== "string") throw typeError("JSON.parse expects a string.")
 
   const parsed = (() => {
     try {
       return fromData(runner.prototypes, JSON.parse(text), "JSON.parse result")
     } catch (error) {
-      throw syntaxError(
-        `JSON.parse received invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
-        node,
-      )
+      throw syntaxError(`JSON.parse received invalid JSON: ${error instanceof Error ? error.message : String(error)}`)
     }
   })()
   if (typeofValue(args[1]) !== "function") return Effect.succeed(parsed)
 
-  const apply = applyCollectionCallback(runner, args[1], "JSON.parse", node)
+  const apply = applyCollectionCallback(runner, args[1], "JSON.parse")
   const visit = (holder: ProgramObject, key: string): Effect.Effect<unknown, unknown, R> =>
     Effect.gen(function* () {
       const value = get(holder, key)
@@ -47,7 +44,7 @@ const parse = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): Effec
   return visit(record(runner.prototypes.Object, { "": parsed }), "")
 }
 
-const stringify = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): Effect.Effect<unknown, unknown, R> => {
+const stringify = <R>(runner: Runner<R>, args: Array<unknown>): Effect.Effect<unknown, unknown, R> => {
   const space = args[2]
   const indent = typeof space === "number" || typeof space === "string" ? space : undefined
   const replacer = args[1]
@@ -64,17 +61,17 @@ const stringify = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): E
 
   // Validate up front; the replacer walk below reads the original value.
   toProgram(runner.prototypes, args[0], "JSON.stringify value")
-  const apply = applyCollectionCallback(runner, replacer, "JSON.stringify", node)
+  const apply = applyCollectionCallback(runner, replacer, "JSON.stringify")
   const stack = new Set<object>()
   const visit = (holder: ProgramObject, key: string): Effect.Effect<unknown, unknown, R> =>
     Effect.gen(function* () {
-      const value = yield* apply([key, yield* toJSONValue(runner, get(holder, key), key, node)])
+      const value = yield* apply([key, yield* toJSONValue(runner, get(holder, key), key)])
       if (value === undefined || typeofValue(value) === "function") return undefined
       toProgram(runner.prototypes, value, "JSON.stringify replacer result")
       if (typeof value === "number") return Number.isFinite(value) ? value : null
       if (value === null || typeof value === "string" || typeof value === "boolean") return value
       if (!(value instanceof ProgramObject)) return {}
-      if (stack.has(value)) throw new InterpreterRuntimeError("Converting circular structure to JSON.", node)
+      if (stack.has(value)) throw typeError("Converting circular structure to JSON.")
       stack.add(value)
       if (value instanceof ProgramArray) {
         const result: Array<unknown> = []
@@ -99,8 +96,8 @@ const stringify = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): E
 }
 
 // SerializeJSONProperty step 2: a callable `toJSON` decides the value, as Date and URL define.
-const toJSONValue = <R>(runner: Runner<R>, value: unknown, key: string, node: AstNode) => {
+const toJSONValue = <R>(runner: Runner<R>, value: unknown, key: string) => {
   if (!(value instanceof ProgramObject)) return Effect.succeed(value)
   const toJSON = get(value, "toJSON")
-  return toJSON instanceof Callable ? runner.invokeCallable(toJSON, value, [key], node) : Effect.succeed(value)
+  return toJSON instanceof Callable ? runner.invokeCallable(toJSON, value, [key]) : Effect.succeed(value)
 }

--- a/packages/codemode/src/stdlib/math.ts
+++ b/packages/codemode/src/stdlib/math.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { constants, type Method, methods } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError } from "../interpreter/model.js"
+import { typeError } from "../interpreter/model.js"
 import { ProgramObject } from "../interpreter/objects.js"
 import { preserveConsumerError, type Runner } from "../interpreter/runner.js"
 
@@ -13,32 +13,28 @@ declare global {
 
 // Validate only the arguments a method consumes; like JS, extras are ignored
 // (so built-ins work as callbacks receiving (element, index, array)).
-const number = (name: string, args: Array<unknown>, index: number, node: AstNode): number => {
+const number = (name: string, args: Array<unknown>, index: number): number => {
   if (index >= args.length) return Number.NaN
   const arg = args[index]
-  if (typeof arg !== "number") throw new InterpreterRuntimeError(`Math.${name} expects number arguments.`, node)
+  if (typeof arg !== "number") throw typeError(`Math.${name} expects number arguments.`)
   return arg
 }
 
-const unary = (name: string, op: (a: number) => number): Method => [
-  name,
-  1,
-  (_, args, node) => op(number(name, args, 0, node)),
-]
+const unary = (name: string, op: (a: number) => number): Method => [name, 1, (_, args) => op(number(name, args, 0))]
 
 const binary = (name: string, op: (a: number, b: number) => number): Method => [
   name,
   2,
-  (_, args, node) => op(number(name, args, 0, node), number(name, args, 1, node)),
+  (_, args) => op(number(name, args, 0), number(name, args, 1)),
 ]
 
 const variadic = (name: string, op: (...values: Array<number>) => number): Method => [
   name,
   2,
-  (_, args, node) =>
+  (_, args) =>
     op(
       ...args.map((arg) => {
-        if (typeof arg !== "number") throw new InterpreterRuntimeError(`Math.${name} expects number arguments.`, node)
+        if (typeof arg !== "number") throw typeError(`Math.${name} expects number arguments.`)
         return arg
       }),
     ),
@@ -97,11 +93,11 @@ export const mathGlobal = <R>(runner: Runner<R>) => {
     [
       "sumPrecise",
       1,
-      (_, args, node) =>
+      (_, args) =>
         Effect.gen(function* () {
-          const cursor = yield* runner.syncIterator(args[0], node)
+          const cursor = yield* runner.syncIterator(args[0])
           if (cursor === undefined) {
-            throw new InterpreterRuntimeError("Math.sumPrecise expects a synchronous iterable.", node)
+            throw typeError("Math.sumPrecise expects a synchronous iterable.")
           }
           const numbers: Array<number> = []
           while (true) {
@@ -111,7 +107,7 @@ export const mathGlobal = <R>(runner: Runner<R>) => {
               cursor,
               Effect.sync(() => {
                 if (typeof step.value !== "number") {
-                  throw new InterpreterRuntimeError("Math.sumPrecise expects an iterable of numbers.", node)
+                  throw typeError("Math.sumPrecise expects an iterable of numbers.")
                 }
                 numbers.push(step.value)
               }),

--- a/packages/codemode/src/stdlib/number.ts
+++ b/packages/codemode/src/stdlib/number.ts
@@ -1,5 +1,5 @@
 import { constructor, constants, methods } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError, rangeError } from "../interpreter/model.js"
+import { rangeError, typeError } from "../interpreter/model.js"
 import type { Runner } from "../interpreter/runner.js"
 import { coercion, coerceToString } from "./value.js"
 
@@ -28,10 +28,10 @@ export const numberGlobal = <R>(runner: Runner<R>) => {
     [
       "parseInt",
       2,
-      (_, args, node) => {
+      (_, args) => {
         const radix = args[1]
         if (radix !== undefined && typeof radix !== "number") {
-          throw new InterpreterRuntimeError("Number.parseInt expects a numeric radix.", node)
+          throw typeError("Number.parseInt expects a numeric radix.")
         }
         return parseInt(coerceToString(args[0]), radix)
       },
@@ -39,49 +39,44 @@ export const numberGlobal = <R>(runner: Runner<R>) => {
     ["parseFloat", 1, (_, args) => parseFloat(coerceToString(args[0]))],
   ])
 
-  const self = (thisValue: unknown, name: string, node: AstNode): number => {
+  const self = (thisValue: unknown, name: string): number => {
     if (typeof thisValue === "number") return thisValue
-    throw new InterpreterRuntimeError(`Number.prototype.${name} requires that 'this' be a Number.`, node)
+    throw typeError(`Number.prototype.${name} requires that 'this' be a Number.`)
   }
-  const optNum = (name: string, arg: unknown, node: AstNode): number | undefined => {
+  const optNum = (name: string, arg: unknown): number | undefined => {
     if (arg === undefined) return undefined
-    if (typeof arg !== "number") throw new InterpreterRuntimeError(`Number.${name} expects a number argument.`, node)
+    if (typeof arg !== "number") throw typeError(`Number.${name} expects a number argument.`)
     return arg
   }
   methods(protos, protos.Number, [
-    [
-      "toFixed",
-      1,
-      (thisValue, args, node) => self(thisValue, "toFixed", node).toFixed(optNum("toFixed", args[0], node)),
-    ],
+    ["toFixed", 1, (thisValue, args) => self(thisValue, "toFixed").toFixed(optNum("toFixed", args[0]))],
     [
       "toExponential",
       1,
-      (thisValue, args, node) =>
-        self(thisValue, "toExponential", node).toExponential(optNum("toExponential", args[0], node)),
+      (thisValue, args) => self(thisValue, "toExponential").toExponential(optNum("toExponential", args[0])),
     ],
     [
       "toPrecision",
       1,
-      (thisValue, args, node) => {
-        const value = self(thisValue, "toPrecision", node)
-        const digits = optNum("toPrecision", args[0], node)
+      (thisValue, args) => {
+        const value = self(thisValue, "toPrecision")
+        const digits = optNum("toPrecision", args[0])
         return digits === undefined ? value.toString() : value.toPrecision(digits)
       },
     ],
     [
       "toString",
       1,
-      (thisValue, args, node) => {
-        const value = self(thisValue, "toString", node)
-        const radix = optNum("toString", args[0], node)
+      (thisValue, args) => {
+        const value = self(thisValue, "toString")
+        const radix = optNum("toString", args[0])
         if (radix !== undefined && (radix < 2 || radix > 36)) {
-          throw rangeError("Number.toString radix must be between 2 and 36.", node)
+          throw rangeError("Number.toString radix must be between 2 and 36.")
         }
         return value.toString(radix)
       },
     ],
-    ["valueOf", 0, (thisValue, _, node) => self(thisValue, "valueOf", node)],
+    ["valueOf", 0, (thisValue) => self(thisValue, "valueOf")],
   ])
   return number
 }
@@ -93,13 +88,13 @@ export const booleanGlobal = <R>(runner: Runner<R>) => {
     length: 1,
     call: coercion(runner, "Boolean").call,
   })
-  const self = (thisValue: unknown, name: string, node: AstNode): boolean => {
+  const self = (thisValue: unknown, name: string): boolean => {
     if (typeof thisValue === "boolean") return thisValue
-    throw new InterpreterRuntimeError(`Boolean.prototype.${name} requires that 'this' be a Boolean.`, node)
+    throw typeError(`Boolean.prototype.${name} requires that 'this' be a Boolean.`)
   }
   methods(protos, protos.Boolean, [
-    ["toString", 0, (thisValue, _, node) => String(self(thisValue, "toString", node))],
-    ["valueOf", 0, (thisValue, _, node) => self(thisValue, "valueOf", node)],
+    ["toString", 0, (thisValue) => String(self(thisValue, "toString"))],
+    ["valueOf", 0, (thisValue) => self(thisValue, "valueOf")],
   ])
   return boolean
 }

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -4,9 +4,10 @@ import { constructor, methods, receiver } from "../interpreter/native.js"
 import {
   type AstNode,
   AsyncIteratorSymbol,
-  InterpreterRuntimeError,
+  invalidData,
   IteratorSymbol,
   rangeError,
+  typeError,
 } from "../interpreter/model.js"
 import {
   Callable,
@@ -34,22 +35,22 @@ import { groupBy } from "./collections.js"
 import { coerceToString } from "./value.js"
 
 // ToObject for enumeration.
-export const enumerableSource = <R>(runner: Runner<R>, label: string, value: unknown, node: AstNode): ProgramObject => {
+export const enumerableSource = <R>(
+  runner: Runner<R>,
+  label: string,
+  value: unknown,
+  node?: AstNode,
+): ProgramObject => {
   if (value === null || value === undefined) {
-    throw new InterpreterRuntimeError(`${label} cannot convert ${describeValue(value)} to an object.`, node)
+    throw typeError(`${label} cannot convert ${describeValue(value)} to an object.`, node)
   }
   if (value instanceof ProgramPromise) {
-    throw new InterpreterRuntimeError(
-      `${label} received an un-awaited Promise; await it before inspecting the result.`,
-      node,
-      "InvalidDataValue",
-    )
+    throw invalidData(`${label} received an un-awaited Promise; await it before inspecting the result.`, node)
   }
   if (value instanceof ToolReference) {
-    throw new InterpreterRuntimeError(
+    throw invalidData(
       `${label} cannot read tool references: they are not plain data. Use Object.keys(tools) for names, or search({ query }) for signatures.`,
       node,
-      "InvalidDataValue",
     )
   }
   if (typeof value === "string") return new ProgramArray(runner.prototypes.Array, [...value])
@@ -57,40 +58,33 @@ export const enumerableSource = <R>(runner: Runner<R>, label: string, value: unk
   return new ProgramObject(runner.prototypes.Object)
 }
 
-export const objectAssign = <R>(runner: Runner<R>, args: Array<unknown>, node: AstNode): unknown => {
+export const objectAssign = <R>(runner: Runner<R>, args: Array<unknown>): unknown => {
   const target = args[0]
   // JS would box a primitive target; wrappers and primitives cannot hold fields here.
   if (!(target instanceof ProgramObject)) {
-    throw new InterpreterRuntimeError(
-      `Object.assign expects a data object or array target, received ${describeValue(target)}.`,
-      node,
-    )
+    throw typeError(`Object.assign expects a data object or array target, received ${describeValue(target)}.`)
   }
   const seen = new Set<object>()
   for (const source of args.slice(1)) {
     if (source === null || source === undefined) continue
-    const from = enumerableSource(runner, "Object.assign(...)", source, node)
+    const from = enumerableSource(runner, "Object.assign(...)", source)
     for (const key of enumerableKeys(from)) {
-      rejectCircularInsertion(target, getOwn(from, key), "Object.assign result", node, seen)
+      rejectCircularInsertion(target, getOwn(from, key), "Object.assign result", seen)
       if (!set(target, key, getOwn(from, key))) {
-        if (target instanceof ProgramArray && key === "length") throw rangeError("Invalid array length", node)
-        throw new InterpreterRuntimeError(`Cannot assign to read only property '${String(key)}'.`, node)
+        if (target instanceof ProgramArray && key === "length") throw rangeError("Invalid array length")
+        throw typeError(`Cannot assign to read only property '${String(key)}'.`)
       }
     }
   }
   return target
 }
 
-const objectFromEntries = <R>(
-  runner: Runner<R>,
-  source: unknown,
-  node: AstNode,
-): Effect.Effect<ProgramObject, unknown, R> => {
+const objectFromEntries = <R>(runner: Runner<R>, source: unknown): Effect.Effect<ProgramObject, unknown, R> => {
   const out = new ProgramObject(runner.prototypes.Object)
   return Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(source, node)
+    const cursor = yield* runner.syncIterator(source)
     if (cursor === undefined) {
-      throw new InterpreterRuntimeError("Object.fromEntries expects a synchronous iterable of entries.", node)
+      throw typeError("Object.fromEntries expects a synchronous iterable of entries.")
     }
     while (true) {
       const step = yield* cursor.next
@@ -99,7 +93,7 @@ const objectFromEntries = <R>(
         cursor,
         Effect.sync(() => {
           if (!(step.value instanceof ProgramObject) || containsOpaqueReference(step.value)) {
-            throw new InterpreterRuntimeError("Object.fromEntries expects [key, value] entry objects.", node)
+            throw typeError("Object.fromEntries expects [key, value] entry objects.")
           }
           define(out, coerceToString(getOwn(step.value, 0)), getOwn(step.value, 1))
         }),
@@ -132,91 +126,83 @@ export const objectGlobal = <R>(
   toolKeys: (path: ReadonlyArray<string>) => ReadonlyArray<string>,
 ) => {
   const protos = runner.prototypes
-  const construct = (args: Array<unknown>, node: AstNode): unknown => {
+  const construct = (args: Array<unknown>): unknown => {
     const first = args[0]
     if (first === null || first === undefined) return new ProgramObject(protos.Object)
     if (typeof first === "object") return first
-    throw new InterpreterRuntimeError(
-      `Object(${typeof first}) wrapper objects are not supported; use the primitive value directly.`,
-      node,
-    )
+    throw typeError(`Object(${typeof first}) wrapper objects are not supported; use the primitive value directly.`)
   }
   const object = constructor<R>(protos, protos.Object, {
     name: "Object",
     length: 1,
-    call: (_, args, node) => Effect.sync(() => construct(args, node)),
-    construct: (args, _, node) => Effect.sync(() => construct(args, node)),
+    call: (_, args) => Effect.sync(() => construct(args)),
+    construct: (args) => Effect.sync(() => construct(args)),
   })
   methods(protos, object, [
     [
       "keys",
       1,
-      (_, args, node) =>
+      (_, args) =>
         toProgram(
           protos,
           args[0] instanceof ToolReference
             ? [...toolKeys(args[0].path)]
-            : keys(enumerableSource(runner, "Object.keys(...)", args[0], node)),
+            : keys(enumerableSource(runner, "Object.keys(...)", args[0])),
           "Object.keys result",
         ),
     ],
     [
       "values",
       1,
-      (_, args, node) =>
+      (_, args) =>
         new ProgramArray(
           protos.Array,
-          entries(enumerableSource(runner, "Object.values(...)", args[0], node)).map((entry) => entry[1]),
+          entries(enumerableSource(runner, "Object.values(...)", args[0])).map((entry) => entry[1]),
         ),
     ],
     [
       "entries",
       1,
-      (_, args, node) =>
+      (_, args) =>
         new ProgramArray(
           protos.Array,
-          entries(enumerableSource(runner, "Object.entries(...)", args[0], node)).map(
+          entries(enumerableSource(runner, "Object.entries(...)", args[0])).map(
             (entry) => new ProgramArray(protos.Array, entry),
           ),
         ),
     ],
-    [
-      "hasOwn",
-      2,
-      (_, args, node) => hasOwn(enumerableSource(runner, "Object.hasOwn(...)", args[0], node), propertyKey(args[1])),
-    ],
+    ["hasOwn", 2, (_, args) => hasOwn(enumerableSource(runner, "Object.hasOwn(...)", args[0]), propertyKey(args[1]))],
     [
       "is",
       2,
-      (_, args, node) => {
+      (_, args) => {
         if (containsOpaqueReference(args[0]) || containsOpaqueReference(args[1])) {
-          throw new InterpreterRuntimeError("Object.is requires data values.", node, "InvalidDataValue")
+          throw invalidData("Object.is requires data values.")
         }
         return Object.is(args[0], args[1])
       },
     ],
-    ["assign", 2, (_, args, node) => objectAssign(runner, args, node)],
-    ["fromEntries", 1, (_, args, node) => objectFromEntries(runner, args[0], node)],
+    ["assign", 2, (_, args) => objectAssign(runner, args)],
+    ["fromEntries", 1, (_, args) => objectFromEntries(runner, args[0])],
   ])
   define(object, "groupBy", groupBy(runner, "Object"), hidden)
   methods(protos, protos.Object, [
     [
       "hasOwnProperty",
       1,
-      (thisValue, args, node) =>
-        hasOwn(receiver(ProgramObject, thisValue, "Object.prototype.hasOwnProperty", node), propertyKey(args[0])),
+      (thisValue, args) =>
+        hasOwn(receiver(ProgramObject, thisValue, "Object.prototype.hasOwnProperty"), propertyKey(args[0])),
     ],
     [
       "isPrototypeOf",
       1,
-      (thisValue, args, node) =>
-        hasPrototype(args[0], receiver(ProgramObject, thisValue, "Object.prototype.isPrototypeOf", node)),
+      (thisValue, args) => hasPrototype(args[0], receiver(ProgramObject, thisValue, "Object.prototype.isPrototypeOf")),
     ],
     [
       "propertyIsEnumerable",
       1,
-      (thisValue, args, node) =>
-        own(receiver(ProgramObject, thisValue, "Object.prototype.propertyIsEnumerable", node), propertyKey(args[0]))
+      (thisValue, args) =>
+        own(receiver(ProgramObject, thisValue, "Object.prototype.propertyIsEnumerable"), propertyKey(args[0]))
           ?.enumerable === true,
     ],
     ["toString", 0, (thisValue) => `[object ${classTag(thisValue)}]`],
@@ -224,9 +210,9 @@ export const objectGlobal = <R>(
     [
       "valueOf",
       0,
-      (thisValue, _, node) => {
+      (thisValue) => {
         if (thisValue === null || thisValue === undefined) {
-          throw new InterpreterRuntimeError("Object.prototype.valueOf called on null or undefined.", node)
+          throw typeError("Object.prototype.valueOf called on null or undefined.")
         }
         return thisValue
       },

--- a/packages/codemode/src/stdlib/regexp.ts
+++ b/packages/codemode/src/stdlib/regexp.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import type { Prototypes } from "../interpreter/intrinsics.js"
 import { constructor, type Method, methods, prototypeFrom, receiver } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError, syntaxError } from "../interpreter/model.js"
+import { syntaxError, typeError } from "../interpreter/model.js"
 import {
   define,
   defineAccessor,
@@ -32,7 +32,7 @@ const regexFailureReason = (error: unknown): string =>
 const escapeRegexHint =
   'To match special characters like ( ) [ ] { } + * ? . literally, escape them with a backslash (e.g. "\\\\(") or test for them with String.includes instead.'
 
-export const toHostRegex = (arg: unknown, method: string, node: AstNode, extraFlags = ""): RegExp => {
+export const toHostRegex = (arg: unknown, method: string, extraFlags = ""): RegExp => {
   // Native parity: an undefined pattern behaves as an empty pattern.
   if (arg === undefined) return new RegExp("", extraFlags)
   if (arg instanceof ProgramRegExp) return arg.regex
@@ -42,13 +42,11 @@ export const toHostRegex = (arg: unknown, method: string, node: AstNode, extraFl
     } catch (error) {
       throw syntaxError(
         `String.${method} received the string ${JSON.stringify(arg)}, which is not a valid regular expression pattern (${regexFailureReason(error)}). ${escapeRegexHint}`,
-        node,
       )
     }
   }
-  throw new InterpreterRuntimeError(
+  throw typeError(
     `String.${method} expects a regular expression (a /pattern/flags literal or new RegExp(...)) or a string pattern, not ${arg === null ? "null" : typeof arg}.`,
-    node,
   )
 }
 
@@ -67,7 +65,6 @@ export const matchToValue = (protos: Prototypes, match: RegExpMatchArray): Progr
 export const constructRegExp = (
   protos: Prototypes,
   args: Array<unknown>,
-  node: AstNode,
   proto: ProgramObject = protos.RegExp,
 ): ProgramRegExp => {
   const first = args[0]
@@ -76,7 +73,6 @@ export const constructRegExp = (
   if (flagsArg !== undefined && typeof flagsArg !== "string") {
     throw syntaxError(
       `RegExp flags must be a string of flag characters (e.g. "g", "gi"), not ${flagsArg === null ? "null" : typeof flagsArg}.`,
-      node,
     )
   }
   const flags = flagsArg ?? (first instanceof ProgramRegExp ? first.regex.flags : "")
@@ -88,7 +84,6 @@ export const constructRegExp = (
       /flag/i.test(reason)
         ? `new RegExp(...) received invalid flags ${JSON.stringify(flags)} (${reason}). Valid flags are d, g, i, m, s, u, v, and y.`
         : `new RegExp(...) received ${JSON.stringify(pattern)}, which is not a valid regular expression pattern (${reason}). ${escapeRegexHint}`,
-      node,
     )
   }
 }
@@ -106,23 +101,21 @@ export const regexpGlobal = <R>(runner: Runner<R>) => {
   const regexp = constructor<R>(protos, proto, {
     name: "RegExp",
     length: 2,
-    call: (_, args, node) => Effect.sync(() => constructRegExp(protos, args, node)),
-    construct: (args, newTarget, node) =>
-      Effect.sync(() => constructRegExp(protos, args, node, prototypeFrom(newTarget, proto))),
+    call: (_, args) => Effect.sync(() => constructRegExp(protos, args)),
+    construct: (args, newTarget) => Effect.sync(() => constructRegExp(protos, args, prototypeFrom(newTarget, proto))),
   })
   methods(protos, regexp, [
     [
       "escape",
       1,
-      (_, args, node) => {
-        if (typeof args[0] !== "string") throw new InterpreterRuntimeError("RegExp.escape expects a string.", node)
+      (_, args) => {
+        if (typeof args[0] !== "string") throw typeError("RegExp.escape expects a string.")
         return RegExp.escape(args[0])
       },
     ],
   ])
 
-  const self = (thisValue: unknown, name: string, node?: AstNode) =>
-    receiver(ProgramRegExp, thisValue, `RegExp.prototype.${name}`, node)
+  const self = (thisValue: unknown, name: string) => receiver(ProgramRegExp, thisValue, `RegExp.prototype.${name}`)
   defineAccessor(proto, "source", (thisValue) => self(thisValue, "source").regex.source)
   defineAccessor(proto, "flags", (thisValue) => self(thisValue, "flags").regex.flags)
   for (const name of flagProperties) defineAccessor(proto, name, (thisValue) => self(thisValue, name).regex[name])
@@ -130,8 +123,8 @@ export const regexpGlobal = <R>(runner: Runner<R>) => {
   const run = (name: "exec" | "test"): Method => [
     name,
     1,
-    (thisValue, args, node) => {
-      const value = self(thisValue, name, node)
+    (thisValue, args) => {
+      const value = self(thisValue, name)
       const input = coerceToString(args[0])
       const stateful = value.regex.global || value.regex.sticky
       value.regex.lastIndex = toLength(getOwn(value, "lastIndex"))
@@ -144,7 +137,7 @@ export const regexpGlobal = <R>(runner: Runner<R>) => {
   methods(protos, proto, [
     run("exec"),
     run("test"),
-    ["toString", 0, (thisValue, _, node) => coerceToString(self(thisValue, "toString", node))],
+    ["toString", 0, (thisValue) => coerceToString(self(thisValue, "toString"))],
   ])
   return regexp
 }

--- a/packages/codemode/src/stdlib/string.ts
+++ b/packages/codemode/src/stdlib/string.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { toProgram } from "../data.js"
 import { constructor, type Method, methods } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError, rangeError } from "../interpreter/model.js"
+import { invalidData, rangeError, typeError } from "../interpreter/model.js"
 import { ProgramArray, ProgramPromise, ProgramRegExp, record } from "../interpreter/objects.js"
 import { containsOpaqueReference, typeofValue } from "../interpreter/references.js"
 import { applyCollectionCallback, isSupportedCallback, type Runner } from "../interpreter/runner.js"
@@ -9,22 +9,17 @@ import { matchToValue, toHostRegex } from "./regexp.js"
 import { coerceToNumber, coerceToString, coercion } from "./value.js"
 
 // console is intercepted by the interpreter before reaching here.
-const requireDataArgument = (name: string, index: number, arg: unknown, node: AstNode): unknown => {
+const requireDataArgument = (name: string, index: number, arg: unknown): unknown => {
   if (containsOpaqueReference(arg)) {
-    throw new InterpreterRuntimeError(
-      `String.${name} expects argument ${index + 1} to be a data value.`,
-      node,
-      "InvalidDataValue",
-    )
+    throw invalidData(`String.${name} expects argument ${index + 1} to be a data value.`)
   }
   return arg
 }
 
-const replaceAllNeedsGlobal = (pattern: RegExp, node: AstNode) => {
+const replaceAllNeedsGlobal = (pattern: RegExp) => {
   if (!pattern.global) {
-    throw new InterpreterRuntimeError(
+    throw typeError(
       `String.replaceAll requires a regular expression with the global (g) flag: write /${pattern.source}/${pattern.flags}g, or use String.replace to replace only the first match.`,
-      node,
     )
   }
 }
@@ -34,10 +29,9 @@ const replaceWithCallback = <R>(
   value: string,
   name: "replace" | "replaceAll",
   args: Array<unknown>,
-  node: AstNode,
 ): Effect.Effect<unknown, unknown, R> => {
   const protos = runner.prototypes
-  const apply = applyCollectionCallback(runner, args[1], `String.${name}`, node)
+  const apply = applyCollectionCallback(runner, args[1], `String.${name}`)
   const matches: Array<{ readonly match: string; readonly offset: number; readonly args: Array<unknown> }> = []
   const collect = (...callbackArgs: Array<unknown>): string => {
     const match = callbackArgs[0]
@@ -45,7 +39,7 @@ const replaceWithCallback = <R>(
     const hasGroups = groups !== null && typeof groups === "object"
     const offset = callbackArgs[callbackArgs.length - (hasGroups ? 3 : 2)]
     if (typeof match !== "string" || typeof offset !== "number") {
-      throw new InterpreterRuntimeError(`String.${name} produced an invalid replacement match.`, node)
+      throw typeError(`String.${name} produced an invalid replacement match.`)
     }
     if (hasGroups) callbackArgs[callbackArgs.length - 1] = record(protos.Object, groups as Record<string, unknown>)
     matches.push({ match, offset, args: callbackArgs })
@@ -54,11 +48,11 @@ const replaceWithCallback = <R>(
 
   const pattern = args[0]
   if (pattern instanceof ProgramRegExp) {
-    if (name === "replaceAll") replaceAllNeedsGlobal(pattern.regex, node)
+    if (name === "replaceAll") replaceAllNeedsGlobal(pattern.regex)
     if (name === "replace") value.replace(pattern.regex, collect)
     else value.replaceAll(pattern.regex, collect)
   } else {
-    const search = coerceToString(requireDataArgument(name, 0, pattern, node))
+    const search = coerceToString(requireDataArgument(name, 0, pattern))
     if (name === "replace") value.replace(search, collect)
     else value.replaceAll(search, collect)
   }
@@ -91,11 +85,11 @@ export const stringGlobal = <R>(runner: Runner<R>) => {
   const codeUnits = (name: string, op: (...codes: Array<number>) => string): Method => [
     name,
     1,
-    (_, args, node) =>
+    (_, args) =>
       op(
         ...args.map((arg) => {
           if (typeof arg !== "number") {
-            throw new InterpreterRuntimeError(`String.${name} expects number arguments.`, node)
+            throw typeError(`String.${name} expects number arguments.`)
           }
           return arg
         }),
@@ -106,52 +100,50 @@ export const stringGlobal = <R>(runner: Runner<R>) => {
     codeUnits("fromCodePoint", String.fromCodePoint),
   ])
 
-  const self = (thisValue: unknown, name: string, node: AstNode): string => {
+  const self = (thisValue: unknown, name: string): string => {
     if (typeof thisValue === "string") return thisValue
     if (thisValue === null || thisValue === undefined) {
-      throw new InterpreterRuntimeError(`String.prototype.${name} called on null or undefined.`, node)
+      throw typeError(`String.prototype.${name} called on null or undefined.`)
     }
     return coerceToString(thisValue)
   }
   // Coerce arguments like native JS; opaque runtime references still reject.
-  const str = (name: string, args: Array<unknown>, index: number, node: AstNode): string =>
-    coerceToString(requireDataArgument(name, index, args[index], node))
-  const num = (name: string, args: Array<unknown>, index: number, node: AstNode): number =>
-    coerceToNumber(requireDataArgument(name, index, args[index], node))
-  const optNum = (name: string, args: Array<unknown>, index: number, node: AstNode): number | undefined =>
-    args[index] === undefined ? undefined : num(name, args, index, node)
-  const optStr = (name: string, args: Array<unknown>, index: number, node: AstNode): string | undefined =>
-    args[index] === undefined ? undefined : str(name, args, index, node)
-  const rejectRegex = (name: string, args: Array<unknown>, node: AstNode): void => {
+  const str = (name: string, args: Array<unknown>, index: number): string =>
+    coerceToString(requireDataArgument(name, index, args[index]))
+  const num = (name: string, args: Array<unknown>, index: number): number =>
+    coerceToNumber(requireDataArgument(name, index, args[index]))
+  const optNum = (name: string, args: Array<unknown>, index: number): number | undefined =>
+    args[index] === undefined ? undefined : num(name, args, index)
+  const optStr = (name: string, args: Array<unknown>, index: number): string | undefined =>
+    args[index] === undefined ? undefined : str(name, args, index)
+  const rejectRegex = (name: string, args: Array<unknown>): void => {
     if (args[0] instanceof ProgramRegExp) {
-      throw new InterpreterRuntimeError(
+      throw typeError(
         `String.${name} cannot take a regular expression; use regex.test(string) or String.search instead.`,
-        node,
       )
     }
   }
-  const simple = (
-    name: string,
-    length: number,
-    op: (value: string, args: Array<unknown>, node: AstNode) => unknown,
-  ): Method => [name, length, (thisValue, args, node) => op(self(thisValue, name, node), args, node)]
+  const simple = (name: string, length: number, op: (value: string, args: Array<unknown>) => unknown): Method => [
+    name,
+    length,
+    (thisValue, args) => op(self(thisValue, name), args),
+  ]
   const replace = (name: "replace" | "replaceAll") =>
-    simple(name, 2, (value, args, node) => {
-      if (isSupportedCallback(args[1])) return replaceWithCallback(runner, value, name, args, node)
+    simple(name, 2, (value, args) => {
+      if (isSupportedCallback(args[1])) return replaceWithCallback(runner, value, name, args)
       if (typeofValue(args[1]) === "function") {
-        throw new InterpreterRuntimeError(
+        throw typeError(
           `String.${name} cannot use this callable as a replacer; wrap it in an arrow function, e.g. (match) => tools.ns.tool(match).`,
-          node,
         )
       }
       if (args[0] instanceof ProgramRegExp) {
         const pattern = args[0].regex
-        const replacement = str(name, args, 1, node)
-        if (name === "replaceAll") replaceAllNeedsGlobal(pattern, node)
+        const replacement = str(name, args, 1)
+        if (name === "replaceAll") replaceAllNeedsGlobal(pattern)
         return name === "replace" ? value.replace(pattern, replacement) : value.replaceAll(pattern, replacement)
       }
-      if (name === "replace") return value.replace(str(name, args, 0, node), str(name, args, 1, node))
-      return value.replaceAll(str(name, args, 0, node), str(name, args, 1, node))
+      if (name === "replace") return value.replace(str(name, args, 0), str(name, args, 1))
+      return value.replaceAll(str(name, args, 0), str(name, args, 1))
     })
 
   methods(protos, protos.String, [
@@ -165,68 +157,60 @@ export const stringGlobal = <R>(runner: Runner<R>) => {
     simple("trimEnd", 0, (value) => value.trimEnd()),
     simple("trimRight", 0, (value) => value.trimEnd()),
     // Locale/options are deliberately unsupported; comparison uses the host default locale.
-    simple("localeCompare", 1, (value, args, node) => value.localeCompare(str("localeCompare", args, 0, node))),
-    simple("normalize", 0, (value, args, node) => {
-      const form = optStr("normalize", args, 0, node)
+    simple("localeCompare", 1, (value, args) => value.localeCompare(str("localeCompare", args, 0))),
+    simple("normalize", 0, (value, args) => {
+      const form = optStr("normalize", args, 0)
       try {
         return value.normalize(form)
       } catch {
         throw rangeError(
           `String.normalize expects the form "NFC", "NFD", "NFKC", or "NFKD" (got ${JSON.stringify(form)}).`,
-          node,
         )
       }
     }),
-    simple("split", 2, (value, args, node) => {
+    simple("split", 2, (value, args) => {
       const wrap = (parts: Array<string>) => new ProgramArray(protos.Array, parts)
       // Native: an undefined separator returns the whole string, not a split on "undefined",
       // unless the limit truncates to zero.
-      const requestedLimit = optNum("split", args, 1, node)
+      const requestedLimit = optNum("split", args, 1)
       if (args[0] === undefined) {
         return wrap(requestedLimit !== undefined && requestedLimit >>> 0 === 0 ? [] : [value])
       }
       if (args[0] instanceof ProgramRegExp) return wrap(value.split(args[0].regex, requestedLimit))
-      return wrap(
-        value.split(str("split", args, 0, node), requestedLimit === undefined ? undefined : requestedLimit >>> 0),
-      )
+      return wrap(value.split(str("split", args, 0), requestedLimit === undefined ? undefined : requestedLimit >>> 0))
     }),
-    simple("slice", 2, (value, args, node) =>
-      value.slice(optNum("slice", args, 0, node), optNum("slice", args, 1, node)),
-    ),
-    simple("includes", 1, (value, args, node) => {
-      rejectRegex("includes", args, node)
-      return value.includes(str("includes", args, 0, node), optNum("includes", args, 1, node))
+    simple("slice", 2, (value, args) => value.slice(optNum("slice", args, 0), optNum("slice", args, 1))),
+    simple("includes", 1, (value, args) => {
+      rejectRegex("includes", args)
+      return value.includes(str("includes", args, 0), optNum("includes", args, 1))
     }),
-    simple("startsWith", 1, (value, args, node) => {
-      rejectRegex("startsWith", args, node)
-      return value.startsWith(str("startsWith", args, 0, node), optNum("startsWith", args, 1, node))
+    simple("startsWith", 1, (value, args) => {
+      rejectRegex("startsWith", args)
+      return value.startsWith(str("startsWith", args, 0), optNum("startsWith", args, 1))
     }),
-    simple("endsWith", 1, (value, args, node) => {
-      rejectRegex("endsWith", args, node)
-      return value.endsWith(str("endsWith", args, 0, node), optNum("endsWith", args, 1, node))
+    simple("endsWith", 1, (value, args) => {
+      rejectRegex("endsWith", args)
+      return value.endsWith(str("endsWith", args, 0), optNum("endsWith", args, 1))
     }),
-    simple("indexOf", 1, (value, args, node) =>
-      value.indexOf(str("indexOf", args, 0, node), optNum("indexOf", args, 1, node)),
-    ),
-    simple("lastIndexOf", 1, (value, args, node) =>
-      value.lastIndexOf(str("lastIndexOf", args, 0, node), optNum("lastIndexOf", args, 1, node)),
+    simple("indexOf", 1, (value, args) => value.indexOf(str("indexOf", args, 0), optNum("indexOf", args, 1))),
+    simple("lastIndexOf", 1, (value, args) =>
+      value.lastIndexOf(str("lastIndexOf", args, 0), optNum("lastIndexOf", args, 1)),
     ),
     replace("replace"),
     replace("replaceAll"),
-    simple("match", 1, (value, args, node) => {
-      const pattern = toHostRegex(args[0], "match", node)
+    simple("match", 1, (value, args) => {
+      const pattern = toHostRegex(args[0], "match")
       const matched = value.match(pattern)
       if (matched === null) return null
       // Preserve the own `index` and `groups` properties on non-global matches.
       if (pattern.global) return toProgram(protos, matched, "String.match result")
       return matchToValue(protos, matched)
     }),
-    simple("matchAll", 1, (value, args, node) => {
-      const pattern = toHostRegex(args[0], "matchAll", node, "g")
+    simple("matchAll", 1, (value, args) => {
+      const pattern = toHostRegex(args[0], "matchAll", "g")
       if (!pattern.global) {
-        throw new InterpreterRuntimeError(
+        throw typeError(
           `String.matchAll requires a regular expression with the global (g) flag: write /${pattern.source}/${pattern.flags}g, or use String.match for a single match.`,
-          node,
         )
       }
       return new ProgramArray(
@@ -234,35 +218,27 @@ export const stringGlobal = <R>(runner: Runner<R>) => {
         Array.from(value.matchAll(pattern), (match) => matchToValue(protos, match)),
       )
     }),
-    simple("search", 1, (value, args, node) => value.search(toHostRegex(args[0], "search", node))),
-    simple("repeat", 1, (value, args, node) => {
-      const count = num("repeat", args, 0, node)
+    simple("search", 1, (value, args) => value.search(toHostRegex(args[0], "search"))),
+    simple("repeat", 1, (value, args) => {
+      const count = num("repeat", args, 0)
       if (!Number.isFinite(count) || count < 0) {
-        throw rangeError("String.repeat expects a finite non-negative count.", node)
+        throw rangeError("String.repeat expects a finite non-negative count.")
       }
       return value.repeat(count)
     }),
-    simple("padStart", 1, (value, args, node) =>
-      value.padStart(num("padStart", args, 0, node), optStr("padStart", args, 1, node)),
+    simple("padStart", 1, (value, args) => value.padStart(num("padStart", args, 0), optStr("padStart", args, 1))),
+    simple("padEnd", 1, (value, args) => value.padEnd(num("padEnd", args, 0), optStr("padEnd", args, 1))),
+    simple("charAt", 1, (value, args) => value.charAt(optNum("charAt", args, 0) ?? 0)),
+    simple("at", 1, (value, args) => value.at(optNum("at", args, 0) ?? 0)),
+    simple("substring", 2, (value, args) =>
+      value.substring(optNum("substring", args, 0) ?? 0, optNum("substring", args, 1)),
     ),
-    simple("padEnd", 1, (value, args, node) =>
-      value.padEnd(num("padEnd", args, 0, node), optStr("padEnd", args, 1, node)),
-    ),
-    simple("charAt", 1, (value, args, node) => value.charAt(optNum("charAt", args, 0, node) ?? 0)),
-    simple("at", 1, (value, args, node) => value.at(optNum("at", args, 0, node) ?? 0)),
-    simple("substring", 2, (value, args, node) =>
-      value.substring(optNum("substring", args, 0, node) ?? 0, optNum("substring", args, 1, node)),
-    ),
-    simple("substr", 2, (value, args, node) =>
-      value.substr(optNum("substr", args, 0, node) ?? 0, optNum("substr", args, 1, node)),
-    ),
+    simple("substr", 2, (value, args) => value.substr(optNum("substr", args, 0) ?? 0, optNum("substr", args, 1))),
     simple("isWellFormed", 0, (value) => value.isWellFormed()),
     simple("toWellFormed", 0, (value) => value.toWellFormed()),
-    simple("charCodeAt", 1, (value, args, node) => value.charCodeAt(optNum("charCodeAt", args, 0, node) ?? 0)),
-    simple("codePointAt", 1, (value, args, node) => value.codePointAt(optNum("codePointAt", args, 0, node) ?? 0)),
-    simple("concat", 1, (value, args, node) =>
-      value.concat(...args.map((_, index) => str("concat", args, index, node))),
-    ),
+    simple("charCodeAt", 1, (value, args) => value.charCodeAt(optNum("charCodeAt", args, 0) ?? 0)),
+    simple("codePointAt", 1, (value, args) => value.codePointAt(optNum("codePointAt", args, 0) ?? 0)),
+    simple("concat", 1, (value, args) => value.concat(...args.map((_, index) => str("concat", args, index)))),
   ])
   return string
 }

--- a/packages/codemode/src/stdlib/url.ts
+++ b/packages/codemode/src/stdlib/url.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import { toProgram, ToolRuntimeError } from "../data.js"
 import type { Prototypes } from "../interpreter/intrinsics.js"
 import { constructor, fn, type Method, methods, prototypeFrom, receiver, requiresNew } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError, uriError } from "../interpreter/model.js"
+import { PendingThrow, typeError, uriError } from "../interpreter/model.js"
 import {
   defineAccessor,
   entries,
@@ -43,15 +43,12 @@ const uriFunctions: Record<UriFunction, (value: string) => string> = {
 }
 
 export const uriGlobal = <R>(runner: Runner<R>, name: UriFunction) =>
-  fn<R>(runner.prototypes, name, 1, (_, args, node) => {
+  fn<R>(runner.prototypes, name, 1, (_, args) => {
     const value = uriArgument(runner.prototypes, args[0], `${name} input`)
     try {
       return uriFunctions[name](value)
     } catch (error) {
-      throw uriError(
-        `${name} received malformed URI data: ${error instanceof Error ? error.message : String(error)}`,
-        node,
-      )
+      throw uriError(`${name} received malformed URI data: ${error instanceof Error ? error.message : String(error)}`)
     }
   })
 
@@ -61,32 +58,29 @@ const urlArgument = (protos: Prototypes, value: unknown, label: string): string 
 export const urlGlobal = <R>(runner: Runner<R>) => {
   const protos = runner.prototypes
   const proto = protos.URL
-  const construct = (args: Array<unknown>, into: ProgramObject, node: AstNode): ProgramURL => {
+  const construct = (args: Array<unknown>, into: ProgramObject): ProgramURL => {
     if (args.length === 0) {
-      throw new InterpreterRuntimeError("new URL(...) requires a URL string and an optional base URL.", node)
+      throw typeError("new URL(...) requires a URL string and an optional base URL.")
     }
     const input = urlArgument(protos, args[0], "new URL input")
     const base = args[1] === undefined ? undefined : urlArgument(protos, args[1], "new URL base")
     try {
       return new ProgramURL(into, protos.URLSearchParams, new URL(input, base))
     } catch {
-      throw new InterpreterRuntimeError(
-        `new URL(...) received an invalid URL${base === undefined ? "" : " or base URL"}.`,
-        node,
-      )
+      throw typeError(`new URL(...) received an invalid URL${base === undefined ? "" : " or base URL"}.`)
     }
   }
   const url = constructor<R>(protos, proto, {
     name: "URL",
     length: 1,
     call: requiresNew("URL"),
-    construct: (args, newTarget, node) => Effect.sync(() => construct(args, prototypeFrom(newTarget, proto), node)),
+    construct: (args, newTarget) => Effect.sync(() => construct(args, prototypeFrom(newTarget, proto))),
   })
   const parse = (name: "canParse" | "parse"): Method => [
     name,
     1,
-    (_, args, node) => {
-      if (args.length === 0) throw new InterpreterRuntimeError(`URL.${name} requires a URL argument.`, node)
+    (_, args) => {
+      if (args.length === 0) throw typeError(`URL.${name} requires a URL argument.`)
       const input = urlArgument(protos, args[0], `URL.${name} input`)
       const base = args[1] === undefined ? undefined : urlArgument(protos, args[1], `URL.${name} base`)
       try {
@@ -99,8 +93,7 @@ export const urlGlobal = <R>(runner: Runner<R>) => {
   ]
   methods(protos, url, [parse("canParse"), parse("parse")])
 
-  const self = (thisValue: unknown, name: string, node?: AstNode) =>
-    receiver(ProgramURL, thisValue, `URL.prototype.${name}`, node)
+  const self = (thisValue: unknown, name: string) => receiver(ProgramURL, thisValue, `URL.prototype.${name}`)
   for (const name of urlProperties) {
     defineAccessor(
       proto,
@@ -113,25 +106,25 @@ export const urlGlobal = <R>(runner: Runner<R>) => {
             try {
               ;(target.url as unknown as Record<string, string>)[name] = uriArgument(protos, value, `URL.${name} value`)
             } catch (error) {
-              if (error instanceof InterpreterRuntimeError || error instanceof ToolRuntimeError) throw error
-              throw new InterpreterRuntimeError(`URL.${name} received an invalid value.`)
+              if (error instanceof PendingThrow || error instanceof ToolRuntimeError) throw error
+              throw typeError(`URL.${name} received an invalid value.`)
             }
           },
     )
   }
   defineAccessor(proto, "searchParams", (thisValue) => self(thisValue, "searchParams").searchParams)
   methods(protos, proto, [
-    ["toString", 0, (thisValue, _, node) => self(thisValue, "toString", node).url.href],
-    ["toJSON", 0, (thisValue, _, node) => self(thisValue, "toJSON", node).url.href],
+    ["toString", 0, (thisValue) => self(thisValue, "toString").url.href],
+    ["toJSON", 0, (thisValue) => self(thisValue, "toJSON").url.href],
   ])
   return url
 }
 
-const readPair = <R>(runner: Runner<R>, value: unknown, node: AstNode): Effect.Effect<Array<string>, unknown, R> =>
+const readPair = <R>(runner: Runner<R>, value: unknown): Effect.Effect<Array<string>, unknown, R> =>
   Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(value, node)
+    const cursor = yield* runner.syncIterator(value)
     if (cursor === undefined) {
-      throw new InterpreterRuntimeError("new URLSearchParams(...) expects iterable [name, value] pairs.", node)
+      throw typeError("new URLSearchParams(...) expects iterable [name, value] pairs.")
     }
     const items: Array<string> = []
     while (true) {
@@ -150,7 +143,6 @@ const constructURLSearchParams = <R>(
   runner: Runner<R>,
   init: unknown,
   proto: ProgramObject,
-  node: AstNode,
 ): Effect.Effect<ProgramURLSearchParams, unknown, R> => {
   const wrap = (params: URLSearchParams) => new ProgramURLSearchParams(proto, params)
   if (init === undefined) return Effect.succeed(wrap(new URLSearchParams()))
@@ -160,31 +152,27 @@ const constructURLSearchParams = <R>(
     return Effect.succeed(wrap(new URLSearchParams(coerceToString(init))))
   }
   return Effect.gen(function* () {
-    const cursor = yield* runner.syncIterator(init, node)
+    const cursor = yield* runner.syncIterator(init)
     if (cursor !== undefined) {
       const pairs: Array<Array<string>> = []
       while (true) {
         const step = yield* cursor.next
         if (step.done) {
           if (pairs.some((entry) => entry.length !== 2)) {
-            throw new InterpreterRuntimeError("new URLSearchParams(...) expects iterable [name, value] pairs.", node)
+            throw typeError("new URLSearchParams(...) expects iterable [name, value] pairs.")
           }
           return wrap(new URLSearchParams(pairs.map((entry): [string, string] => [entry[0] ?? "", entry[1] ?? ""])))
         }
-        pairs.push(yield* preserveConsumerError(cursor, readPair(runner, step.value, node)))
+        pairs.push(yield* preserveConsumerError(cursor, readPair(runner, step.value)))
       }
     }
     if (isRuntimeReference(init)) {
-      throw new InterpreterRuntimeError(
-        "new URLSearchParams(...) expects a query string, data object, or synchronous iterable pairs.",
-        node,
-      )
+      throw typeError("new URLSearchParams(...) expects a query string, data object, or synchronous iterable pairs.")
     }
     if (isWrapper(init)) return wrap(new URLSearchParams())
     if (!(init instanceof ProgramObject)) {
-      throw new InterpreterRuntimeError(
+      throw typeError(
         "new URLSearchParams(...) expects a query string, data object, iterable pairs, or URLSearchParams.",
-        node,
       )
     }
     return wrap(
@@ -199,20 +187,16 @@ export const urlSearchParamsGlobal = <R>(runner: Runner<R>) => {
   const searchParams = constructor<R>(protos, proto, {
     name: "URLSearchParams",
     call: requiresNew("URLSearchParams"),
-    construct: (args, newTarget, node) =>
-      constructURLSearchParams(runner, args[0], prototypeFrom(newTarget, proto), node),
+    construct: (args, newTarget) => constructURLSearchParams(runner, args[0], prototypeFrom(newTarget, proto)),
   })
-  const self = (thisValue: unknown, name: string, node?: AstNode) =>
-    receiver(ProgramURLSearchParams, thisValue, `URLSearchParams.prototype.${name}`, node)
+  const self = (thisValue: unknown, name: string) =>
+    receiver(ProgramURLSearchParams, thisValue, `URLSearchParams.prototype.${name}`)
   const wrap = (items: Array<unknown>) => new ProgramArray(protos.Array, items)
   const arg = (name: string, args: Array<unknown>, index: number): string =>
     uriArgument(protos, args[index], `URLSearchParams.${name} argument ${index + 1}`)
-  const requireArgs = (name: string, args: Array<unknown>, count: number, node: AstNode): void => {
+  const requireArgs = (name: string, args: Array<unknown>, count: number): void => {
     if (args.length < count) {
-      throw new InterpreterRuntimeError(
-        `URLSearchParams.${name} requires ${count} argument${count === 1 ? "" : "s"}.`,
-        node,
-      )
+      throw typeError(`URLSearchParams.${name} requires ${count} argument${count === 1 ? "" : "s"}.`)
     }
   }
   defineAccessor(proto, "size", (thisValue) => self(thisValue, "size").params.size)
@@ -220,18 +204,18 @@ export const urlSearchParamsGlobal = <R>(runner: Runner<R>) => {
     [
       "append",
       2,
-      (thisValue, args, node) => {
-        requireArgs("append", args, 2, node)
-        self(thisValue, "append", node).params.append(arg("append", args, 0), arg("append", args, 1))
+      (thisValue, args) => {
+        requireArgs("append", args, 2)
+        self(thisValue, "append").params.append(arg("append", args, 0), arg("append", args, 1))
         return undefined
       },
     ],
     [
       "delete",
       1,
-      (thisValue, args, node) => {
-        requireArgs("delete", args, 1, node)
-        const params = self(thisValue, "delete", node).params
+      (thisValue, args) => {
+        requireArgs("delete", args, 1)
+        const params = self(thisValue, "delete").params
         if (args[1] !== undefined) params.delete(arg("delete", args, 0), arg("delete", args, 1))
         else params.delete(arg("delete", args, 0))
         return undefined
@@ -240,25 +224,25 @@ export const urlSearchParamsGlobal = <R>(runner: Runner<R>) => {
     [
       "get",
       1,
-      (thisValue, args, node) => {
-        requireArgs("get", args, 1, node)
-        return self(thisValue, "get", node).params.get(arg("get", args, 0))
+      (thisValue, args) => {
+        requireArgs("get", args, 1)
+        return self(thisValue, "get").params.get(arg("get", args, 0))
       },
     ],
     [
       "getAll",
       1,
-      (thisValue, args, node) => {
-        requireArgs("getAll", args, 1, node)
-        return wrap(self(thisValue, "getAll", node).params.getAll(arg("getAll", args, 0)))
+      (thisValue, args) => {
+        requireArgs("getAll", args, 1)
+        return wrap(self(thisValue, "getAll").params.getAll(arg("getAll", args, 0)))
       },
     ],
     [
       "has",
       1,
-      (thisValue, args, node) => {
-        requireArgs("has", args, 1, node)
-        const params = self(thisValue, "has", node).params
+      (thisValue, args) => {
+        requireArgs("has", args, 1)
+        const params = self(thisValue, "has").params
         return args[1] !== undefined
           ? params.has(arg("has", args, 0), arg("has", args, 1))
           : params.has(arg("has", args, 0))
@@ -267,36 +251,36 @@ export const urlSearchParamsGlobal = <R>(runner: Runner<R>) => {
     [
       "set",
       2,
-      (thisValue, args, node) => {
-        requireArgs("set", args, 2, node)
-        self(thisValue, "set", node).params.set(arg("set", args, 0), arg("set", args, 1))
+      (thisValue, args) => {
+        requireArgs("set", args, 2)
+        self(thisValue, "set").params.set(arg("set", args, 0), arg("set", args, 1))
         return undefined
       },
     ],
     [
       "sort",
       0,
-      (thisValue, _, node) => {
-        self(thisValue, "sort", node).params.sort()
+      (thisValue) => {
+        self(thisValue, "sort").params.sort()
         return undefined
       },
     ],
-    ["keys", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "keys", node).params.keys()))],
-    ["values", 0, (thisValue, _, node) => wrap(Array.from(self(thisValue, "values", node).params.values()))],
+    ["keys", 0, (thisValue) => wrap(Array.from(self(thisValue, "keys").params.keys()))],
+    ["values", 0, (thisValue) => wrap(Array.from(self(thisValue, "values").params.values()))],
     [
       "entries",
       0,
-      (thisValue, _, node) =>
-        wrap(Array.from(self(thisValue, "entries", node).params.entries(), ([key, value]) => wrap([key, value]))),
+      (thisValue) =>
+        wrap(Array.from(self(thisValue, "entries").params.entries(), ([key, value]) => wrap([key, value]))),
     ],
-    ["toString", 0, (thisValue, _, node) => self(thisValue, "toString", node).params.toString()],
+    ["toString", 0, (thisValue) => self(thisValue, "toString").params.toString()],
     [
       "forEach",
       1,
-      (thisValue, args, node) => {
-        requireArgs("forEach", args, 1, node)
-        const target = self(thisValue, "forEach", node)
-        const apply = applyCollectionCallback(runner, args[0], "URLSearchParams.forEach", node)
+      (thisValue, args) => {
+        requireArgs("forEach", args, 1)
+        const target = self(thisValue, "forEach")
+        const apply = applyCollectionCallback(runner, args[0], "URLSearchParams.forEach")
         return Effect.gen(function* () {
           for (const [key, value] of Array.from(target.params.entries())) yield* apply([value, key, target])
           return undefined

--- a/packages/codemode/src/stdlib/value.ts
+++ b/packages/codemode/src/stdlib/value.ts
@@ -1,6 +1,6 @@
 import { toProgram } from "../data.js"
 import { fn } from "../interpreter/native.js"
-import { type AstNode, InterpreterRuntimeError } from "../interpreter/model.js"
+import { typeError } from "../interpreter/model.js"
 import {
   get,
   isWrapper,
@@ -55,7 +55,7 @@ export const coerceToNumber = (value: unknown): number => {
 
 export type Coercion = "Number" | "String" | "Boolean" | "parseInt" | "parseFloat" | "isFinite" | "isNaN"
 
-const coerce = <R>(runner: Runner<R>, name: Coercion, args: Array<unknown>, node: AstNode): unknown => {
+const coerce = <R>(runner: Runner<R>, name: Coercion, args: Array<unknown>): unknown => {
   // Native: Number() is 0 and String() is "", unlike their undefined-argument forms; the
   // other coercers match native through the undefined-argument path below.
   if (args.length === 0) {
@@ -80,7 +80,7 @@ const coerce = <R>(runner: Runner<R>, name: Coercion, args: Array<unknown>, node
   if (name === "parseInt") {
     const radix = args[1]
     if (radix !== undefined && typeof radix !== "number") {
-      throw new InterpreterRuntimeError("parseInt expects a numeric radix.", node)
+      throw typeError("parseInt expects a numeric radix.")
     }
     return parseInt(coerceToString(value), radix)
   }
@@ -90,6 +90,6 @@ const coerce = <R>(runner: Runner<R>, name: Coercion, args: Array<unknown>, node
 
 /** A global coercion function such as `Number` or `parseInt`. */
 export const coercion = <R>(runner: Runner<R>, name: Coercion, length = 1): NativeFunction<R> =>
-  fn(runner.prototypes, name, length, (_, args, node) =>
-    toProgram(runner.prototypes, coerce(runner, name, args, node), `${name} result`),
+  fn(runner.prototypes, name, length, (_, args) =>
+    toProgram(runner.prototypes, coerce(runner, name, args), `${name} result`),
   )

--- a/packages/codemode/src/stdlib/web.ts
+++ b/packages/codemode/src/stdlib/web.ts
@@ -1,5 +1,5 @@
 import { fn, methods } from "../interpreter/native.js"
-import { InterpreterRuntimeError } from "../interpreter/model.js"
+import { typeError } from "../interpreter/model.js"
 import { ProgramObject } from "../interpreter/objects.js"
 import type { Runner } from "../interpreter/runner.js"
 import { coerceToString } from "./value.js"
@@ -7,13 +7,13 @@ import { coerceToString } from "./value.js"
 // WebIDL DOMString conversion: a missing argument is a TypeError, anything else stringifies. Invalid input is a
 // TypeError as well; browsers throw a DOMException named InvalidCharacterError, which CodeMode does not have.
 export const base64Global = <R>(runner: Runner<R>, name: "atob" | "btoa") =>
-  fn<R>(runner.prototypes, name, 1, (_, args, node) => {
-    if (args.length === 0) throw new InterpreterRuntimeError(`${name} requires 1 argument (a string)`, node)
+  fn<R>(runner.prototypes, name, 1, (_, args) => {
+    if (args.length === 0) throw typeError(`${name} requires 1 argument (a string)`)
     const input = coerceToString(args[0])
     try {
       return name === "atob" ? atob(input) : btoa(input)
     } catch {
-      throw new InterpreterRuntimeError("The string contains invalid characters.", node)
+      throw typeError("The string contains invalid characters.")
     }
   })
 

--- a/packages/codemode/test/codemode.test.ts
+++ b/packages/codemode/test/codemode.test.ts
@@ -347,7 +347,7 @@ describe("CodeMode console capture", () => {
     )
 
     expect(result.ok ? undefined : result.logs).toStrictEqual(["before failure"])
-    expect(result.ok ? undefined : result.error.message).toBe("Uncaught: boom")
+    expect(result.ok ? undefined : result.error.message).toBe("Error: boom")
   })
 
   test("prints NaN and Infinity literally instead of the JSON null", async () => {

--- a/packages/codemode/test/errors.test.ts
+++ b/packages/codemode/test/errors.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { CodeMode } from "../src/index.js"
+
+// One failure is one program error object, and rethrowing it keeps the diagnostic it started with.
+const run = (code: string) => Effect.runPromise(CodeMode.execute({ code, tools: {} }))
+const value = async (code: string) => {
+  const result = await run(code)
+  if (!result.ok) throw new Error(`expected success, got ${result.error.kind}: ${result.error.message}`)
+  return result.value
+}
+const error = async (code: string) => {
+  const result = await run(code)
+  if (result.ok) throw new Error(`expected failure, got value ${JSON.stringify(result.value)}`)
+  return result.error
+}
+
+describe("error identity", () => {
+  test("awaiting the same rejected promise twice yields the same error object", async () => {
+    expect(
+      await value(`
+        const fail = async () => { null.foo }
+        const p = fail()
+        const a = await p.catch((e) => e)
+        try { await p } catch (b) { return a === b }
+      `),
+    ).toBe(true)
+  })
+
+  test("allSettled reasons for the same failure are identical", async () => {
+    expect(
+      await value(`
+        const fail = async () => { null.foo }
+        const p = fail()
+        const [a, b] = await Promise.allSettled([p, p])
+        return [a.reason === b.reason, a.reason.name, a.reason.message]
+      `),
+    ).toEqual([true, "TypeError", "Cannot read properties of null (reading 'foo')."])
+  })
+
+  test("Promise.any collects the same object a direct catch would", async () => {
+    expect(
+      await value(`
+        const fail = async () => { null.foo }
+        const p = fail()
+        const direct = await p.catch((e) => e)
+        try { await Promise.any([p]) } catch (aggregate) { return aggregate.errors[0] === direct }
+      `),
+    ).toBe(true)
+  })
+})
+
+describe("rethrown interpreter failures", () => {
+  test("keep their diagnostic kind and source location", async () => {
+    const failure = await error(`try { switch (Symbol) {} } catch (e) { throw e }`)
+    expect(failure.kind).toBe("InvalidDataValue")
+    expect(failure.message).toStartWith("Switch discriminants must be data values. (line ")
+    expect(failure.location).toBeDefined()
+  })
+
+  test("keep their location through a rejection handler", async () => {
+    const direct = await error(`
+      const fail = async () => { null.foo }
+      await fail()
+    `)
+    const rethrown = await error(`
+      const fail = async () => { null.foo }
+      await fail().catch((e) => { throw e })
+    `)
+    expect(direct.location).toBeDefined()
+    expect(rethrown).toEqual(direct)
+  })
+})
+
+describe("uncaught program throws", () => {
+  test("an Error reports as name: message", async () => {
+    const failure = await error(`throw new TypeError("bad input")`)
+    expect(failure).toEqual({ kind: "ExecutionFailure", message: "TypeError: bad input" })
+  })
+
+  test("a custom name is honored", async () => {
+    const failure = await error(`const e = new Error("x"); e.name = "ValidationError"; throw e`)
+    expect(failure.message).toBe("ValidationError: x")
+  })
+
+  test("non-Error values keep the Uncaught prefix", async () => {
+    expect((await error(`throw "boom"`)).message).toBe("Uncaught: boom")
+    expect((await error(`throw { code: 7 }`)).message).toBe('Uncaught: {"code":7}')
+  })
+})
+
+describe("host errors escaping built-ins", () => {
+  test("become the same-named program error", async () => {
+    expect(
+      await value(`
+        try { (1).toFixed(200) } catch (e) { return [e.name, e instanceof RangeError, e.message] }
+      `),
+    ).toEqual(["RangeError", true, "toFixed() argument must be between 0 and 100"])
+  })
+
+  test("report the location of the call that raised them", async () => {
+    const failure = await error(`return [1].map((n) => n.toFixed(200))`)
+    expect(failure.kind).toBe("ExecutionFailure")
+    expect(failure.message).toBe("toFixed() argument must be between 0 and 100 (line 1, col 23)")
+  })
+
+  test("a failure inside a built-in called by another built-in is located at the outer call", async () => {
+    const failure = await error(`return Array.from({ [Symbol.iterator]: () => ({ next: 1 }) })`)
+    expect(failure.message).toBe("Iterator next must be a function. (line 1, col 8)")
+  })
+})

--- a/packages/codemode/test/promise.test.ts
+++ b/packages/codemode/test/promise.test.ts
@@ -330,7 +330,7 @@ describe("first-class promise values", () => {
     if (!result.ok) return
     expect(result.value).toBe("done")
     expect(result.warnings).toStrictEqual([
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: boom" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: boom" },
     ])
   })
 
@@ -363,7 +363,7 @@ describe("first-class promise values", () => {
     expect(result.truncated).toBe(true)
     expect(typeof result.value).toBe("string")
     expect(result.warnings).toStrictEqual([
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: boom" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: boom" },
     ])
   })
 
@@ -399,9 +399,9 @@ describe("first-class promise values", () => {
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.warnings).toStrictEqual([
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: first" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: first" },
       { kind: "ToolFailure", message: "Unhandled rejection from an un-awaited promise: Lookup refused" },
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: third" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: third" },
     ])
   })
 
@@ -417,8 +417,8 @@ describe("first-class promise values", () => {
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.warnings).toStrictEqual([
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: outer" },
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: inner" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: outer" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: inner" },
     ])
   })
 
@@ -445,7 +445,7 @@ describe("first-class promise values", () => {
     )
     expect(result.ok).toBe(false)
     if (result.ok) return
-    expect(result.error.message).toBe("Uncaught: boom")
+    expect(result.error.message).toBe("Error: boom")
     expect("warnings" in result).toBe(false)
     expect(trace.completed).toBe(0)
     expect(trace.interrupted).toBe(1)
@@ -911,7 +911,7 @@ describe("Promise.resolve / Promise.reject", () => {
     if (!result.ok) return
     expect(result.value).toBe("done")
     expect(result.warnings).toStrictEqual([
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: abandoned" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: abandoned" },
     ])
   })
 })
@@ -1068,7 +1068,7 @@ describe("promise chaining", () => {
     expect(result.value).toBe("done")
     // The source rejection belongs to the chain (no warning); only the derived tail warns.
     expect(result.warnings).toStrictEqual([
-      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Uncaught: boom" },
+      { kind: "ExecutionFailure", message: "Unhandled rejection from an un-awaited promise: Error: boom" },
     ])
   })
 

--- a/packages/codemode/test/test262/run.ts
+++ b/packages/codemode/test/test262/run.ts
@@ -3,7 +3,7 @@
 // test262's own assert.js relies on.
 import path from "node:path"
 import { Cause, Effect } from "effect"
-import { caughtErrorValue } from "../../src/interpreter/errors.js"
+import { materialize } from "../../src/interpreter/errors.js"
 import { executeProgram } from "../../src/interpreter/execute.js"
 import type { Host } from "../../src/interpreter/globals.js"
 import { ProgramThrow } from "../../src/interpreter/model.js"
@@ -128,13 +128,13 @@ const harness = <R>(host: Host<R>, onDone: (error: unknown) => void): ReadonlyAr
     [
       "throws",
       3,
-      (_, args, node) => {
+      (_, args) => {
         const expected = args[0] instanceof Callable ? String(get(args[0], "name")) : show(args[0])
-        return host.runner.invokeCallable(args[1], undefined, [], node).pipe(
+        return host.runner.invokeCallable(args[1], undefined, []).pipe(
           Effect.matchCauseEffect({
             onFailure: (cause) => {
               if (cause.reasons.some(Cause.isInterruptReason)) return Effect.failCause(cause)
-              const thrown = caughtErrorValue(host.runner, Cause.squash(cause))
+              const thrown = materialize(host.runner, Cause.squash(cause))
               if (!(thrown instanceof ProgramObject)) return fail(`${prefix(args[2])}Thrown value was not an object!`)
               const actual = get(thrown, "constructor")
               if (actual === args[0]) return Effect.void


### PR DESCRIPTION
Interpreter failures now travel as one `PendingThrow` and become one program `Error` object the first time a handler sees them. Location is attached where the call happened, not where the built-in was written, so built-ins no longer carry an AST node.

## What changes for a program

```diff
 const p = failingAsyncFn()
 const a = await p.catch((e) => e)
 try { await p } catch (b) {
-  a === b   // false: two Error objects for one failure
+  a === b   // true
 }

 try { switch (Symbol) {} } catch (e) { throw e }
-// ExecutionFailure  "Uncaught: Switch discriminants must be data values."
+// InvalidDataValue  "TypeError: Switch discriminants must be data values. (line 1, col 7)"

 null.foo
-// "Cannot read properties of null (reading 'foo'). (line 1, col 1)"
+// "TypeError: Cannot read properties of null (reading 'foo'). (line 1, col 1)"

 throw new TypeError("bad input")
-// "Uncaught: bad input"
+// "TypeError: bad input"

 (1).toFixed(200)
-// Error, no location:  "toFixed() argument must be between 0 and 100"
+// "RangeError: toFixed() argument must be between 0 and 100 (line 1, col 1)"
```

Every uncaught error now reads `name: message`, as `Error.prototype.toString` prints it, whether the interpreter or the program raised it. Non-Error throws keep the prefix: `throw "boom"` → `Uncaught: boom`, `throw { code: 7 }` → `Uncaught: {"code":7}`.

## How a failure travels

```mermaid
flowchart LR
    A["throw typeError(msg)<br/>in a built-in (no node)"] --> B["invokeCallable<br/>catchDefect → locate(defect, callNode)"]
    B --> C{"who observes it?"}
    C -->|"try/catch · .catch · allSettled · any"| D["materialize(runner, thrown)<br/>memoized → one ProgramError<br/>error.host = pending"]
    C -->|"uncaught"| E["normalizeError(pending)<br/>kind · message · location"]
    D -->|"rethrown"| F["normalizeError(value.host)<br/>same diagnostic"]
```

```text
PendingThrow            (model.ts, not an Error)
  type        "TypeError" | "RangeError" | …   what the program catches
  message
  node?       mutable; locate() fills it once, first node wins
  kind        DiagnosticKind, default ExecutionFailure
  suggestions?
  value?      memoized ProgramError

ProgramError            (objects.ts)
  host?       the PendingThrow it came from
```

## Where nodes come from now

```text
Frame.native(body, callNode)                        one wrapper around every built-in call / new
  provideService(CallSite, callNode)                 "the current program call is here"
    catchDefect(suspend(body)) → locate(defect, callNode)

PromiseRuntime.create(effect)                        every promise a built-in forks
  site = CallSite (inherited fiber context)
  forkIn(catchDefect(effect) → locate(defect, site))  rejections born inside get the creating call
```

Failures that pass through program code keep their own, more precise location (first node wins). The `CallSite` context is a fiber-local snapshot, not shared state: sibling calls never see each other's node.

```diff
 evaluateCallExpression
   invokeCallable(callable, thisValue, args, node)
-    native.call(thisValue, args, node)          // every stdlib fn threads node down
+    catchDefect(native.call(thisValue, args))   // attach node on the way out
+      locate(defect, node)                      // also converts leaked host Errors
 evaluateNewExpression
-    native.construct(args, newTarget, node)
+    catchDefect(native.construct(args, newTarget)) → locate
 declarePattern / assignPattern
-    get(value, key)
+    readProperty(value, key, pattern)           // accessors get the pattern's location
```

`Runner.invokeCallable`, `Runner.syncIterator`, `toPrimitive*`, `applyCollectionCallback`, `receiver`, `Impl`, `NativeCall`, `NativeConstruct`, and `ProgramGenerator.request` lose their `node` parameter. The evaluator's own throw sites in `runtime.ts` and `scope.ts` keep their precise nodes.

## Factories

```diff
-new InterpreterRuntimeError(msg, node)
-new InterpreterRuntimeError(msg, node, "InvalidDataValue")
+typeError(msg, node?)
+invalidData(msg, node?)        // TypeError + InvalidDataValue kind (15 sites)
 rangeError / referenceError / syntaxError / uriError (unchanged shape)
```

## Files

```text
src/interpreter/
├── model.ts        PendingThrow, typeError, invalidData
├── errors.ts       locate, materialize (was caughtErrorValue), errorToString, normalizeError
├── objects.ts      ProgramError.host; node-free NativeCall/NativeConstruct
├── runtime.ts      catchDefect at native call/construct; readProperty; drop promiseResolutionNode
├── native.ts · runner.ts · promises.ts · generators.ts · globals.ts · scope.ts · references.ts
src/stdlib/*.ts     node plumbing removed (13 files)
test/errors.test.ts identity, rethrow, uncaught wording, host-error normalization
interpreter-support.md
```

## Behavior notes

- `throw { message: "x" }` uncaught now reports `Uncaught: {"message":"x"}` (was `Uncaught: x`); only real `Error` objects get the `name: message` form.
- Test expectations for `throw new Error("boom")` updated from `Uncaught: boom` to `Error: boom`; interpreter-failure expectations gained their `TypeError: `/`SyntaxError: ` prefix.
- test262 narrow: 3858 pass / 426 skip / 0 fail; wide (28 dirs): 9709 pass / 1335 skip / 0 fail. No change in either skip set — this PR changes how failures are reported to the host, not which error class is thrown.
- `Effect.provideService` on every native call costs ~0.2 µs; a loop of 300k `Math.floor` calls went 742 → 799 ms.
