### PR TITLE
fix(session): freeze system prompt per session to preserve prefix cache

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -141,6 +141,11 @@ const layer = Layer.effect(
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
     const { db } = database
+    // Freeze the system prompt per session after the first LLM call, so that
+    // mid-session changes to the instruction files (AGENTS.md / memory.md), git
+    // status or the calendar date do not invalidate the provider's prefix cache
+    // for the whole conversation. Adapted from anomalyco/opencode#33246.
+    const frozenSystemPrompts = new Map<SessionID, string[]>()
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
         cancel: (sessionID: SessionID) => cancel(sessionID),
@@ -1254,19 +1259,30 @@ const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, mcpInstructions, modelMsgs] = yield* Effect.all([
+            const [skills, frozenSystem, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
-              sys.environment(model),
-              instruction.system().pipe(Effect.orDie),
-              sys.mcp(agent, session.permission),
+              Effect.suspend(() => {
+                const cached = frozenSystemPrompts.get(sessionID)
+                if (cached) return Effect.succeed(cached)
+                return Effect.all([
+                  sys.environment(model),
+                  instruction.system().pipe(Effect.orDie),
+                  sys.mcp(agent, session.permission),
+                ]).pipe(
+                  Effect.map(([env, instructions, mcpInstructions]) => {
+                    const computed = [...env, ...instructions, ...(mcpInstructions ? [mcpInstructions] : [])]
+                    if (frozenSystemPrompts.size >= 2048) {
+                      const oldest = frozenSystemPrompts.keys().next().value
+                      if (oldest !== undefined) frozenSystemPrompts.delete(oldest)
+                    }
+                    frozenSystemPrompts.set(sessionID, computed)
+                    return computed
+                  }),
+                )
+              }),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
-            const system = [
-              ...env,
-              ...instructions,
-              ...(mcpInstructions ? [mcpInstructions] : []),
-              ...(skills ? [skills] : []),
-            ]
+            const system = [...frozenSystem, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({


### PR DESCRIPTION
### Issue for this PR

Closes #48778

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode rebuilds the system prompt on every request: `instruction.system()` re-reads the instruction files (`AGENTS.md`, `memory.md`, …) and `system.ts` injects `Today's date`. A mid-session edit to an instruction file, or the date rolling over at midnight, changes that prefix — so the provider's cached prefix diverges at token ~0 and the entire conversation is re-prefilled (~450K tokens / ~4 min on a 1M-context session, with no signal in the UI).

This computes the environment + instruction + MCP system parts once per session (on the first LLM call) and reuses them for the session's lifetime; skills stay computed per call. The per-session map is capped at 2048 entries.

The approach is rebased onto current `dev` from #33246 by @0byte-coding (co-authored in the commit).

### How did you verify your code works?

- `bun run typecheck` passes.
- Built the binary and sent a prompt through it on a side port.
- Deployed and dogfooded: editing `memory.md` mid-session no longer triggers a re-prefill, and the midnight rollover no longer does either.

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
