### PR TITLE
fix(provider): strip reasoning replay for models without interleaved support

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -38,6 +38,24 @@ function isKimiFamily(model: Provider.Model) {
   return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) => url.includes(host))
 }
 
+// These chat-completions SDKs serialize reasoning parts as plain-text body
+// fields (e.g. `reasoning_content`) on assistant history. Unlike signed
+// reasoning transports (Anthropic, OpenAI Responses, Google), these APIs are
+// free to reject replayed reasoning — Cerebras qwen-3.8-27b 400s with
+// "reasoning_content is unsupported", which the retry loop turns into an
+// infinite request loop. models.dev `interleaved` marks models whose API
+// explicitly accepts reasoning fed back in (e.g. DeepSeek); everywhere else
+// on these transports, drop reasoning from history.
+const REASONING_ECHO_TRANSPORTS = new Set([
+  "@ai-sdk/cerebras",
+  "@ai-sdk/openai-compatible",
+  "@ai-sdk/deepinfra",
+  "@ai-sdk/togetherai",
+  "@ai-sdk/deepseek",
+  "ai-gateway-provider",
+  "venice-ai-sdk-provider",
+])
+
 // Maps npm package to the key the AI SDK expects for providerOptions
 function sdkKey(npm: string): string | undefined {
   switch (npm) {
@@ -315,6 +333,19 @@ function normalizeMessages(
           { type: "reasoning" as const, text: "" },
         ],
       }
+    })
+  }
+
+  // Strip reasoning from assistant history on plain-text echo transports when
+  // the model has not declared interleaved reasoning support. A reasoning-only
+  // assistant turn carries no replayable state on these APIs, so drop it
+  // entirely rather than emit an empty message.
+  if (!model.capabilities.interleaved && REASONING_ECHO_TRANSPORTS.has(model.api.npm)) {
+    msgs = msgs.flatMap((msg) => {
+      if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
+      const content = msg.content.filter((part) => part.type !== "reasoning")
+      if (content.length === 0) return []
+      return [{ ...msg, content }]
     })
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2325,7 +2325,9 @@ describe("ProviderTransform.message - surrogate sanitization", () => {
     api: {
       id: "test-model",
       url: "https://api.test.com",
-      npm: "@ai-sdk/openai-compatible",
+      // Use a signed-reasoning transport: plain-text echo transports now strip
+      // reasoning before the model ever sees it (see "reasoning echo" tests).
+      npm: "@ai-sdk/openai",
     },
     name: "Test Model",
     capabilities: {
@@ -6207,5 +6209,160 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
     }
     const result = ProviderTransform.options({ model, sessionID: "s1", providerOptions: {} })
     expect(result.thinking).toBeUndefined()
+  })
+})
+
+describe("ProviderTransform.message - reasoning echo", () => {
+  const createModel = (overrides: Record<string, any> = {}) =>
+    ({
+      id: "cerebras/qwen-3.8-27b",
+      providerID: "cerebras",
+      api: {
+        id: "qwen-3.8-27b",
+        url: "https://api.cerebras.ai/v1",
+        npm: "@ai-sdk/cerebras",
+      },
+      name: "Qwen3.8 27B",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 262128, output: 65536 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2026-08-14",
+      ...overrides,
+    }) as any
+
+  const reasoningTurn: ModelMessage[] = [
+    { role: "user", content: "Remember the word pineapple. Reply with just: OK" },
+    {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: 'The user asked me to remember "pineapple".' },
+        { type: "text", text: "OK" },
+      ],
+    },
+    { role: "user", content: "What word did I ask you to remember?" },
+  ]
+
+  test("strips reasoning from assistant history for cerebras models without interleaved support", () => {
+    const result = ProviderTransform.message(reasoningTurn, createModel(), {})
+    expect(result).toStrictEqual([
+      { role: "user", content: "Remember the word pineapple. Reply with just: OK" },
+      { role: "assistant", content: [{ type: "text", text: "OK" }] },
+      { role: "user", content: "What word did I ask you to remember?" },
+    ])
+  })
+
+  test("drops reasoning-only assistant messages instead of emitting empty content", () => {
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: [{ type: "reasoning", text: "thinking" }] },
+        { role: "user", content: "are you there?" },
+      ],
+      createModel(),
+      {},
+    )
+    expect(result).toStrictEqual([
+      { role: "user", content: "hi" },
+      { role: "user", content: "are you there?" },
+    ])
+  })
+
+  test("keeps tool calls while stripping reasoning", () => {
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "run ls" },
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "I should list files" },
+            { type: "tool-call", toolCallId: "call_1", toolName: "bash", input: { command: "ls" } },
+          ],
+        },
+        {
+          role: "tool",
+          content: [{ type: "tool-result", toolCallId: "call_1", toolName: "bash", output: { type: "text", value: "ok" } }],
+        },
+      ],
+      createModel(),
+      {},
+    )
+    expect(result[1]).toStrictEqual({
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "call_1", toolName: "bash", input: { command: "ls" } }],
+    })
+    expect(result).toHaveLength(3)
+  })
+
+  test("applies to every plain-text echo transport", () => {
+    for (const npm of [
+      "@ai-sdk/cerebras",
+      "@ai-sdk/openai-compatible",
+      "@ai-sdk/deepinfra",
+      "@ai-sdk/togetherai",
+      "@ai-sdk/deepseek",
+      "ai-gateway-provider",
+      "venice-ai-sdk-provider",
+    ]) {
+      const model = createModel({ providerID: "custom", api: { id: "some-model", url: "https://example.com", npm } })
+      const result = ProviderTransform.message(reasoningTurn, model, {})
+      const assistant = result[1] as Extract<ModelMessage, { role: "assistant" }>
+      if (!Array.isArray(assistant.content)) throw new Error("expected array content")
+      expect(assistant.content.some((part) => part.type === "reasoning")).toBe(false)
+      expect(assistant.content).toHaveLength(1)
+      expect(assistant.content[0]).toMatchObject({ type: "text", text: "OK" })
+    }
+  })
+
+  test("preserves reasoning when the model declares interleaved support", () => {
+    const model = createModel({
+      providerID: "deepseek",
+      api: { id: "deepseek-v4-flash-0731", url: "https://api.deepseek.com/v1", npm: "@ai-sdk/deepseek" },
+      capabilities: {
+        ...createModel().capabilities,
+        interleaved: { field: "reasoning_content" },
+      },
+    })
+    const result = ProviderTransform.message(reasoningTurn, model, {})
+    const assistant = result[1] as Extract<ModelMessage, { role: "assistant" }>
+    expect(assistant.providerOptions?.openaiCompatible?.reasoning_content).toBe(
+      'The user asked me to remember "pineapple".',
+    )
+    expect(assistant.content).toStrictEqual([{ type: "text", text: "OK" }])
+  })
+
+  test("leaves signed reasoning transports untouched", () => {
+    const model = createModel({
+      providerID: "anthropic",
+      api: { id: "claude-sonnet-4-5", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
+    })
+    const result = ProviderTransform.message(reasoningTurn, model, {})
+    const assistant = result[1] as Extract<ModelMessage, { role: "assistant" }>
+    expect(Array.isArray(assistant.content) ? assistant.content : []).toStrictEqual([
+      { type: "reasoning", text: 'The user asked me to remember "pineapple".' },
+      { type: "text", text: "OK" },
+    ])
+  })
+
+  test("passes through string assistant content unchanged", () => {
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+      ],
+      createModel(),
+      {},
+    )
+    expect(result[1]).toStrictEqual({ role: "assistant", content: "hello" })
   })
 })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -968,7 +968,7 @@ describe("session.llm.stream", () => {
 
   const cerebrasFixture = { providerID: "cerebras", modelID: "gpt-oss-120b" }
   it.instance(
-    "replays Cerebras assistant reasoning using the provider-supported field",
+    "omits Cerebras assistant reasoning when the model does not declare interleaved support",
     () =>
       Effect.gen(function* () {
         const fixture = loadFixture(cerebrasFixture.providerID, cerebrasFixture.modelID)
@@ -1025,8 +1025,12 @@ describe("session.llm.stream", () => {
         const messages = capture.body.messages as Array<Record<string, unknown>>
         const assistant = messages.find((msg) => msg.role === "assistant")
 
-        expect(assistant?.reasoning).toBe("thinking")
+        // Cerebras rejects replayed reasoning in any plain-text field
+        // ("reasoning_content is unsupported"), so non-interleaved models must
+        // not echo it at all — only the text reply survives.
+        expect(assistant && "reasoning" in assistant).toBe(false)
         expect(assistant && "reasoning_content" in assistant).toBe(false)
+        expect(assistant?.content).toBe("Previous answer")
       }),
     {
       config: () => ({


### PR DESCRIPTION
# Fix: strip reasoning replay for models without interleaved support

Fixes #48774

## Problem

Sessions on `cerebras/qwen-3.8-27b` hang in an infinite retry loop. The assistant's reasoning parts are replayed in history and serialized by the chat-completions transport as a plain-text `reasoning_content` field; Cerebras rejects it (`400 — "reasoning_content … is unsupported"`) and OpenCode retries the identical request forever. The same echo exists in `@ai-sdk/openai-compatible`, `@ai-sdk/deepinfra`, `@ai-sdk/togetherai`, `@ai-sdk/deepseek`, `ai-gateway-provider`, and `venice-ai-sdk-provider` — any provider on those transports that decides to reject replayed reasoning hits the same loop.

## Fix

In `ProviderTransform`'s `normalizeMessages` — the choke point used by both the aisdk path (`session/llm.ts`) and the native runtime (`session/llm/native-runtime.ts`) — drop `reasoning` parts from outbound assistant messages when:

1. the model has **not** declared `interleaved` reasoning support (models.dev `interleaved`, e.g. DeepSeek — untouched, still replays via the declared field), and
2. the model's transport is one of the plain-text echo SDKs above.

A reasoning-only assistant turn carries no replayable state on these APIs, so an emptied message is dropped entirely rather than sent as an empty message. Signed-reasoning transports (Anthropic, OpenAI Responses, Google) are unaffected — they aren't in the set.

## Validation

- **Unit tests**: 7 new cases in `test/provider/transform.test.ts` (strip per transport, keep when `interleaved` declared, drop reasoning-only messages, leave tool calls and text intact, non-echo transports untouched). Full package suite: **3580 pass / 0 fail**.
- **Live end-to-end** against `api.cerebras.ai` through a logging proxy: two-turn `qwen-3.8-27b` conversation + history replay — full 35 KB request bodies contain zero occurrences of `reasoning_content`; replayed assistant messages carry only `role`/`content`; all responses 200; follow-up answered correctly (no loop). Before the fix, the same replay 400-loops (captured request in the issue).

## Test change worth calling out

`test/session/llm.test.ts` — "replays Cerebras assistant reasoning using the provider-supported field" asserted that `cerebras/gpt-oss-120b` history replays reasoning via the `reasoning` field (reachable only when the cerebras SDK's request transform runs). I verified against the live API that **both** Cerebras models reject `reasoning_content` and accept `reasoning`, but on transports/builds where the older `openai-compatible` converter runs (e.g. the current desktop bundle), gpt-oss history replay 400s exactly like qwen. This PR chooses correctness everywhere over replay on one path, so that test now asserts reasoning is omitted for non-interleaved Cerebras models. If restoring gpt-oss replay is desirable, a follow-up could declare `interleaved: { field: "reasoning" }` for Cerebras in models.dev and make the interleaved branch providerOptions-key aware (it currently hardcodes the `openaiCompatible` key, which the cerebras SDK ignores in favor of `cerebras`).
