### PR TITLE
docs: add Copilot for Obsidian to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -70,6 +70,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk   |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
+| [Copilot for Obsidian](https://github.com/logancyang/obsidian-copilot)                     | OpenCode in Obsidian with managed setup and vault context        |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |


### PR DESCRIPTION
### Issue for this PR

Closes #42930

Supersedes #43291, which was closed automatically by the stale-PR cleanup workflow while this contribution remained active.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Copilot for Obsidian to the Ecosystem Projects list. Copilot launches OpenCode as an ACP backend, so it belongs with external OpenCode clients rather than runtime plugins.

### How did you verify your code works?

Ran `npx --yes prettier@3.6.2 --check packages/web/src/content/docs/ecosystem.mdx` and verified the linked repository.

### Screenshots / recordings

Not applicable; this is a documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
