### PR TITLE
feat(tui): add inline home footer slot

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -191,6 +191,7 @@ export interface PanelInput {
 export interface SlotMap {
   readonly app: Readonly<Record<string, never>>
   readonly "home.footer": Readonly<Record<string, never>>
+  readonly "home.footer.status": Readonly<Record<string, never>>
   readonly "prompt.footer": PromptFooterInput
   readonly "prompt.footer.status": PromptFooterInput
   readonly "prompt.footer.file": PromptFooterInput

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -2,6 +2,7 @@ import { Plugin } from "@opencode/plugin/tui"
 import { createMemo, Match, Show, Switch } from "solid-js"
 import { useTerminalDimensions } from "@opentui/solid"
 import { usePlugin } from "../../plugin/context"
+import { Slot } from "../../plugin/render"
 
 export function homeFooterVisibility(width: number) {
   return {
@@ -91,6 +92,7 @@ function View(props: { context: Plugin.Context }) {
       >
         <Mcp context={props.context} />
         <Plugins context={props.context} />
+        <Slot path="home.footer.status" />
         <box flexGrow={1} />
         <Show when={visibility().version}>
           <box flexShrink={0}>

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -27,7 +27,6 @@ import { useTuiLifecycle } from "../context/runtime"
 import { useClient } from "../context/client"
 import { useData } from "../context/data"
 import { errorMessage } from "../util/error"
-import { builtins } from "./builtins"
 import { createPluginContext, usePluginHost, type Dispose, type RegisteredSlot, type SlotRender } from "./api"
 import { createSourceWatcher } from "./watch"
 import { discoverPluginTargets, localSource } from "./discovery"
@@ -306,6 +305,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
 
     // Resolve: fold entries into one desired generation. A source that fails
     // to import keeps its running previous version and only reports failure.
+    const { builtins } = await import("./builtins")
     const desired = new Map<string, Desired>()
     for (const plugin of builtins)
       desired.set(plugin.id, { plugin, source: "builtin", version: "builtin", enabled: true })

--- a/services/www/src/docs/content/build/plugins/cli.mdx
+++ b/services/www/src/docs/content/build/plugins/cli.mdx
@@ -391,8 +391,8 @@ if (context.ui.tabs.enabled()) {
 
 ## Slots
 
-Slots insert or replace JSX at `app`, `home.footer`, `prompt.footer`, `prompt.footer.status`, `prompt.footer.file`,
-`session.composer.top`, `sidebar.content`, or `sidebar.footer`.
+Slots insert or replace JSX at `app`, `home.footer`, `home.footer.status`, `prompt.footer`, `prompt.footer.status`,
+`prompt.footer.file`, `session.composer.top`, `sidebar.content`, or `sidebar.footer`.
 
 ```tsx
 return context.ui.slot({
@@ -409,6 +409,13 @@ context.ui.slot({ append: "home.footer", render: () => <text>After footer conten
 context.ui.slot({ before: "home.footer", render: () => <text>Before footer slot</text> })
 context.ui.slot({ after: "home.footer", render: () => <text>After footer slot</text> })
 context.ui.slot({ replace: "home.footer", render: () => <text>New footer</text> })
+```
+
+Use `home.footer.status` to add content to the built-in footer row without replacing it. Status contributions appear
+after OpenCode's health indicators and before the version.
+
+```tsx
+context.ui.slot({ append: "home.footer.status", render: () => <text>SYNCED</text> })
 ```
 
 ### Session panels


### PR DESCRIPTION
### Issue for this PR

Closes #48797

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a typed `home.footer.status` slot inside the built-in home footer row. Plugins can now render compact status components alongside the built-in MCP/plugin indicators and version without replacing the whole footer.

The built-in registry is loaded lazily during reconciliation to avoid a module cycle when a built-in plugin mounts a nested slot.

### How did you verify your code works?

- Full repository pre-push typecheck: 35/35 tasks passed
- `packages/plugin`: typecheck passed
- `packages/tui`: typecheck passed
- Focused home-footer tests: 2 passed
- Full TUI suite: 1,343 passed, 4 skipped; two existing shell-output tests timed out
- Documentation typecheck, generated check, build, and link validation passed
- Lint passed with two pre-existing warnings in `packages/tui/src/plugin/context.tsx`

The plugin test suite has one environment-specific failure caused by macOS resolving `/var` as `/private/var`; the remaining 8 tests pass.

### Screenshots / recordings

**Before (it was imposible to get the slot on the same row, always above or below, which doesnt look the best)**

<img width="1604" height="1027" alt="Screenshot 2026-09-13 at 13 01 31" src="https://github.com/user-attachments/assets/4f029014-0eae-41ae-8746-d70fd6afdd12" />

**After**

<img width="1604" height="1027" alt="Screenshot 2026-09-13 at 13 00 28" src="https://github.com/user-attachments/assets/00f1c9c6-d9c4-4b57-9ca9-3e3c5a913926" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR