### PR TITLE
fix(opencode): show actionable error details when `opencode serve` fails

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect"
-import { effectCmd } from "../effect-cmd"
+import { effectCmd, CliError } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { errorMessage } from "@/util/error"
 
 export const ServeCommand = effectCmd({
   command: "serve",
@@ -16,9 +17,44 @@ export const ServeCommand = effectCmd({
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = yield* resolveNetworkOptions(args)
-    const server = yield* Effect.promise(() => Server.listen(opts))
+    const server = yield* Effect.tryPromise({
+      try: () => Server.listen(opts),
+      catch: (error) => new CliError({ message: `Failed to start server: ${extractServerCause(error)}` }),
+    })
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
     yield* Effect.never
   }),
 })
+
+export function extractServerCause(error: unknown): string {
+  // Effect.runPromise wraps failures in FiberFailure. The inner cause chain
+  // is typically: FiberFailure → Cause.Fail → ServeError { cause: <node error> }.
+  // Walk the chain to find the deepest actionable message.
+  let current: unknown = error
+  for (let depth = 0; depth < 10 && current != null; depth++) {
+    if (current instanceof Error && current.cause != null) {
+      current = current.cause
+      continue
+    }
+    if (typeof current === "object") {
+      const rec = current as Record<string, unknown>
+      // Effect Cause objects: check .error (Fail) or .defect (Die)
+      if ("error" in rec && rec.error != null) {
+        current = rec.error
+        continue
+      }
+      if ("defect" in rec && rec.defect != null) {
+        current = rec.defect
+        continue
+      }
+      // ServeError and similar: { _tag, cause }
+      if ("cause" in rec && rec.cause != null && rec.cause !== current) {
+        current = rec.cause
+        continue
+      }
+    }
+    break
+  }
+  return errorMessage(current ?? error)
+}

--- a/packages/opencode/test/cli/serve/extract-server-cause.test.ts
+++ b/packages/opencode/test/cli/serve/extract-server-cause.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { extractServerCause } from "../../../src/cli/cmd/serve"
+
+describe("extractServerCause", () => {
+  test("extracts message from a plain Error", () => {
+    const err = new Error("listen EADDRINUSE: address already in use :::4096")
+    expect(extractServerCause(err)).toBe("listen EADDRINUSE: address already in use :::4096")
+  })
+
+  test("digs through Error.cause chain", () => {
+    const root = new Error("EADDRINUSE")
+    const wrapper = new Error("outer", { cause: root })
+    expect(extractServerCause(wrapper)).toBe("EADDRINUSE")
+  })
+
+  test("digs through ServeError-shaped { _tag, cause }", () => {
+    const nodeErr = new Error("listen EADDRINUSE: address already in use :::4096")
+    const serveError = { _tag: "ServeError", cause: nodeErr }
+    expect(extractServerCause(serveError)).toBe("listen EADDRINUSE: address already in use :::4096")
+  })
+
+  test("digs through Effect Cause.Fail shape { error }", () => {
+    const nodeErr = new Error("EADDRINUSE")
+    const serveError = { _tag: "ServeError", cause: nodeErr }
+    const failCause = { error: serveError }
+    expect(extractServerCause(failCause)).toBe("EADDRINUSE")
+  })
+
+  test("handles FiberFailure → Cause.Fail → ServeError → node Error", () => {
+    const nodeErr = new Error("listen EADDRINUSE: address already in use :::4096")
+    const serveError = { _tag: "ServeError", cause: nodeErr }
+    const failCause = { error: serveError }
+    const fiberFailure = new Error("ServeError", { cause: failCause })
+    expect(extractServerCause(fiberFailure)).toBe("listen EADDRINUSE: address already in use :::4096")
+  })
+
+  test("handles Cause.Die shape { defect }", () => {
+    const inner = new Error("permission denied")
+    const dieCause = { defect: inner }
+    expect(extractServerCause(dieCause)).toBe("permission denied")
+  })
+
+  test("falls back to errorMessage for string errors", () => {
+    expect(extractServerCause("string error")).toBe("string error")
+  })
+
+  test("falls back for null/undefined", () => {
+    const result = extractServerCause(null)
+    expect(typeof result).toBe("string")
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  test("does not loop on self-referencing cause", () => {
+    const obj: Record<string, unknown> = { _tag: "ServeError", message: "fallback" }
+    obj.cause = obj
+    expect(extractServerCause(obj)).toBe("fallback")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #48784

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `opencode serve` fails to start (e.g. port already in use, permission denied), the only output is `Unexpected error` followed by `ServeError` — no indication of what actually went wrong.

The cause: `Server.listen()` internally uses `Effect.runPromise()`, which wraps failures in a `FiberFailure`. The serve handler used `Effect.promise()` to call it, which converts the rejection into an Effect defect (Die). By the time it reaches the top-level catch, the real error is buried several layers deep in the cause chain, and neither `FormatError()` nor `errorMessage()` can reach it.

The fix replaces `Effect.promise()` with `Effect.tryPromise()` and adds `extractServerCause()`, which walks the nested cause chain — `FiberFailure` → `Cause.Fail`/`Cause.Die` → `ServeError` → Node error — to find the deepest actionable message. The error is then wrapped in a `CliError`, which `FormatError()` already knows how to display cleanly.

### How did you verify your code works?

- Reproduced with `opencode serve --port 80 --hostname 0.0.0.0` (see below).
- 9 unit tests for `extractServerCause()` covering plain errors, `Error.cause` chains, `ServeError`-shaped objects, Effect `Cause.Fail`/`Cause.Die` shapes, the full `FiberFailure` → `ServeError` → Node error chain, string/null fallbacks, and self-referencing cause protection. All pass.
- Type-checked with `tsc --noEmit` — no new errors.

### Screenshots / recordings

**Before** (`opencode serve --port 80 --hostname 0.0.0.0`):
```bash
$ opencode serve --port 80 --hostname 0.0.0.0
Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.
Error: Unexpected error

ServeError
```

**After**:
```bash
$ opencode serve --port 80 --hostname 0.0.0.0
Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.
Error: Failed to start server: permission denied 0.0.0.0:80
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR