### PR TITLE
fix(app): query worktree inventory without booting locations

### DIFF
--- a/packages/app/e2e/regression/settings-loading.spec.ts
+++ b/packages/app/e2e/regression/settings-loading.spec.ts
@@ -3,26 +3,27 @@ import { mockOpenCodeServer } from "../utils/mock-server"
 
 const directory = "C:/Projects/settings-demo"
 const sandboxes = Array.from({ length: 12 }, (_, index) => `${directory}/workspace-${index + 1}`)
+const project = {
+  id: "proj_settings_demo",
+  canonical: directory,
+  name: "Settings demo",
+  icon: {
+    color: "orange",
+    override:
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' fill='red'/%3E%3C/svg%3E",
+  },
+  commands: { start: "echo setup" },
+  vcs: "git",
+  time: { created: 1700000000000, updated: 1700000000000 },
+  sandboxes,
+}
 
 test.use({ viewport: { width: 1440, height: 1000 }, colorScheme: "dark" })
 
 test.beforeEach(async ({ page }) => {
   await mockOpenCodeServer(page, {
     directory,
-    project: {
-      id: "proj_settings_demo",
-      canonical: directory,
-      name: "Settings demo",
-      icon: {
-        color: "orange",
-        override:
-          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' fill='red'/%3E%3C/svg%3E",
-      },
-      commands: { start: "echo setup" },
-      vcs: "git",
-      time: { created: 1700000000000, updated: 1700000000000 },
-      sandboxes,
-    },
+    project,
     provider: { all: [], connected: [], default: {} },
     preferences: { shell: "zsh", websearch: { provider: "exa" } },
     shells: [{ path: "/bin/zsh", name: "zsh", acceptable: true }],
@@ -222,7 +223,7 @@ test("workspaces opens without waiting for inventory or sessions", async ({ page
   const inventory = Promise.withResolvers<void>()
   const sessions = Promise.withResolvers<void>()
   await page.route(
-    (url) => url.pathname === "/api/worktree",
+    (url) => url.pathname === "/api/worktree/inventory",
     async (route) => {
       await inventory.promise
       await route.fallback()
@@ -234,10 +235,7 @@ test("workspaces opens without waiting for inventory or sessions", async ({ page
   })
   const settings = page.getByTestId("settings-screen")
   const requested = page.waitForRequest(
-    (request) =>
-      new URL(request.url()).pathname === "/api/worktree" &&
-      new URL(request.url()).searchParams.get("location[directory]") === directory &&
-      request.method() === "GET",
+    (request) => new URL(request.url()).pathname === "/api/worktree/inventory" && request.method() === "GET",
   )
   await settings.getByRole("tab", { name: "Worktrees", exact: true }).click()
   await requested
@@ -253,7 +251,7 @@ test("workspaces opens without waiting for inventory or sessions", async ({ page
 
   const refresh = Promise.withResolvers<void>()
   await page.route(
-    (url) => url.pathname === "/api/worktree",
+    (url) => url.pathname === "/api/worktree/inventory",
     async (route) => {
       await refresh.promise
       await route.fallback()
@@ -267,6 +265,23 @@ test("workspaces opens without waiting for inventory or sessions", async ({ page
 
 test("worktree deletion sends the project location separately from the target", async ({ page }) => {
   const removed = new Set<string>()
+  await page.route(
+    (url) => url.pathname === "/api/worktree/inventory",
+    (route) =>
+      route.fulfill({
+        json: [
+          {
+            project,
+            worktrees: [
+              { directory },
+              ...sandboxes
+                .filter((directory) => !removed.has(directory))
+                .map((directory) => ({ directory, strategy: "git" })),
+            ],
+          },
+        ],
+      }),
+  )
   await page.route(
     (url) => url.pathname === "/api/worktree",
     async (route) => {

--- a/packages/app/e2e/regression/workspaces-prefetch.spec.ts
+++ b/packages/app/e2e/regression/workspaces-prefetch.spec.ts
@@ -11,6 +11,13 @@ const project = {
   time: { created: 1, updated: 1 },
 }
 const other = { ...project, id: "proj_other", name: "Other project", canonical: "/repo/other", sandboxes: [] }
+const storedInventory = [project, other].map((project) => ({
+  project,
+  worktrees: [
+    { directory: project.canonical },
+    ...project.sandboxes.map((directory) => ({ directory, strategy: "git" })),
+  ],
+}))
 
 test.use({ viewport: { width: 1280, height: 900 } })
 
@@ -43,20 +50,18 @@ test.beforeEach(async ({ page }) => {
 })
 
 for (const interaction of ["hover", "focus"] as const) {
-  test(`project Worktrees ${interaction} prefetches only its inventory and reuses the request`, async ({ page }) => {
+  test(`project Worktrees ${interaction} reuses the global inventory and filters the selected project`, async ({
+    page,
+  }) => {
     const inventory = Promise.withResolvers<void>()
     const calls: string[] = []
     const sessions: string[] = []
     await page.route(
-      (url) => url.pathname === "/api/project",
-      (route) => route.fulfill({ json: [project, other] }),
-    )
-    await page.route(
-      (url) => url.pathname === "/api/worktree",
+      (url) => url.pathname === "/api/worktree/inventory",
       async (route) => {
-        calls.push(new URL(route.request().url()).searchParams.get("location[directory]") ?? "")
+        calls.push(new URL(route.request().url()).search)
         await inventory.promise
-        await route.fallback()
+        await route.fulfill({ json: storedInventory })
       },
     )
     page.on("request", (request) => {
@@ -70,17 +75,17 @@ for (const interaction of ["hover", "focus"] as const) {
     await settings.getByRole("button", { name: project.name, exact: true }).click()
     const worktrees = settings.getByRole("tab", { name: "Worktrees", exact: true })
     await expect(worktrees).toBeEnabled()
-    const requested = page.waitForRequest((request) => new URL(request.url()).pathname === "/api/project")
+    const requested = page.waitForRequest((request) => new URL(request.url()).pathname === "/api/worktree/inventory")
     await worktrees[interaction]()
     await requested
     await expect(worktrees).toHaveAttribute("aria-selected", "false")
-    await expect.poll(() => calls).toEqual([directory])
+    expect(calls).toEqual([""])
     expect(sessions).toEqual([])
 
     if (interaction === "hover") {
       const finished = page.waitForEvent(
         "requestfinished",
-        (request) => new URL(request.url()).pathname === "/api/worktree",
+        (request) => new URL(request.url()).pathname === "/api/worktree/inventory",
       )
       inventory.resolve()
       await finished
@@ -90,7 +95,7 @@ for (const interaction of ["hover", "focus"] as const) {
     inventory.resolve()
     await expect(settings.getByText("2 worktrees", { exact: true })).toBeVisible()
     await expect(settings.getByText("Cached worktree session", { exact: true })).toBeVisible()
-    expect(calls).toEqual([directory])
+    expect(calls).toEqual([""])
     await expect.poll(() => sessions.toSorted()).toEqual(sandboxes.toSorted())
   })
 }
@@ -113,7 +118,14 @@ for (const nested of [false, true]) {
       await page.reload()
       await page.getByTestId("settings-screen").getByRole("tab", { name: "Settings server", exact: true }).click()
     }
-    const calls = { projects: 0, worktrees: [] as string[] }
+    const calls = { inventory: 0, projects: 0, worktrees: [] as string[] }
+    await page.route(
+      (url) => url.pathname === "/api/worktree/inventory",
+      (route) => {
+        calls.inventory += 1
+        return route.fulfill({ json: storedInventory })
+      },
+    )
     await page.route(
       (url) => url.pathname === "/api/project",
       async (route) => {
@@ -135,18 +147,17 @@ for (const nested of [false, true]) {
     await expect(worktrees).toBeEnabled()
     const fetched = page.waitForEvent(
       "requestfinished",
-      (request) => new URL(request.url()).pathname === "/api/project",
+      (request) => new URL(request.url()).pathname === "/api/worktree/inventory",
     )
     await worktrees.hover()
     await fetched
     await worktrees.focus()
     await expect(worktrees).toHaveAttribute("aria-selected", "false")
-    expect(calls).toEqual({ projects: 1, worktrees: [] })
+    expect(calls).toEqual({ inventory: 1, projects: 0, worktrees: [] })
 
     await worktrees.click()
     await expect(settings.getByText("2 worktrees", { exact: true })).toBeVisible()
-    expect(calls.projects).toBe(1)
-    expect(calls.worktrees.toSorted()).toEqual([directory, other.canonical].toSorted())
+    expect(calls).toEqual({ inventory: 1, projects: 0, worktrees: [] })
   })
 }
 
@@ -190,15 +201,18 @@ test("project deletion updates the cached server-wide inventory", async ({ page 
         removed.add(route.request().postDataJSON().directory)
         return route.fulfill({ status: 204 })
       }
-      return route.fulfill({
-        json: [
-          { directory },
-          ...sandboxes
-            .filter((directory) => !removed.has(directory))
-            .map((directory) => ({ directory, strategy: "git" })),
-        ],
-      })
+      return route.fallback()
     },
+  )
+  await page.route(
+    (url) => url.pathname === "/api/worktree/inventory",
+    (route) =>
+      route.fulfill({
+        json: storedInventory.map((entry) => ({
+          ...entry,
+          worktrees: entry.worktrees.filter((worktree) => !removed.has(worktree.directory)),
+        })),
+      }),
   )
   const settings = page.getByTestId("settings-screen")
   await settings.getByRole("tab", { name: "Worktrees", exact: true }).click()
@@ -216,4 +230,50 @@ test("project deletion updates the cached server-wide inventory", async ({ page 
   await settings.getByRole("tab", { name: "Worktrees", exact: true }).click()
   await expect(settings.getByText("1 worktree", { exact: true })).toBeVisible()
   await expect(settings.getByLabel(sandboxes[1], { exact: true })).toHaveCount(0)
+})
+
+test("View all reads 336 historical projects in one metadata request without Location discovery", async ({
+  page,
+}, testInfo) => {
+  const inventory = Array.from({ length: 336 }, (_, index) => ({
+    project: {
+      ...project,
+      id: `historical-${index}`,
+      name: `Historical ${index}`,
+      canonical: `/missing/historical-${index}`,
+      sandboxes: [],
+    },
+    worktrees: [{ directory: `/missing/historical-${index}/feature`, strategy: "git" }],
+  }))
+  const reads: string[] = []
+  page.on("request", (request) => {
+    const url = new URL(request.url())
+    if (["/api/project", "/api/worktree", "/api/worktree/inventory"].includes(url.pathname)) reads.push(url.pathname)
+  })
+  await page.route(
+    (url) => url.pathname === "/api/project",
+    (route) => route.fulfill({ json: inventory.map((entry) => entry.project) }),
+  )
+  await page.route(
+    (url) => url.pathname === "/api/worktree",
+    (route) =>
+      route.fulfill({
+        json:
+          inventory.find(
+            (entry) =>
+              entry.project.canonical === new URL(route.request().url()).searchParams.get("location[directory]"),
+          )?.worktrees ?? [],
+      }),
+  )
+  await page.route(
+    (url) => url.pathname === "/api/worktree/inventory",
+    (route) => route.fulfill({ json: inventory }),
+  )
+  const settings = page.getByTestId("settings-screen")
+  await settings.getByRole("tab", { name: "Worktrees", exact: true }).click()
+  await expect(settings.getByText("336 worktrees", { exact: true })).toBeVisible()
+  await expect(settings.getByLabel("/missing/historical-335/feature", { exact: true })).toHaveCount(1)
+  await page.screenshot({ path: testInfo.outputPath("inventory.png") })
+  await testInfo.attach("inventory-requests", { body: JSON.stringify(reads), contentType: "application/json" })
+  expect(reads).toEqual(["/api/worktree/inventory"])
 })

--- a/packages/app/e2e/utils/mock-api.ts
+++ b/packages/app/e2e/utils/mock-api.ts
@@ -92,6 +92,7 @@ const Group = HttpApiGroup.make("mock")
       success: Json,
     }),
   )
+  .add(HttpApiEndpoint.get("worktreeInventory", "/api/worktree/inventory", { success: Json }))
   .add(
     HttpApiEndpoint.post("worktreeCreate", "/api/worktree", {
       payload: JsonPayload,

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -307,6 +307,22 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
               strategy: "git",
             })),
           ]),
+        worktreeInventory: () => {
+          const project = config.project as typeof config.project & {
+            canonical?: string
+            worktree?: string
+            sandboxes?: string[]
+          }
+          return Effect.succeed([
+            {
+              project: { ...project, canonical: project.canonical ?? project.worktree ?? config.directory },
+              worktrees: [
+                { directory: config.directory },
+                ...(project.sandboxes ?? []).map((directory) => ({ directory, strategy: "git" })),
+              ],
+            },
+          ])
+        },
         worktreeCreate: (ctx) => {
           const input = record(ctx.payload) ? ctx.payload : {}
           return Effect.succeed({

--- a/packages/app/src/runtime/server/request-queue.test.ts
+++ b/packages/app/src/runtime/server/request-queue.test.ts
@@ -100,6 +100,7 @@ describe("createRequestQueue", () => {
     expect(isSlowRequest("/api/vcs")).toBe(true)
     expect(isSlowRequest("/api/vcs/branches")).toBe(true)
     expect(isSlowRequest("/api/worktree")).toBe(true)
+    expect(isSlowRequest("/api/worktree/inventory")).toBe(false)
     expect(isSlowRequest("/api/vcsx")).toBe(false)
     expect(isSlowRequest("/api/session")).toBe(false)
   })

--- a/packages/app/src/runtime/server/request-queue.ts
+++ b/packages/app/src/runtime/server/request-queue.ts
@@ -25,6 +25,7 @@ export const requestHeadersTimeoutMs = 60_000
 export const setupRequestHeadersTimeoutMs = 10 * 60_000
 
 export function isSlowRequest(pathname: string) {
+  if (pathname === "/api/worktree/inventory") return false
   return slowRequestPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`))
 }
 

--- a/packages/app/src/settings/shell.tsx
+++ b/packages/app/src/settings/shell.tsx
@@ -413,10 +413,7 @@ function ProjectSettings(props: { server: ServerConnection.Any; project: LocalPr
   const language = useLanguage()
   const surface = useSettingsSurface()
   const activeDirectory = useSettingsDirectory(() => props.server)
-  const prefetchWorkspaces = useWorkspacesPrefetch(
-    () => props.server,
-    () => props.project.id,
-  )
+  const prefetchWorkspaces = useWorkspacesPrefetch(() => props.server)
   const groups: SettingsNavGroup[] = [
     {
       items: nestedProjectTabs.map((item) => ({

--- a/packages/app/src/settings/workspaces/queries.ts
+++ b/packages/app/src/settings/workspaces/queries.ts
@@ -1,52 +1,27 @@
-import { queryOptions, useQueryClient, type QueryClient } from "@tanstack/solid-query"
+import { queryOptions, useQueryClient } from "@tanstack/solid-query"
 import type { Accessor } from "solid-js"
-import type { ServerSDK } from "@/runtime/server/client"
 import type { ServerConnection } from "@/runtime/server/registry"
 import { useServerCtx, type ServerCtx } from "@/runtime/server/runtime"
 import { normalizeProjectInfo } from "@/runtime/server/global-sync/utils"
 
-function workspaceProjectsQuery(sdk: ServerSDK) {
+export function workspaceInventoryQuery(context: ServerCtx) {
   return queryOptions({
-    queryKey: [sdk.scope, "settings-workspace-project-metadata"],
-    queryFn: () => sdk.api.project.list(),
-    staleTime: 30_000,
-  })
-}
-
-export function workspaceInventoryQuery(context: ServerCtx, client: QueryClient, projectID?: string) {
-  return queryOptions({
-    queryKey: [context.sdk.scope, "settings-workspace-inventory", projectID ?? null],
-    queryFn: async () =>
-      Promise.all(
-        (await client.fetchQuery(workspaceProjectsQuery(context.sdk)))
-          .filter((project) => projectID === undefined || project.id === projectID)
-          .map(async (project) => {
-            const worktrees = (await context.sync.worktrees.load(project.canonical)) ?? [
-              { directory: project.canonical },
-              ...project.sandboxes.map((directory) => ({ directory })),
-            ]
-            return normalizeProjectInfo({ ...project, worktrees })
-          }),
+    queryKey: [context.sdk.scope, "settings-workspace-inventory"],
+    // One stored-inventory read. Location-scoped worktree.list performs live discovery and boots plugins.
+    queryFn: async ({ signal }) =>
+      (await context.sdk.api.worktree.inventory({ signal })).map((entry) =>
+        normalizeProjectInfo({ ...entry.project, worktrees: entry.worktrees }),
       ),
     staleTime: 30_000,
   })
 }
 
-export function useWorkspacesPrefetch(
-  server: Accessor<ServerConnection.Any | undefined>,
-  projectID?: Accessor<string | undefined>,
-) {
+export function useWorkspacesPrefetch(server: Accessor<ServerConnection.Any | undefined>) {
   const client = useQueryClient()
   const context = useServerCtx(server)
   return () => {
     const current = context()
     if (!current || current.sdk.connection.status() !== "connected") return
-    const project = projectID?.()
-    if (project) {
-      void client.prefetchQuery(workspaceInventoryQuery(current, client, project))
-      return
-    }
-    // Server-level hover warms metadata without booting every project's Location.
-    void client.prefetchQuery(workspaceProjectsQuery(current.sdk))
+    void client.prefetchQuery(workspaceInventoryQuery(current))
   }
 }

--- a/packages/app/src/settings/workspaces/workspaces.tsx
+++ b/packages/app/src/settings/workspaces/workspaces.tsx
@@ -76,7 +76,8 @@ export const SettingsWorkspaces: Component<{
   })
 
   const projectQuery = useQuery(() => ({
-    ...workspaceInventoryQuery(server.ctx, queryClient, props.projectID),
+    ...workspaceInventoryQuery(server.ctx),
+    select: (projects) => projects.filter((project) => props.projectID === undefined || project.id === props.projectID),
     enabled: serverSDK.connection.status() === "connected",
     refetchOnMount: true,
   }))

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -2027,11 +2027,15 @@ export type WorktreeRefreshOperation<E = never> = (
   input?: WorktreeRefreshInput,
 ) => Effect.Effect<WorktreeRefreshOutput, E>
 
+export type WorktreeInventoryOutput = Worktree.Inventory
+export type WorktreeInventoryOperation<E = never> = () => Effect.Effect<WorktreeInventoryOutput, E>
+
 export interface WorktreeApi<E = never> {
   readonly list: WorktreeListOperation<E>
   readonly create: WorktreeCreateOperation<E>
   readonly remove: WorktreeRemoveOperation<E>
   readonly refresh: WorktreeRefreshOperation<E>
+  readonly inventory: WorktreeInventoryOperation<E>
 }
 
 export type WorkspaceCreateInput = { readonly id?: Workspace.ID | undefined; readonly provider: string }

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -248,6 +248,7 @@ import type {
   WorktreeRemoveOutput,
   WorktreeRefreshInput,
   WorktreeRefreshOutput,
+  WorktreeInventoryOutput,
   WorkspaceCreateInput,
   WorkspaceCreateOutput,
   WorkspaceDestroyInput,
@@ -1499,11 +1500,15 @@ const EndpointWorktreeRefresh = (raw: RawClient["server.worktree"]) => (input?: 
     raw["worktree.refresh"]({ query: { location: input?.["location"] } }).pipe(Effect.mapError(mapClientError)),
   )
 
+const EndpointWorktreeInventory = (raw: RawClient["server.worktree"]) => () =>
+  preserveEffect<WorktreeInventoryOutput>()(raw["worktree.inventory"]({}).pipe(Effect.mapError(mapClientError)))
+
 const adaptGroupWorktree = (raw: RawClient["server.worktree"]) => ({
   list: EndpointWorktreeList(raw),
   create: EndpointWorktreeCreate(raw),
   remove: EndpointWorktreeRemove(raw),
   refresh: EndpointWorktreeRefresh(raw),
+  inventory: EndpointWorktreeInventory(raw),
 })
 
 const EndpointWorkspaceCreate = (raw: RawClient["server.workspace"]) => (input: WorkspaceCreateInput) =>

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -244,6 +244,7 @@ import type {
   WorktreeRemoveOutput,
   WorktreeRefreshInput,
   WorktreeRefreshOutput,
+  WorktreeInventoryOutput,
   WorkspaceCreateInput,
   WorkspaceCreateOutput,
   WorkspaceDestroyInput,
@@ -2048,6 +2049,17 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [400, 401],
             empty: true,
+          },
+          requestOptions,
+        ),
+      inventory: (requestOptions?: RequestOptions) =>
+        request<WorktreeInventoryOutput>(
+          {
+            method: "GET",
+            path: `/api/worktree/inventory`,
+            successStatus: 200,
+            declaredStatuses: [400, 401],
+            empty: false,
           },
           requestOptions,
         ),

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -1870,6 +1870,8 @@ export type ReferenceInfo = {
   source: ReferenceSource
 }
 
+export type WorktreeInventoryEntry = { project: Project; worktrees: WorktreeList }
+
 export type AgentInfo = {
   id: string
   name: string
@@ -2161,6 +2163,8 @@ export type SessionMessageAssistantTool1 = {
 export type FormFields = [FormField, ...Array<FormField>]
 
 export type FormFields2 = [FormField1, ...Array<FormField1>]
+
+export type WorktreeInventory = Array<WorktreeInventoryEntry>
 
 export type SessionsResponse = { data: Array<SessionInfo>; cursor: { previous?: string | null; next?: string | null } }
 
@@ -6382,6 +6386,8 @@ export type WorktreeRefreshInput = {
 }
 
 export type WorktreeRefreshOutput = void
+
+export type WorktreeInventoryOutput = WorktreeInventory
 
 export type WorkspaceCreateInput = {
   readonly id?: { readonly id?: string | undefined; readonly provider: string }["id"]

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -55,7 +55,7 @@ test("exposes every standard HTTP API group", () => {
   expect(client.experimental.persistentPty.read).toBeFunction()
   expect(Object.keys(client.shell)).toEqual(["list", "create", "get", "timeout", "output", "remove"])
   expect(Object.keys(client.project)).toEqual(["list", "update", "current"])
-  expect(Object.keys(client.worktree)).toEqual(["list", "create", "remove", "refresh"])
+  expect(Object.keys(client.worktree)).toEqual(["list", "create", "remove", "refresh", "inventory"])
 })
 
 test("config.get returns ordered config entries for a location", async () => {
@@ -336,7 +336,7 @@ test("file.read returns binary content from the public HTTP contract", async () 
   )
 })
 
-test("all worktree operations use location-based routes without a project parameter", async () => {
+test("worktree discovery and mutations use location-based routes without a project parameter", async () => {
   const requests: Request[] = []
   const client = OpenCode.make({
     baseUrl: "http://localhost:3000",

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -31,6 +31,7 @@ import { Workspace } from "../workspace.js"
 import { Vcs } from "../vcs.js"
 import { WebSearch } from "../websearch.js"
 import { Worktree } from "../worktree.js"
+import { WorktreeInventory } from "../worktree/inventory.js"
 import { Generate } from "../generate.js"
 import { Permission } from "../permission.js"
 import { PluginHooks } from "./hooks.js"
@@ -71,6 +72,7 @@ export const make = Effect.fn("PluginHost.make")(function* (
   const persistentPty = yield* PersistentPty.Service
   const locations = yield* LocationServiceMap.Service
   const worktrees = yield* Worktree.Service
+  const worktreeInventory = yield* WorktreeInventory.Service
   const locationInfo = () =>
     new Location.Info({
       directory: location.directory,
@@ -484,6 +486,7 @@ export const make = Effect.fn("PluginHost.make")(function* (
         }),
     },
     worktree: {
+      inventory: worktreeInventory.list,
       list: (input) => atWorktree(locationRef(input), (service) => service.list()),
       create: (input) => atWorktree(locationRef(input), (service) => service.create(input)),
       refresh: (input) => atWorktree(locationRef(input), (service) => service.refresh()).pipe(Effect.asVoid),
@@ -553,6 +556,7 @@ export const requirements = LayerNode.group([
   Vcs.node,
   WebSearch.node,
   Worktree.node,
+  WorktreeInventory.node,
   Generate.node,
   Permission.node,
   PluginHooks.node,

--- a/packages/core/src/worktree/inventory.ts
+++ b/packages/core/src/worktree/inventory.ts
@@ -1,0 +1,45 @@
+export * as WorktreeInventory from "./inventory.js"
+
+import { Context, Effect, Layer } from "effect"
+import { asc, desc } from "drizzle-orm"
+import { Worktree } from "@opencode/schema/worktree"
+import { makeGlobalNode } from "@opencode/util/effect/app-node"
+import { Database } from "../database/database.js"
+import { Project } from "../project.js"
+import { WorktreeTable } from "./sql.js"
+
+export interface Interface {
+  readonly list: () => Effect.Effect<Worktree.Inventory>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/WorktreeInventory") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const database = yield* Database.Service
+    const projects = yield* Project.Service
+
+    return Service.of({
+      // Inventory reads must not resolve paths, discover strategies, or acquire a Location.
+      list: Effect.fn("WorktreeInventory.list")(function* () {
+        const rows = yield* database.db
+          .select()
+          .from(WorktreeTable)
+          .orderBy(desc(WorktreeTable.time_created), asc(WorktreeTable.directory))
+          .all()
+          .pipe(Effect.orDie)
+        const grouped = Map.groupBy(rows, (row) => row.project_id)
+        return (yield* projects.list()).map((project) => ({
+          project,
+          worktrees: (grouped.get(project.id) ?? []).map((row) => ({
+            directory: row.directory,
+            strategy: row.strategy ?? undefined,
+          })),
+        }))
+      }),
+    })
+  }),
+)
+
+export const node = makeGlobalNode({ service: Service, layer, deps: [Database.node, Project.node] })

--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -33,6 +33,7 @@ import { Tool } from "@opencode/core/tool"
 import { Vcs } from "@opencode/core/vcs"
 import { WebSearch } from "@opencode/core/websearch"
 import { Worktree } from "@opencode/core/worktree"
+import { WorktreeInventory } from "@opencode/core/worktree/inventory"
 import { Effect, Layer } from "effect"
 import { tempLocationLayer } from "../fixture/location"
 import { emptyMcpLayer } from "../fixture/mcp"
@@ -96,6 +97,7 @@ export const PluginTestLayer = AppNodeBuilder.build(
     Watcher.node,
     WebSearch.node,
     Worktree.node,
+    WorktreeInventory.node,
   ]),
   [
     Location.node.replace(tempLocationLayer),

--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -147,6 +147,7 @@ export function host(overrides: Overrides = {}): Plugin.Context {
       reload: () => Effect.die("unused vcs.reload"),
     },
     worktree: overrides.worktree ?? {
+      inventory: () => Effect.die("unused worktree.inventory"),
       list: () => Effect.die("unused worktree.list"),
       create: () => Effect.die("unused worktree.create"),
       remove: () => Effect.die("unused worktree.remove"),

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -546,6 +546,7 @@ export function fromPromise(plugin: Plugin) {
               ),
           },
           worktree: {
+            inventory: adaptApiMethod(WorktreeEndpoints["worktree.inventory"], host.worktree.inventory),
             list: adaptApiMethod(WorktreeEndpoints["worktree.list"], host.worktree.list),
             create: adaptApiMethod(WorktreeEndpoints["worktree.create"], host.worktree.create),
             remove: adaptApiMethod(WorktreeEndpoints["worktree.remove"], host.worktree.remove),

--- a/packages/protocol/src/api.ts
+++ b/packages/protocol/src/api.ts
@@ -30,7 +30,7 @@ import { WebSearchGroup } from "./groups/websearch.js"
 import { McpGroup } from "./groups/mcp.js"
 import { CredentialGroup } from "./groups/credential.js"
 import { ProjectGroup } from "./groups/project.js"
-import { WorktreeGroup } from "./groups/worktree.js"
+import { makeWorktreeGroup } from "./groups/worktree.js"
 import { VcsGroup } from "./groups/vcs.js"
 import { MigrationGroup } from "./groups/migration.js"
 import { ConfigGroup } from "./groups/config.js"
@@ -54,7 +54,6 @@ type LocationGroups<LocationId extends HttpApiMiddleware.AnyId> =
   | HttpApiGroup.AddMiddleware<typeof PtyGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof ShellGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof ReferenceGroup, LocationId>
-  | HttpApiGroup.AddMiddleware<typeof WorktreeGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof VcsGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof ConfigGroup, LocationId>
 
@@ -92,6 +91,7 @@ type ApiGroups<
   | typeof WorkspaceGroup
   | typeof GenerateGroup
   | typeof PersistentPtyGroup
+  | ReturnType<typeof makeWorktreeGroup<LocationId, LocationService>>
   | LocationGroups<LocationId>
   | FormGroups<LocationId, LocationService, FormLocationId, FormLocationService>
   | SessionGroups<SessionLocationId, SessionLocationService>
@@ -176,7 +176,7 @@ const makeApiFromGroup = <
     .add(PersistentPtyGroup)
     .add(ShellGroup.middleware(locationMiddleware))
     .add(ReferenceGroup.middleware(locationMiddleware))
-    .add(WorktreeGroup.middleware(locationMiddleware))
+    .add(makeWorktreeGroup(locationMiddleware))
     .add(WorkspaceGroup)
     .add(VcsGroup.middleware(locationMiddleware))
     .add(DebugGroup)

--- a/packages/protocol/src/groups/worktree.ts
+++ b/packages/protocol/src/groups/worktree.ts
@@ -1,6 +1,6 @@
 import { Worktree } from "@opencode/schema/worktree"
-import { Schema } from "effect"
-import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { Context, Schema } from "effect"
+import { HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import { LocationQuery, locationQueryOpenApi } from "./location.js"
 
 const root = "/api/worktree"
@@ -82,3 +82,21 @@ export const WorktreeGroup = HttpApiGroup.make("server.worktree")
       ),
   )
   .annotateMerge(OpenApi.annotations({ title: "worktree", description: "Location-scoped worktree management routes." }))
+
+export const makeWorktreeGroup = <LocationId extends HttpApiMiddleware.AnyId, LocationService>(
+  locationMiddleware: Context.Key<LocationId, LocationService>,
+) =>
+  WorktreeGroup.middleware(locationMiddleware)
+    // Group middleware applies only to endpoints already added. Inventory must never acquire a Location.
+    .add(
+      HttpApiEndpoint.get("worktree.inventory", `${root}/inventory`, {
+        success: Worktree.Inventory,
+      }).annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.worktree.inventory",
+          summary: "List stored worktree inventory",
+          description:
+            "List all known projects with their stored worktrees. This metadata-only read does not check filesystem existence, discover worktrees, or activate locations and plugins. Use the location-scoped worktree routes for live discovery and operations.",
+        }),
+      ),
+    )

--- a/packages/schema/src/worktree.ts
+++ b/packages/schema/src/worktree.ts
@@ -51,6 +51,15 @@ export class OperationError extends Schema.TaggedError<OperationError>()("Worktr
 export const List = Schema.Array(Directory).annotate({ identifier: "Worktree.List" })
 export type List = typeof List.Type
 
+export const InventoryEntry = Schema.Struct({
+  project: Project.Info,
+  worktrees: List,
+}).annotate({ identifier: "Worktree.InventoryEntry" })
+export interface InventoryEntry extends Schema.Schema.Type<typeof InventoryEntry> {}
+
+export const Inventory = Schema.Array(InventoryEntry).annotate({ identifier: "Worktree.Inventory" })
+export type Inventory = typeof Inventory.Type
+
 const Updated = ephemeral({
   type: "worktree.updated",
   schema: { projectID: Project.ID },

--- a/packages/server/src/handlers/worktree.ts
+++ b/packages/server/src/handlers/worktree.ts
@@ -1,5 +1,6 @@
 import { Git } from "@opencode/core/git"
 import { Worktree } from "@opencode/core/worktree"
+import { WorktreeInventory } from "@opencode/core/worktree/inventory"
 import { Plugin } from "@opencode/core/plugin"
 import { WorktreeError } from "@opencode/protocol/groups/worktree"
 import { Effect } from "effect"
@@ -7,15 +8,19 @@ import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { Api } from "../api"
 
 export const WorktreeHandler = HttpApiBuilder.group(Api, "server.worktree", (handlers) =>
-  handlers
-    .handle("worktree.list", () => run((worktrees) => worktrees.list()))
-    .handle("worktree.create", (ctx) => run((worktrees) => worktrees.create(ctx.payload)))
-    .handle("worktree.remove", (ctx) =>
-      run((worktrees) => worktrees.remove(ctx.payload)).pipe(Effect.as(HttpApiSchema.NoContent.make())),
-    )
-    .handle("worktree.refresh", () =>
-      run((worktrees) => worktrees.refresh()).pipe(Effect.as(HttpApiSchema.NoContent.make())),
-    ),
+  Effect.gen(function* () {
+    const inventory = yield* WorktreeInventory.Service
+    return handlers
+      .handle("worktree.inventory", () => inventory.list())
+      .handle("worktree.list", () => run((worktrees) => worktrees.list()))
+      .handle("worktree.create", (ctx) => run((worktrees) => worktrees.create(ctx.payload)))
+      .handle("worktree.remove", (ctx) =>
+        run((worktrees) => worktrees.remove(ctx.payload)).pipe(Effect.as(HttpApiSchema.NoContent.make())),
+      )
+      .handle("worktree.refresh", () =>
+        run((worktrees) => worktrees.refresh()).pipe(Effect.as(HttpApiSchema.NoContent.make())),
+      )
+  }),
 )
 
 function run<A>(action: (service: Worktree.Interface) => Effect.Effect<A, Worktree.Error>) {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -14,6 +14,7 @@ import { PermissionSaved } from "@opencode/core/permission/saved"
 import { PtyTicket } from "@opencode/core/pty/ticket"
 import { PersistentPty } from "@opencode/core/persistent-pty"
 import { Project } from "@opencode/core/project"
+import { WorktreeInventory } from "@opencode/core/worktree/inventory"
 import { Session } from "@opencode/core/session"
 import { Instance } from "@opencode/core/instance/service"
 import { SessionTransfer } from "@opencode/core/session/transfer"
@@ -55,6 +56,7 @@ const applicationServiceNodes = [
   httpClient,
   Job.node,
   Project.node,
+  WorktreeInventory.node,
   Session.node,
   Instance.node,
   SessionTransfer.node,

--- a/packages/server/test/worktree-inventory.test.ts
+++ b/packages/server/test/worktree-inventory.test.ts
@@ -1,0 +1,85 @@
+import path from "node:path"
+import { expect } from "bun:test"
+import { Context, Effect, Layer, RcMap } from "effect"
+import { HttpEffect, HttpRouter, HttpServer } from "effect/unstable/http"
+import { Database } from "@opencode/core/database/database"
+import { LocationServiceMap } from "@opencode/core/location-service-map"
+import { ProjectTable } from "@opencode/core/project/sql"
+import { WorktreeTable } from "@opencode/core/worktree/sql"
+import { Project } from "@opencode/schema/project"
+import { AbsolutePath } from "@opencode/schema/schema"
+import { Global } from "@opencode/util/global"
+import { OpenCode } from "@opencode/client"
+import { tempGlobalLayer } from "../../core/test/fixture/global"
+import { tmpdirScoped } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { createRoutes } from "../src/routes"
+
+it.live("lists historical inventory without booting Locations or pruning missing directories", () =>
+  Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped()
+    const context = yield* Layer.build(
+      createRoutes({ password: "secret", database: { path: ":memory:" }, models: { fetch: false } }, () => [], [
+        Global.node.replace(tempGlobalLayer),
+      ]).pipe(Layer.provide(HttpServer.layerServices)),
+    )
+    const db = Context.get(context, Database.Service).db
+    const locations = Context.get(context, LocationServiceMap.Service)
+    const handler = Context.get(context, HttpRouter.HttpRouter)
+      .asHttpEffect()
+      .pipe(HttpEffect.toWebHandlerWith(context))
+    const api = OpenCode.make({
+      baseUrl: "http://opencode.local",
+      headers: {
+        authorization: `Basic ${btoa("opencode:secret")}`,
+        // A metadata endpoint must ignore placement even when a caller supplies it.
+        "x-opencode-directory": encodeURIComponent(path.join(tmp.path, "missing-default")),
+      },
+      fetch: Object.assign((input: RequestInfo | URL, init?: RequestInit) => handler(new Request(input, init)), {
+        preconnect: () => {},
+      }),
+    })
+    expect(yield* Effect.promise(() => api.worktree.inventory())).toEqual([])
+    const projects = Array.from({ length: 336 }, (_, index) => ({
+      id: Project.ID.make(`inventory-${index.toString().padStart(3, "0")}`),
+      worktree: AbsolutePath.make(path.join(tmp.path, "missing", String(index))),
+      sandboxes: [],
+      time_created: 1,
+      time_updated: 1,
+    }))
+    yield* db.insert(ProjectTable).values(projects).run().pipe(Effect.orDie)
+    const worktrees = projects.slice(1).flatMap((project) => [
+      { project_id: project.id, directory: project.worktree, strategy: null, time_created: 1 },
+      {
+        project_id: project.id,
+        directory: AbsolutePath.make(path.join(project.worktree, "feature")),
+        strategy: "custom-strategy",
+        time_created: 2,
+      },
+    ])
+    yield* db.insert(WorktreeTable).values(worktrees).run().pipe(Effect.orDie)
+    const expected = projects.map((project, index) => ({
+      project: {
+        id: project.id,
+        canonical: project.worktree,
+        sandboxes: [],
+        time: { created: 1, updated: 1 },
+      },
+      worktrees:
+        index === 0
+          ? []
+          : [
+              { directory: path.join(project.worktree, "feature"), strategy: "custom-strategy" },
+              { directory: project.worktree },
+            ],
+    }))
+    expect(yield* Effect.promise(() => api.worktree.inventory())).toEqual(expected)
+    expect(yield* Effect.promise(() => api.worktree.inventory())).toEqual(expected)
+    expect(Array.from(yield* RcMap.keys(locations.rcMap))).toEqual([])
+    expect(yield* db.select().from(WorktreeTable).all().pipe(Effect.orDie)).toHaveLength(worktrees.length)
+    const unauthorized = yield* Effect.promise(() =>
+      handler(new Request("http://opencode.local/api/worktree/inventory")),
+    )
+    expect(unauthorized.status).toBe(401)
+  }),
+)


### PR DESCRIPTION
- Add one global `GET /api/worktree/inventory` endpoint to the existing `worktree` API group. It returns project metadata and stored worktree lists without acquiring a Location, discovering strategies, or starting plugins/MCPs.
- Use that read for Desktop's Worktrees screen and hover/focus prefetch, with one shared server-scoped cache and client-side project filtering.
- Preserve Location-scoped discovery/create/remove/refresh for CLI, TUI, and plugins. The additive inventory method is also exposed through the generated clients and plugin adapters.

```mermaid
flowchart LR
  A[Desktop: View all] --> B[GET /api/worktree/inventory]
  B --> C[Global WorktreeInventory]
  C --> D[(Stored projects + worktrees)]
  D --> E[One inventory response]
```

```ts
const inventory = await client.worktree.inventory({ signal })
// [{ project: { id, canonical, ... }, worktrees: [{ directory, strategy? }] }]
```

Stored inventory includes missing paths; live discovery remains responsible for reconciliation.

### 336-project fixture, production builds

| Inventory-related requests | Before (`v2`) | After |
| --- | ---: | ---: |
| Project list | 1 | 0 |
| Location-scoped worktree discovery | 336 | 0 |
| Global inventory | 0 | 1 |
| **Total** | **337** | **1** |
