### PR TITLE
fix(desktop): [v2] fix add WSL server issue with commands --exec

### DIFF
--- a/packages/desktop/src/main/wsl/runtime.test.ts
+++ b/packages/desktop/src/main/wsl/runtime.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { wslArgs } from "./runtime"
+
+test("wslArgs runs distro commands without the default shell", () => {
+  expect(wslArgs(["sh", "-lc", 'printf "%s\\n" "$HOME"'], "Debian")).toEqual([
+    "-d",
+    "Debian",
+    "--exec",
+    "sh",
+    "-lc",
+    'printf "%s\\n" "$HOME"',
+  ])
+})
+
+test("wslArgs keeps the user flag ahead of the command", () => {
+  expect(wslArgs(["bash", "-se"], "Debian", "root")).toEqual([
+    "-d",
+    "Debian",
+    "--user",
+    "root",
+    "--exec",
+    "bash",
+    "-se",
+  ])
+})

--- a/packages/desktop/src/main/wsl/runtime.ts
+++ b/packages/desktop/src/main/wsl/runtime.ts
@@ -39,7 +39,8 @@ const DEFAULT_WSL_TIMEOUT_MS = 20_000
 const DEFAULT_WSL_INSTALL_TIMEOUT_MS = 15 * 60_000
 
 export function wslArgs(args: string[], distro?: string | null, user?: string | null) {
-  return [...(distro ? ["-d", distro] : []), ...(user ? ["--user", user] : []), "--", ...args]
+  // Use --exec, not --, so the distro's default shell does not expand $VAR in our scripts.
+  return [...(distro ? ["-d", distro] : []), ...(user ? ["--user", user] : []), "--exec", ...args]
 }
 
 export function runWsl(args: string[], opts: RunWslOptions = {}) {


### PR DESCRIPTION
### Issue for this PR

Closes #48640

This fixes the Windows desktop V2 bug where **adding a WSL server never worked:** the distro showed "OpenCode not installed" even though the CLI was installed, and "Install OpenCode" f**ailed with WSL servers request failed UnknownError: An error occurred in Effect.tryPromise.**

### Type of change

- [x] Bug fix

### What does this PR do?

WSL runs arguments passed after `--` through the distro's default login shell, which expands `$VAR` and `$(...)` before the target `sh` sees them. The probe script built by `RemoteCli.discoverScript()` relies on runtime expansion, so `resolveWslCli()` always returned empty and the desktop reported "OpenCode not installed". The same applies to the install version check.

`wslArgs()` is only used to run commands inside the distro (`/bin/true`, `sh -lc ...`, `bash -se`), never for wsl's own flags, so I switched it from `--` to `--exec`. That runs the command without the default shell. `--user` still works.

I went with the minimal `--exec` option the issue lists rather than moving the scripts to stdin, since it is a one-line change and keeps the existing `sh -lc` login-shell behavior for the scripts themselves.

### How did you verify your code works?

On Windows 11 build 26200 + WSL 2.7.14 (archlinux), using the same `child_process.spawn("wsl", ...)` call the Electron main process uses:

- `wsl -d archlinux -- sh -lc <discoverScript>` → empty
- `wsl -d archlinux --exec sh -lc <discoverScript>` → `/home/<user>/.opencode/bin/opencode`
- `wsl -d archlinux --user root --exec sh -lc 'id -un'` → `root`

With `--exec`, the sidecar starts and `/api/health` returns `{"healthy":true,"version":"2.0.3",...}`.

Added `runtime.test.ts` for the argument shape; `bun test src/main/wsl` (8 pass, 1 skipped posix-only) and typecheck both pass.

### `--exec` compatibility

`wsl --exec`/`-e` exists since Windows build 17666 (2018) and works on WSL1 and WSL2. It predates the `wsl` flags this code already depends on (`--version`, `--install --no-distribution --web-download`, `--no-launch`), so any WSL that can run the current flows supports it.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
